### PR TITLE
Prepare 2.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [2.4.1] (Unreleased)
+## [2.4.1] (January 21, 2022)
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.4.1] (Unreleased)
+
+BUG FIXES:
+
+- Fixes a [bug](https://github.com/launchdarkly/terraform-provider-launchdarkly/issues/79) introduced in v2.2.0 where `launchdarkly_segments` with `rule` blocks not containing a `weight` were defaulting to a `weight` of 0.
+
 ## [2.4.0] (January 19, 2022)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 BUG FIXES:
 
-- Fixes a [bug](https://github.com/launchdarkly/terraform-provider-launchdarkly/issues/79) introduced in v2.2.0 where `launchdarkly_segments` with `rule` blocks not containing a `weight` were defaulting to a `weight` of 0.
+- Fixed a [bug](https://app.shortcut.com/launchdarkly/story/138913/terraform-provider-panics-when-trying-to-create-triggers-that-are-enabled) preventing `launchdarkly_flag_trigger`s from being created in the `enabled` state.
+
+- Fixed a [bug](https://github.com/launchdarkly/terraform-provider-launchdarkly/issues/79) introduced in v2.2.0 where `launchdarkly_segments` with `rule` blocks not containing a `weight` were defaulting to a `weight` of 0.
 
 ## [2.4.0] (January 19, 2022)
 

--- a/launchdarkly/project_helper.go
+++ b/launchdarkly/project_helper.go
@@ -85,7 +85,6 @@ func projectRead(ctx context.Context, d *schema.ResourceData, meta interface{}, 
 		if err != nil {
 			return diag.Errorf("could not set include_in_snippet on project with key %q: %v", project.Key, err)
 		}
-
 	}
 
 	err = d.Set(TAGS, project.Tags)

--- a/launchdarkly/segment_rule_helper_test.go
+++ b/launchdarkly/segment_rule_helper_test.go
@@ -1,0 +1,64 @@
+package launchdarkly
+
+import (
+	"testing"
+
+	ldapi "github.com/launchdarkly/api-client-go/v7"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSegmentRuleFromResourceData(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    map[string]interface{}
+		expected ldapi.UserSegmentRule
+	}{
+		{
+			// https://github.com/launchdarkly/terraform-provider-launchdarkly/issues/79
+			name: "Zero case should not create a UserSegmentRule with 0 weight",
+			input: map[string]interface{}{
+				WEIGHT:    0,
+				BUCKET_BY: "",
+				CLAUSES:   []interface{}{},
+			},
+			expected: ldapi.UserSegmentRule{
+				Clauses: []ldapi.Clause{},
+			},
+		},
+		{
+			name: "Clauses only - most typical case",
+			input: map[string]interface{}{
+				WEIGHT:    0,
+				BUCKET_BY: "",
+				CLAUSES: []interface{}{
+					map[string]interface{}{
+						ATTRIBUTE:  "country",
+						OP:         "in",
+						NEGATE:     false,
+						VALUES:     []interface{}{"us", "gb"},
+						VALUE_TYPE: "string",
+					},
+				},
+			},
+			expected: ldapi.UserSegmentRule{
+				Clauses: []ldapi.Clause{
+					{
+						Attribute: "country",
+						Op:        "in",
+						Negate:    false,
+						Values:    []interface{}{"us", "gb"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := segmentRuleFromResourceData(tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/website/docs/r/segment.html.markdown
+++ b/website/docs/r/segment.html.markdown
@@ -59,7 +59,7 @@ resource "launchdarkly_segment" "example" {
 
 Nested `rules` blocks have the following structure:
 
-- `weight` - (Optional) The integer weight of the rule (between 0 and 100000).
+- `weight` - (Optional) The integer weight of the rule (between 1 and 100000).
 
 - `bucket_by` - (Optional) The attribute by which to group users together.
 


### PR DESCRIPTION
## [2.4.1] (January 21, 2022)

BUG FIXES:

- Fixed a [bug](https://app.shortcut.com/launchdarkly/story/138913/terraform-provider-panics-when-trying-to-create-triggers-that-are-enabled) preventing `launchdarkly_flag_trigger`s from being created in the `enabled` state.

- Fixed a [bug](https://github.com/launchdarkly/terraform-provider-launchdarkly/issues/79) introduced in v2.2.0 where `launchdarkly_segments` with `rule` blocks not containing a `weight` were defaulting to a `weight` of 0.