### PR TITLE
Prepare 1.7.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+BUG FIXES:
+
+- Fixes [a bug](https://github.com/launchdarkly/terraform-provider-launchdarkly/issues/60) where attempts to create `resource_launchdarkly_feature_flag` variations with an empty string value were throwing a panic.
+
 NOTES:
 
 - The `launchdarkly_feature_flag_environment` resource and data source's `flag_fallthrough` argument has been deprecated in favor of `fallthrough`. Please update your config to use `fallthrough` in order to maintain compatibility with future versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,7 @@ NOTES:
 
 - The `launchdarkly_feature_flag_environment` resource's `targeting_enabled` argument has been deprecated in favor of `on`. Please update your config to use `on` in order to maintain compatibility with future versions.
 
-<<<<<<< HEAD
-
-- # The `resource_launchdarkly_webhook` resource's `policy_statements` argument has been deprecated in favor of `inline_roles`. Please update your config to use `inline_roles` in order to maintain compatibility with future versions.
 - The `resource_launchdarkly_access_token` resource's `policy_statements` argument has been deprecated in favor of `inline_roles`. Please update your config to use `inline_roles` in order to maintain compatibility with future versions.
-  > > > > > > > 090c48d257abdc15f10ea4d4e9a8fab1321ad036
 
 ## [1.6.0] (July 20, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+NOTES:
+
+- The `launchdarkly_feature_flag_environment` resource and data source's `flag_fallthrough` argument has been deprecated in favor of `fallthrough`. Please update your config to use `fallthrough` in order to maintain compatibility with future versions.
+
+- The `launchdarkly_feature_flag_environment` resource and data source's `user_targets` argument has been deprecated in favor of `targets`. Please update your config to use `targets` in order to maintain compatibility with future versions.
+
 ## [1.7.0] (August 2, 2021)
 
 FEATURES:

--- a/launchdarkly/data_source_launchdarkly_feature_flag_environment_test.go
+++ b/launchdarkly/data_source_launchdarkly_feature_flag_environment_test.go
@@ -174,6 +174,8 @@ func TestAccDataSourceFeatureFlagEnvironment_exists(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "prerequisites.0.variation", fmt.Sprint(thisConfig.Prerequisites[0].Variation)),
 					resource.TestCheckResourceAttr(resourceName, "off_variation", fmt.Sprint(thisConfig.OffVariation)),
 					// user targets will be two long because there is an empty one for the 0 value
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.#", fmt.Sprint(len(thisConfig.Targets[0].Values))),
+					resource.TestCheckResourceAttr(resourceName, "fallthrough.0.variation", fmt.Sprint(thisConfig.Fallthrough_.Variation)),
 					resource.TestCheckResourceAttr(resourceName, "user_targets.1.values.#", fmt.Sprint(len(thisConfig.Targets[0].Values))),
 					resource.TestCheckResourceAttr(resourceName, "flag_fallthrough.0.variation", fmt.Sprint(thisConfig.Fallthrough_.Variation)),
 				),

--- a/launchdarkly/fallthrough_helper.go
+++ b/launchdarkly/fallthrough_helper.go
@@ -68,7 +68,14 @@ func isPercentRollout(fall []interface{}) bool {
 }
 
 func fallthroughFromResourceData(d *schema.ResourceData) (fallthroughModel, error) {
-	f := d.Get(FLAG_FALLTHROUGH).([]interface{})
+	var f []interface{}
+	fallthroughHasChange := d.HasChange(FALLTHROUGH)
+	flagFallthroughHasChange := d.HasChange(FLAG_FALLTHROUGH)
+	if fallthroughHasChange {
+		f = d.Get(FALLTHROUGH).([]interface{})
+	} else if flagFallthroughHasChange {
+		f = d.Get(FLAG_FALLTHROUGH).([]interface{})
+	}
 	err := validateFallThroughResourceData(f)
 	if err != nil {
 		return fallthroughModel{}, err

--- a/launchdarkly/keys.go
+++ b/launchdarkly/keys.go
@@ -59,13 +59,15 @@ const (
 	BUCKET_BY                = "bucket_by"
 	ROLLOUT_WEIGHTS          = "rollout_weights"
 	VARIATION                = "variation"
-	USER_TARGETS             = "user_targets"
+	USER_TARGETS             = "user_targets" // deprecated
+	TARGETS                  = "targets"
 	PREREQUISITES            = "prerequisites"
 	FLAG_KEY                 = "flag_key"
 	TARGETING_ENABLED        = "targeting_enabled"
 	TRACK_EVENTS             = "track_events"
 	OFF_VARIATION            = "off_variation"
-	FLAG_FALLTHROUGH         = "flag_fallthrough"
+	FLAG_FALLTHROUGH         = "flag_fallthrough" // deprecated
+	FALLTHROUGH              = "fallthrough"
 	KIND                     = "kind"
 	CONFIG                   = "config"
 	DEFAULT_ON_VARIATION     = "default_on_variation"

--- a/launchdarkly/resource_launchdarkly_feature_flag.go
+++ b/launchdarkly/resource_launchdarkly_feature_flag.go
@@ -38,7 +38,7 @@ func resourceFeatureFlagCreate(d *schema.ResourceData, metaRaw interface{}) erro
 		if err != nil {
 			return err
 		}
-		return fmt.Errorf("Cannot find project with key %q", projectKey)
+		return fmt.Errorf("cannot find project with key %q", projectKey)
 	}
 
 	key := d.Get(KEY).(string)

--- a/launchdarkly/resource_launchdarkly_feature_flag_environment.go
+++ b/launchdarkly/resource_launchdarkly_feature_flag_environment.go
@@ -97,14 +97,16 @@ func resourceFeatureFlagEnvironmentCreate(d *schema.ResourceData, metaRaw interf
 		patches = append(patches, patchReplace(patchFlagEnvPath(d, "prerequisites"), prerequisites))
 	}
 
-	_, ok = d.GetOk(USER_TARGETS)
-	if ok {
-		targets := targetsFromResourceData(d, USER_TARGETS)
+	_, oldOk := d.GetOk(USER_TARGETS)
+	_, newOk := d.GetOk(TARGETS)
+	if oldOk || newOk {
+		targets := targetsFromResourceData(d)
 		patches = append(patches, patchReplace(patchFlagEnvPath(d, "targets"), targets))
 	}
 
-	_, ok = d.GetOk(FLAG_FALLTHROUGH)
-	if ok {
+	_, newOk = d.GetOk(FALLTHROUGH)
+	_, oldOk = d.GetOk(FLAG_FALLTHROUGH)
+	if oldOk || newOk {
 		fall, err := fallthroughFromResourceData(d)
 		if err != nil {
 			return err
@@ -150,7 +152,7 @@ func resourceFeatureFlagEnvironmentUpdate(d *schema.ResourceData, metaRaw interf
 		if err != nil {
 			return err
 		}
-		return fmt.Errorf("Cannot find project with key %q", projectKey)
+		return fmt.Errorf("cannot find project with key %q", projectKey)
 	}
 
 	if exists, err := environmentExists(projectKey, envKey, client); !exists {
@@ -167,7 +169,7 @@ func resourceFeatureFlagEnvironmentUpdate(d *schema.ResourceData, metaRaw interf
 	}
 	trackEvents := d.Get(TRACK_EVENTS).(bool)
 	prerequisites := prerequisitesFromResourceData(d, PREREQUISITES)
-	targets := targetsFromResourceData(d, USER_TARGETS)
+	targets := targetsFromResourceData(d)
 	offVariation := d.Get(OFF_VARIATION).(int)
 
 	fall, err := fallthroughFromResourceData(d)
@@ -212,7 +214,7 @@ func resourceFeatureFlagEnvironmentDelete(d *schema.ResourceData, metaRaw interf
 		if err != nil {
 			return err
 		}
-		return fmt.Errorf("Cannot find project with key %q", projectKey)
+		return fmt.Errorf("cannot find project with key %q", projectKey)
 	}
 
 	if exists, err := environmentExists(projectKey, envKey, client); !exists {

--- a/launchdarkly/target_helper.go
+++ b/launchdarkly/target_helper.go
@@ -27,12 +27,15 @@ func targetsSchema() *schema.Schema {
 	}
 }
 
-func targetsFromResourceData(d *schema.ResourceData, metaRaw interface{}) []ldapi.Target {
-	tgts, ok := d.GetOk(USER_TARGETS)
-	if !ok {
-		return []ldapi.Target{}
+func targetsFromResourceData(d *schema.ResourceData) []ldapi.Target {
+	var schemaTargets []interface{}
+	targetsHasChange := d.HasChange(TARGETS)
+	userTargetsHasChange := d.HasChange(USER_TARGETS)
+	if targetsHasChange {
+		schemaTargets = d.Get(TARGETS).([]interface{})
+	} else if userTargetsHasChange {
+		schemaTargets = d.Get(USER_TARGETS).([]interface{})
 	}
-	schemaTargets := tgts.([]interface{})
 	targets := make([]ldapi.Target, len(schemaTargets))
 	for i, target := range schemaTargets {
 		v := targetFromResourceData(i, target)
@@ -58,9 +61,9 @@ func targetFromResourceData(variation int, val interface{}) ldapi.Target {
 	return p
 }
 
-// targetToResourceData converts the user_target information returned
+// targetToResourceData converts the `target` information returned
 // by the LaunchDarkly API into a format suitable for Terraform
-// If no user_targets are specified for a given variation, LaunchDarkly may
+// If no `targets` are specified for a given variation, LaunchDarkly may
 // omit this information in the response. For example:
 // "targets": [
 // 	{

--- a/launchdarkly/variations_helper.go
+++ b/launchdarkly/variations_helper.go
@@ -176,8 +176,17 @@ func boolVariationFromResourceData(variation interface{}) ldapi.Variation {
 }
 
 func stringVariationFromResourceData(variation interface{}) ldapi.Variation {
+	var v interface{}
+	if variation == nil { // handle empty string value
+		v = ""
+		return ldapi.Variation{
+			Name:        "",
+			Description: "",
+			Value:       &v,
+		}
+	}
 	variationMap := variation.(map[string]interface{})
-	v := variationMap[VALUE]
+	v = variationMap[VALUE]
 	return ldapi.Variation{
 		Name:        variationMap[NAME].(string),
 		Description: variationMap[DESCRIPTION].(string),

--- a/website/docs/d/feature_flag_environment.html.markdown
+++ b/website/docs/d/feature_flag_environment.html.markdown
@@ -38,11 +38,11 @@ In addition to the arguments above, the resource exports the following attribute
 
 - `prerequisites` - List of nested blocks describing prerequisite feature flags rules. To learn more, read [Nested Prequisites Blocks](#nested-prerequisites-blocks).
 
-- `user_targets` - List of nested blocks describing the individual user targets for each variation. The order of the `user_targets` blocks determines the index of the variation to serve if a `user_target` is matched. To learn more, read [Nested User Target Blocks](#nested-user-targets-blocks).
+- `targets` (previously `user_targets`) - List of nested blocks describing the individual user targets for each variation. The order of the `targets` blocks determines the index of the variation to serve if a `target` is matched. To learn more, read [Nested Target Blocks](#nested-targets-blocks).
 
 - `rules` - List of logical targeting rules. To learn more, read [Nested Rules Blocks](#nested-rules-blocks).
 
-- `flag_fallthrough` - Nested block describing the default variation to serve if no `prerequisites`, `user_target`, or `rules` apply. To learn more, read [Nested Flag Fallthrough Block](#nested-flag-fallthrough-block).
+- `fallthrough` (previously `flag_fallthrough`) - Nested block describing the default variation to serve if no `prerequisites`, `target`, or `rules` apply. To learn more, read [Nested Fallthrough Block](#nested-fallthrough-block).
 
 ### Nested Prerequisites Blocks
 
@@ -52,21 +52,21 @@ Nested `prerequisites` blocks have the following structure:
 
 - `variation` - The index of the prerequisite feature flag's variation targeted.
 
-### Nested User Targets Blocks
+### Nested Targets Blocks
 
-Nested `user_targets` blocks have the following structure:
+Nested `targets` blocks have the following structure:
 
 - `values` - List of `user` strings to target.
 
-### Nested Flag Fallthrough Block
+### Nested Fallthrough Block
 
-The nested `flag_fallthrough` block has the following structure:
+The nested `fallthrough` block has the following structure:
 
-- `variation` - The default integer variation index served if no `prerequisites`, `user_target`, or `rules` apply. 
+- `variation` - The default integer variation index served if no `prerequisites`, `target`, or `rules` apply.
 
-- `rollout_weights` - List of integer percentage rollout weights applied to each variation when no `prerequisites`, `user_target`, or `rules` apply. 
+- `rollout_weights` - List of integer percentage rollout weights applied to each variation when no `prerequisites`, `target`, or `rules` apply.
 
-- `bucket_by` - Group percentage rollout by a custom attribute. 
+- `bucket_by` - Group percentage rollout by a custom attribute.
 
 ### Nested Rules Blocks
 
@@ -74,11 +74,11 @@ Nested `rules` blocks have the following structure:
 
 - `clauses` - List of nested blocks specifying the logical clauses evaluated. To learn more, read [Nested Clauses Blocks](#nested-clauses-blocks).
 
-- `variation` - The integer variation index served if the rule clauses evaluate to `true`. 
+- `variation` - The integer variation index served if the rule clauses evaluate to `true`.
 
-- `rollout_weights` - List of integer percentage rollout weights applied to each variation when the rule clauses evaluates to `true`. 
+- `rollout_weights` - List of integer percentage rollout weights applied to each variation when the rule clauses evaluates to `true`.
 
-- `bucket_by` - Group percentage rollout by a custom attribute. 
+- `bucket_by` - Group percentage rollout by a custom attribute.
 
 ### Nested Clauses Blocks
 
@@ -94,9 +94,8 @@ Nested `clauses` blocks have the following structure:
 
 - `negate` - Whether the rule clause is negated.
 
-Nested `flag_fallthrough` blocks have the following structure:
+Nested `fallthrough` blocks have the following structure:
 
-- `variation` - The integer variation index served when the rule clauses evaluate to `true`. 
+- `variation` - The integer variation index served when the rule clauses evaluate to `true`.
 
-- `rollout_weights` - List of integer percentage rollout weights applied to each variation when the rule clauses evaluates to `true`. 
-
+- `rollout_weights` - List of integer percentage rollout weights applied to each variation when the rule clauses evaluates to `true`.

--- a/website/docs/r/feature_flag.html.markdown
+++ b/website/docs/r/feature_flag.html.markdown
@@ -104,6 +104,14 @@ Nested `variations` blocks have the following structure:
 
 - `value` - (Required) The variation value. The value's type must correspond to the `variation_type` argument. For example: `variation_type = "boolean"` accepts only `true` or `false`. The `"number"` variation type accepts both floats and ints, but please note that any trailing zeroes on floats will be trimmed (i.e. `1.1` and `1.100` will both be converted to `1.1`).
 
+If you wish to define an empty string variation, you must still define the value field on the variations block like so:
+
+```
+variations {
+  value = ""
+}
+```
+
 - `name` - (Optional) The name of the variation.
 
 - `description` - (Optional) The variation's description.

--- a/website/docs/r/feature_flag_environment.html.markdown
+++ b/website/docs/r/feature_flag_environment.html.markdown
@@ -51,7 +51,7 @@ resource "launchdarkly_feature_flag_environment" "number_env" {
     variation = 0
   }
 
-  flag_fallthrough {
+  fallthrough {
     rollout_weights = [60000, 40000, 0]
   }
 }
@@ -77,7 +77,9 @@ resource "launchdarkly_feature_flag_environment" "number_env" {
 
 - `rules` - (Optional) List of logical targeting rules. To learn more, read [Nested Rules Blocks](#nested-rules-blocks).
 
-- `flag_fallthrough` - (Optional) Nested block describing the default variation to serve if no `prerequisites`, `user_target`, or `rules` apply. To learn more, read [Nested Flag Fallthrough Block](#nested-flag-fallthrough-block).
+- `flag_fallthrough` - (Optional, **Deprecated**) Nested block describing the default variation to serve if no `prerequisites`, `user_target`, or `rules` apply. This attribute is **deprecated** in favor of `fallthrough`. Please update all references of `flag_fallthrough` to `fallthrough` to maintain compatibility with future versions.
+
+- `fallthrough` - (Optional) Nested block describing the default variation to serve if no `prerequisites`, `user_target`, or `rules` apply.To learn more, read [Nested Fallthrough Block](#nested-fallthrough-block).
 
 ### Nested Prerequisites Blocks
 
@@ -93,9 +95,9 @@ Nested `user_targets` blocks have the following structure:
 
 - `values` - (Optional) List of `user` strings to target.
 
-### Nested Flag Fallthrough Block
+### Nested Fallthrough Block
 
-The nested `flag_fallthrough` block has the following structure:
+The nested `fallthrough` (previously `flag_fallthrough`) block has the following structure:
 
 - `variation` - (Optional) The default integer variation index to serve if no `prerequisites`, `user_target`, or `rules` apply. You must specify either `variation` or `rollout_weights`.
 
@@ -128,12 +130,6 @@ Nested `clauses` blocks have the following structure:
 - `value_type` - (Optional) The type for each of the clause's values. Available types are `boolean`, `string`, and `number`. If omitted, `value_type` defaults to `string`.
 
 - `negate` - (Required) Whether to negate the rule clause.
-
-Nested `flag_fallthrough` blocks have the following structure:
-
-- `variation` - (Optional) The integer variation index to serve if the rule clauses evaluate to `true`. You must specify either `variation` or `rollout_weights`.
-
-- `rollout_weights` - (Optional) List of integer percentage rollout weights (in thousandths of a percent) to apply to each variation if the rule clauses evaluates to `true`. The sum of the `rollout_weights` must equal 100000. You must specify either `variation` or `rollout_weights`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
BUG FIXES:

- Fixes [a bug](https://github.com/launchdarkly/terraform-provider-launchdarkly/issues/60) where attempts to create `resource_launchdarkly_feature_flag` variations with an empty string value were throwing a panic.

NOTES:

- The `launchdarkly_feature_flag_environment` resource and data source's `flag_fallthrough` argument has been deprecated in favor of `fallthrough`. Please update your config to use `fallthrough` in order to maintain compatibility with future versions.

- The `launchdarkly_feature_flag_environment` resource and data source's `user_targets` argument has been deprecated in favor of `targets`. Please update your config to use `targets` in order to maintain compatibility with future versions.
