### PR TITLE
Create SSO team member role resource

### DIFF
--- a/launchdarkly/provider.go
+++ b/launchdarkly/provider.go
@@ -55,6 +55,7 @@ func Provider() terraform.ResourceProvider {
 			"launchdarkly_feature_flag_environment": resourceFeatureFlagEnvironment(),
 			"launchdarkly_destination":              resourceDestination(),
 			"launchdarkly_access_token":             resourceAccessToken(),
+			"launchdarkly_sso_team_member":          resourceSSOTeamMember(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"launchdarkly_team_member":              dataSourceTeamMember(),

--- a/launchdarkly/resource_launchdarkly_sso_team_member.go
+++ b/launchdarkly/resource_launchdarkly_sso_team_member.go
@@ -1,0 +1,168 @@
+package launchdarkly
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	ldapi "github.com/launchdarkly/api-client-go"
+)
+
+func resourceSSOTeamMember() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSSOMemberCreate,
+		Read:   resourceSSOMemberRead,
+		Update: resourceSSOMemberUpdate,
+		Delete: resourceSSOMemberDelete,
+		Exists: resourceSSOMemberExists,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			EMAIL: {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			ROLE: {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateTeamMemberRole,
+			},
+			CUSTOM_ROLES: {
+				Type:     schema.TypeSet,
+				Set:      schema.HashString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceSSOMemberCreate(d *schema.ResourceData, metaRaw interface{}) error {
+	client := metaRaw.(*Client)
+	memberEmail := d.Get(EMAIL).(string)
+
+	member, err := getTeamMemberByEmail(client, memberEmail)
+	if err != nil {
+		return err
+	}
+	memberID := member.Id
+	memberRole := ldapi.Role(d.Get(ROLE).(string))
+	if len(memberRole) == 0 {
+		memberRole = *member.Role
+	}
+	customRolesRaw := d.Get(CUSTOM_ROLES).(*schema.Set).List()
+
+	customRoleKeys := make([]string, len(customRolesRaw))
+	for i, cr := range customRolesRaw {
+		customRoleKeys[i] = cr.(string)
+	}
+	customRoleIds, err := customRoleKeysToIDs(client, customRoleKeys)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(memberID)
+	patch := []ldapi.PatchOperation{
+		// these are the only fields we are allowed to update:
+		patchReplace("/role", &memberRole),
+		patchReplace("/customRoles", &customRoleIds),
+	}
+
+	_, _, err = handleRateLimit(func() (interface{}, *http.Response, error) {
+		return handleNoConflict(func() (interface{}, *http.Response, error) {
+			return client.ld.TeamMembersApi.PatchMember(client.ctx, d.Id(), patch)
+		})
+	})
+	if err != nil {
+		return fmt.Errorf("failed to assign role to team member with id %q: %s", memberID, handleLdapiErr(err))
+	}
+	return resourceSSOMemberRead(d, metaRaw)
+}
+
+func resourceSSOMemberRead(d *schema.ResourceData, metaRaw interface{}) error {
+	client := metaRaw.(*Client)
+	memberID := d.Id()
+
+	memberRaw, res, err := handleRateLimit(func() (interface{}, *http.Response, error) {
+		return client.ld.TeamMembersApi.GetMember(client.ctx, memberID)
+	})
+	member := memberRaw.(ldapi.Member)
+	if isStatusNotFound(res) {
+		log.Printf("[WARN] failed to find member with id %q, removing from state", memberID)
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get member with id %q: %v", memberID, err)
+	}
+
+	d.SetId(member.Id)
+	_ = d.Set(EMAIL, member.Email)
+	_ = d.Set(ROLE, member.Role)
+
+	customRoleKeys, err := customRoleIDsToKeys(client, member.CustomRoles)
+	if err != nil {
+		return err
+	}
+	err = d.Set(CUSTOM_ROLES, customRoleKeys)
+	if err != nil {
+		return fmt.Errorf("failed to set custom roles on team member with id %q: %v", member.Id, err)
+	}
+	return nil
+}
+
+func resourceSSOMemberDelete(d *schema.ResourceData, metaRaw interface{}) error {
+	client := metaRaw.(*Client)
+
+	_, _, err := handleRateLimit(func() (interface{}, *http.Response, error) {
+		res, err := client.ld.TeamMembersApi.DeleteMember(client.ctx, d.Id())
+		return nil, res, err
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete team member with id %q: %s", d.Id(), handleLdapiErr(err))
+	}
+
+	return nil
+}
+
+func resourceSSOMemberExists(d *schema.ResourceData, metaRaw interface{}) (bool, error) {
+	return teamMemberExists(d.Id(), metaRaw.(*Client))
+}
+
+func resourceSSOMemberUpdate(d *schema.ResourceData, metaRaw interface{}) error {
+	client := metaRaw.(*Client)
+	memberRole := ldapi.Role(d.Get(ROLE).(string))
+	customRolesRaw := d.Get(CUSTOM_ROLES).(*schema.Set).List()
+
+	customRoleKeys := make([]string, len(customRolesRaw))
+	for i, cr := range customRolesRaw {
+		customRoleKeys[i] = cr.(string)
+	}
+	customRoleIds, err := customRoleKeysToIDs(client, customRoleKeys)
+	if err != nil {
+		return err
+	}
+
+	patch := []ldapi.PatchOperation{
+		// these are the only fields we are allowed to update:
+		patchReplace("/role", &memberRole),
+		patchReplace("/customRoles", &customRoleIds),
+	}
+
+	_, _, err = handleRateLimit(func() (interface{}, *http.Response, error) {
+		return handleNoConflict(func() (interface{}, *http.Response, error) {
+			return client.ld.TeamMembersApi.PatchMember(client.ctx, d.Id(), patch)
+		})
+	})
+	if err != nil {
+		return fmt.Errorf("failed to assign role to team member with id %q: %s", d.Id(), handleLdapiErr(err))
+	}
+
+	return resourceSSOMemberRead(d, metaRaw)
+}

--- a/launchdarkly/resource_launchdarkly_team_member_test.go
+++ b/launchdarkly/resource_launchdarkly_team_member_test.go
@@ -41,7 +41,7 @@ func testAccTeamMemberCustomRoleCreate(roleKey, rName string) string {
 		name = "Updated - %s"
 		description= "Allow all actions on staging environments"
 		policy_statements {
-			actions = ["*"]	
+			actions = ["*"]
 			effect = "allow"
 			resources = ["proj/*:env/staging"]
 		}
@@ -63,7 +63,7 @@ func testAccTeamMemberCustomRoleUpdate(roleKey1, roleKey2, rName string) string 
 		name = "Updated - %s"
 		description= "Allow all actions on staging environments"
 		policy_statements {
-			actions = ["*"]	
+			actions = ["*"]
 			effect = "allow"
 			resources = ["proj/*:env/staging"]
 		}
@@ -74,7 +74,7 @@ func testAccTeamMemberCustomRoleUpdate(roleKey1, roleKey2, rName string) string 
 		name = "Updated - %s"
 		description= "Allow all actions on production environments"
 		policy_statements {
-			actions = ["*"]	
+			actions = ["*"]
 			effect = "allow"
 			resources = ["proj/*:env/production"]
 		}


### PR DESCRIPTION
- Create a new resource called "sso_team_member" which will be used to apply a role to an existing team member that get access from SSO, as the current team member resource can only create new user while doing role assignment. By having this resource, it can benefit to role assignment automation for the case that users are provisioned from SSO.