### PR TITLE
Fix typo in multiple docs headers

### DIFF
--- a/website/docs/d/feature_flag.html.markdown
+++ b/website/docs/d/feature_flag.html.markdown
@@ -72,7 +72,7 @@ Nested `defaults` blocks have the following structure:
 
 - `off_variation` - (Required) The index of the variation the flag will default to in all new environments when off.
 
-### Nested Client-Side Availibility Block
+### Nested Client-Side Availability Block
 
 The nested `client_side_availability` block has the following attributes:
 

--- a/website/docs/d/project.html.markdown
+++ b/website/docs/d/project.html.markdown
@@ -38,7 +38,7 @@ Please migrate to `default_client_side_availability` to maintain future compatab
 
 - `tags` - The project's set of tags.
 
-### Nested Client-Side Availibility Block
+### Nested Client-Side Availability Block
 
 The nested `default_client_side_availability` block has the following attributes:
 

--- a/website/docs/r/feature_flag.html.markdown
+++ b/website/docs/r/feature_flag.html.markdown
@@ -129,7 +129,7 @@ Nested `defaults` blocks have the following structure:
 
 - `off_variation` - (Required) The index of the variation the flag will default to in all new environments when off.
 
-### Nested Client-Side Availibility Block
+### Nested Client-Side Availability Block
 
 The nested `client_side_availability` block has the following structure:
 

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -98,7 +98,7 @@ Nested environments `approval_settings` blocks have the following structure:
 
 - `required_approval_tags` - An array of tags used to specify which flags with those tags require approval. You may only set `required_approval_tags` if `required` is not set to `true` and vice versa.
 
-### Nested Client side Availibility Block
+### Nested Client side Availability Block
 
 The nested `default_client_side_availability` block describes which client-side SDKs can use new flags by default. To learn more about this setting, read [Making flags available to client-side and mobile SDKs](https://docs.launchdarkly.com/home/getting-started/feature-flags#making-flags-available-to-client-side-and-mobile-sdks). This block has the following structure:
 


### PR DESCRIPTION
This fixes links to these anchors from earlier in each page.
