### PR TITLE
Fix merge issue in Circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,6 @@ jobs:
       # sc-146360 - overrides the default timeout of 3000ms when reaching checkpoint-api.hashicorp.com
       CHECKPOINT_TIMEOUT: 15000
 
-    environment:
-      # sc-146360 - overrides the default timeout of 3000ms when reaching checkpoint-api.hashicorp.com
-      CHECKPOINT_TIMEOUT: 15000
-
     steps:
       - checkout
       - go/mod-download-cached


### PR DESCRIPTION
Somehow we ended up with the `CHECKPOINT_TIMEOUT` twice in our CIrcle config.