### PR TITLE
prepare v2.9.1 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,56 +41,56 @@ jobs:
           command: TESTARGS="-v" make test
       - run:
           name: Test Data Sources
-          command: TESTARGS="-run TestAccDataSource" make testacc
+          command: TESTARGS="-run TestAccDataSource" make testacc-with-retry
       - run:
           name: Test Access Token Resource
-          command: TESTARGS="-run TestAccAccessToken" make testacc
+          command: TESTARGS="-run TestAccAccessToken" make testacc-with-retry
       - run:
           name: Test Audit Log Subscription Resource
-          command: TESTARGS="-run TestAccAuditLogSubscription" make testacc
+          command: TESTARGS="-run TestAccAuditLogSubscription" make testacc-with-retry
       - run:
           name: Test Custom Role Resource
-          command: TESTARGS="-run TestAccCustomRole" make testacc
+          command: TESTARGS="-run TestAccCustomRole" make testacc-with-retry
       - run:
           name: Test Destination Resource
-          command: TESTARGS="-run TestAccDestination" make testacc
+          command: TESTARGS="-run TestAccDestination" make testacc-with-retry
       - run:
           name: Test Environment Resource
-          command: TESTARGS="-run TestAccEnvironment" make testacc
+          command: TESTARGS="-run TestAccEnvironment" make testacc-with-retry
       - run:
           name: Test Feature Flag Resource
-          command: TESTARGS="-run TestAccFeatureFlag" make testacc
+          command: TESTARGS="-run TestAccFeatureFlag" make testacc-with-retry
       - run:
           name: Test Feature Flag Environment Resource
-          command: TESTARGS="-run TestAccFeatureFlagEnvironment" make testacc
+          command: TESTARGS="-run TestAccFeatureFlagEnvironment" make testacc-with-retry
       - run:
           name: Test Flag Trigger Resource
-          command: TESTARGS="-run TestAccFlagTrigger" make testacc
+          command: TESTARGS="-run TestAccFlagTrigger" make testacc-with-retry
       - run:
           name: Test Metric Resource
-          command: TESTARGS="-run TestAccMetric" make testacc
+          command: TESTARGS="-run TestAccMetric" make testacc-with-retry
       - run:
           name: Test Project Resource
-          command: TESTARGS="-run TestAccProject" make testacc
+          command: TESTARGS="-run TestAccProject" make testacc-with-retry
       - run:
           name: Test Relay Proxy Configuration Resource
-          command: TESTARGS="-run TestAccRelayProxy" make testacc
+          command: TESTARGS="-run TestAccRelayProxy" make testacc-with-retry
       - run:
           name: Test Segment Resource
-          command: TESTARGS="-run TestAccSegment" make testacc
+          command: TESTARGS="-run TestAccSegment" make testacc-with-retry
       - run:
           name: Test Team Members
           command: |
-            TESTARGS="-run TestAccTeamMember_CreateGeneric" make testacc
-            TESTARGS="-run TestAccTeamMember_UpdateGeneric" make testacc
-            TESTARGS="-run TestAccTeamMember_CreateWithCustomRole" make testacc
-            TESTARGS="-run TestAccTeamMember_UpdateWithCustomRole" make testacc
+            TESTARGS="-run TestAccTeamMember_CreateGeneric" make testacc-with-retry
+            TESTARGS="-run TestAccTeamMember_UpdateGeneric" make testacc-with-retry
+            TESTARGS="-run TestAccTeamMember_CreateWithCustomRole" make testacc-with-retry
+            TESTARGS="-run TestAccTeamMember_UpdateWithCustomRole" make testacc-with-retry
       - run:
           name: Test Team Resource
-          command: TESTARGS="-run TestAccTeam_" make testacc
+          command: TESTARGS="-run TestAccTeam_" make testacc-with-retry
       - run:
           name: Test Webhook Resource
-          command: TESTARGS="-run TestAccWebhook" make testacc
+          command: TESTARGS="-run TestAccWebhook" make testacc-with-retry
       - notify-slack-of-failures
 
   lint:

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+launchdarkly/audit_log_subscription_configs_generated.go linguist-generated=false

--- a/.github/workflows/generate_integration_config_pr.yml
+++ b/.github/workflows/generate_integration_config_pr.yml
@@ -1,0 +1,35 @@
+name: Open PR when integration configs change
+on:
+  schedule:
+    # Run every 30 minutes
+    - cron: "5,35 * * * *"
+jobs:
+  generate-manifest:
+    runs-on: ubuntu-latest
+    if: github.repository == 'launchdarkly/terraform-provider-launchdarkly-private'
+    steps:
+      # Check out goaltender and LDIF side by side
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: scripts/codegen/go.mod
+          cache: true
+          cache-dependency-path: |
+            scripts/codegen/go.sum
+            go.sum
+
+      - run: make generate
+        env:
+          LAUNCHDARKLY_ACCESS_TOKEN: ${{secrets.LAUNCHDARKLY_ACCESS_TOKEN}}
+
+      - name: Create Pull request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          branch: regenerate-integration-configs/patch
+          delete-branch: true
+          commit-message: "[bot] Regenerate integration configs"
+          title: "[bot] Regenerate integration configs"
+          body: |
+            This PR regenerates `launchdarkly/audit_log_subscription_configs_generated.go` based on recent changes to the [integrations manifest endpoint](https://app.launchdarkly.com/api/v2/integration-manifests).
+          labels: bot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2.9.1] (August 24, 2022)
+
+BUG FIXES:
+
+- Fixes a bug in the `launchdarkly_feature_flag_environment` that prevented users from updating targeting rule clauses when the targeting rule was being used as the fallthrough variation with a percentage rollout.
+
+- Fixes a bug in the `launchdarkly_feature_flag_environment` that resulted in the default `string` rule clause value type not being respected. [#102](https://github.com/launchdarkly/terraform-provider-launchdarkly/issues/102)
+
 ## [2.9.0] (August 05, 2022)
 
 FEATURES:
@@ -30,9 +38,11 @@ NOTES:
 
 - Upgrade Go version to 1.18
 
-## [2.7.0] (May 5, 2022)
+## [2.7.1] (July 27, 2022)
 
-FEATURES:
+BUG FIXES:
+
+- The `launchdarkly_feature_flag_environment` data source now checks whether the environment exists and prints out a more descriptive error. [#101](https://github.com/launchdarkly/terraform-provider-launchdarkly/issues/101)
 
 - Added the `base_permissions` field to the `launchdarkly_custom_role` resource.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,9 @@ NOTES:
 
 - Upgrade Go version to 1.18
 
-## [2.7.1] (July 27, 2022)
+## [2.7.0] (May 5, 2022)
 
-BUG FIXES:
-
-- The `launchdarkly_feature_flag_environment` data source now checks whether the environment exists and prints out a more descriptive error. [#101](https://github.com/launchdarkly/terraform-provider-launchdarkly/issues/101)
+FEATURES:
 
 - Added the `base_permissions` field to the `launchdarkly_custom_role` resource.
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @launchdarkly/squad-integrations

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -19,6 +19,12 @@ test: fmtcheck
 testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
 
+testacc-with-retry: fmtcheck
+	make testacc; if [ $$? -eq 1 ]; then \
+		printf "\n\nRetrying failed test\n\n"; \
+		make testacc; \
+	fi
+
 vet:
 	@echo "go vet ."
 	@go vet $$(go list ./...) ; if [ $$? -eq 1 ]; then \
@@ -67,4 +73,4 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build install apply test testacc vet fmt fmtcheck errcheck lint test-compile website website-test
+.PHONY: build install apply test testacc testacc-with-retry vet fmt fmtcheck errcheck lint test-compile website website-test

--- a/launchdarkly/audit_log_subscription_configs_generated.go
+++ b/launchdarkly/audit_log_subscription_configs_generated.go
@@ -33,7 +33,7 @@ var SUBSCRIPTION_CONFIGURATION_FIELDS = map[string]IntegrationConfig{
 		"apiToken": {
 			AllowedValues: []string{},
 			DefaultValue:  nil,
-			Description:   "Enter your Dynatrace API token. [Learn more](https://www.dynatrace.com/support/help/shortlink/api-authentication#generate-a-token) about generating tokens. The 'access problem and event feed, metrics, and topology' scope is required.",
+			Description:   "Enter your Dynatrace Access token. [Learn more](https://www.dynatrace.com/support/help/shortlink/api-authentication#generate-a-token) about generating tokens. The 'Access problem and event feed, metrics, and topology' scope is required.",
 			IsOptional:    false,
 			IsSecret:      true,
 			Type:          "string",
@@ -173,7 +173,7 @@ var SUBSCRIPTION_CONFIGURATION_FIELDS = map[string]IntegrationConfig{
 		"base-url": {
 			AllowedValues: []string{},
 			DefaultValue:  nil,
-			Description:   "Enter your [Splunk HTTP event collector base URL](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector).",
+			Description:   "Enter your [Splunk HTTP event collector base URL](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector) (omitting the path).",
 			IsOptional:    false,
 			IsSecret:      false,
 			Type:          "string",

--- a/launchdarkly/clause_helper.go
+++ b/launchdarkly/clause_helper.go
@@ -43,10 +43,11 @@ func clauseSchema() *schema.Schema {
 					Description: "The list of values associated with the rule clause",
 				},
 				VALUE_TYPE: {
-					Type:        schema.TypeString,
-					Default:     STRING_CLAUSE_VALUE,
-					Optional:    true,
-					Description: "The type for each of the clause's values. Available types are boolean, string, and number. If omitted, value_type defaults to string",
+					Type:             schema.TypeString,
+					Default:          STRING_CLAUSE_VALUE,
+					Optional:         true,
+					Description:      "The type for each of the clause's values. Available types are boolean, string, and number. If omitted, value_type defaults to string",
+					DiffSuppressFunc: diffSuppressFunc,
 					ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(
 						[]string{
 							BOOL_CLAUSE_VALUE,
@@ -67,6 +68,10 @@ func clauseSchema() *schema.Schema {
 	}
 }
 
+func diffSuppressFunc(_, old, new string, d *schema.ResourceData) bool {
+	return (old == "" && new == STRING_CLAUSE_VALUE && d.Get("value_type") == nil)
+}
+
 func clauseFromResourceData(val interface{}) (ldapi.Clause, error) {
 	clauseMap := val.(map[string]interface{})
 	c := ldapi.Clause{
@@ -75,6 +80,9 @@ func clauseFromResourceData(val interface{}) (ldapi.Clause, error) {
 		Negate:    clauseMap[NEGATE].(bool),
 	}
 	valueType := clauseMap[VALUE_TYPE].(string)
+	if valueType == "" {
+		valueType = STRING_CLAUSE_VALUE
+	}
 	values, err := clauseValuesFromResourceData(clauseMap[VALUES].([]interface{}), valueType)
 	if err != nil {
 		return c, err

--- a/launchdarkly/data_source_launchdarkly_team_member_test.go
+++ b/launchdarkly/data_source_launchdarkly_team_member_test.go
@@ -42,7 +42,7 @@ func testAccDataSourceTeamMemberDelete(client *Client, id string) error {
 }
 
 func TestAccDataSourceTeamMember_noMatchReturnsError(t *testing.T) {
-	email := "does-not-exist@example.com"
+	email := "does-not-exist+wbteste2e@launchdarkly.com"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -70,7 +70,7 @@ func TestAccDataSourceTeamMember_exists(t *testing.T) {
 
 	teamMembers := make([]ldapi.Member, 0, teamMemberCount)
 	for i := 0; i < teamMemberCount; i++ {
-		randomEmail := fmt.Sprintf("%s@example.com", acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz012346789+"))
+		randomEmail := fmt.Sprintf("%s+wbteste2e@launchdarkly.com", acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz012346789+"))
 		member, err := testAccDataSourceTeamMemberCreate(client, randomEmail)
 		require.NoError(t, err)
 		teamMembers = append(teamMembers, *member)

--- a/launchdarkly/data_source_launchdarkly_team_members_test.go
+++ b/launchdarkly/data_source_launchdarkly_team_members_test.go
@@ -31,7 +31,7 @@ data "launchdarkly_team_members" "test" {
 }
 
 func TestAccDataSourceTeamMembers_noMatchReturnsError(t *testing.T) {
-	emails := `["does-not-exist@example.com"]`
+	emails := `["does-not-exist+wbteste2e@launchdarkly.com"]`
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -40,14 +40,14 @@ func TestAccDataSourceTeamMembers_noMatchReturnsError(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceTeamMembersConfig(emails),
-				ExpectError: regexp.MustCompile(`Error: No team member found for email: does-not-exist@example.com`),
+				ExpectError: regexp.MustCompile(`Error: No team member found for email: does-not-exist\+wbteste2e@launchdarkly.com`),
 			},
 		},
 	})
 }
 
 func TestAccDataSourceTeamMembers_noMatchReturnsNoErrorIfIgnoreMissing(t *testing.T) {
-	emails := `["does-not-exist@example.com"]`
+	emails := `["does-not-exist+wbteste2e@launchdarkly.com"]`
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -74,7 +74,7 @@ func TestAccDataSourceTeamMembers_exists(t *testing.T) {
 
 	teamMembers := make([]ldapi.Member, 0, teamMemberCount)
 	for i := 0; i < teamMemberCount; i++ {
-		randomEmail := fmt.Sprintf("%s@example.com", acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz012346789+"))
+		randomEmail := fmt.Sprintf("%s+wbteste2e@launchdarkly.com", acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz012346789+"))
 		member, err := testAccDataSourceTeamMemberCreate(client, randomEmail)
 		require.NoError(t, err)
 		teamMembers = append(teamMembers, *member)

--- a/launchdarkly/resource_launchdarkly_feature_flag_test.go
+++ b/launchdarkly/resource_launchdarkly_feature_flag_test.go
@@ -116,7 +116,7 @@ resource "launchdarkly_feature_flag" "json" {
 	// not support creating members with the same email address more than once.
 	testAccFeatureFlagWithMaintainer = `
 resource "launchdarkly_team_member" "test" {
-	email = "%s@example.com"
+	email = "%s+wbteste2e@launchdarkly.com"
 	first_name = "first"
 	last_name = "last"
 	role = "admin"
@@ -136,7 +136,7 @@ resource "launchdarkly_feature_flag" "maintained" {
 	// the previous maintainer if that maintainer still exists
 	testAccFeatureFlagMaintainerComputed = `
 resource "launchdarkly_team_member" "test" {
-	email = "%s@example.com"
+	email = "%s+wbteste2e@launchdarkly.com"
 	first_name = "first"
 	last_name = "last"
 	role = "admin"

--- a/launchdarkly/resource_launchdarkly_team_member_test.go
+++ b/launchdarkly/resource_launchdarkly_team_member_test.go
@@ -12,7 +12,7 @@ import (
 const (
 	testAccTeamMemberCreate = `
 resource "launchdarkly_team_member" "test" {
-	email = "%s@example.com"
+	email = "%s+wbteste2e@launchdarkly.com"
 	first_name = "first"
 	last_name = "last"
 	role = "admin"
@@ -21,7 +21,7 @@ resource "launchdarkly_team_member" "test" {
 `
 	testAccTeamMemberUpdate = `
 resource "launchdarkly_team_member" "test" {
-	email = "%s@example.com"
+	email = "%s+wbteste2e@launchdarkly.com"
 	first_name = "first"
 	last_name = "last"
 	role = "no_access"
@@ -42,7 +42,7 @@ resource "launchdarkly_custom_role" "test" {
 }
 
 resource "launchdarkly_team_member" "custom_role_test" {
-	email = "%s@example.com"
+	email = "%s+wbteste2e@launchdarkly.com"
 	first_name = "first"
 	last_name = "last"
 	custom_roles = [launchdarkly_custom_role.test.key]
@@ -72,7 +72,7 @@ resource "launchdarkly_custom_role" "test_2" {
 }
 
 resource "launchdarkly_team_member" "custom_role_test" {
-	email = "%s@example.com"
+	email = "%s+wbteste2e@launchdarkly.com"
 	first_name = "first"
 	last_name = "last"
 	custom_roles = [launchdarkly_custom_role.test_2.key]
@@ -93,7 +93,7 @@ func TestAccTeamMember_CreateGeneric(t *testing.T) {
 				Config: fmt.Sprintf(testAccTeamMemberCreate, randomName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMemberExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, EMAIL, fmt.Sprintf("%s@example.com", randomName)),
+					resource.TestCheckResourceAttr(resourceName, EMAIL, fmt.Sprintf("%s+wbteste2e@launchdarkly.com", randomName)),
 					resource.TestCheckResourceAttr(resourceName, FIRST_NAME, "first"),
 					resource.TestCheckResourceAttr(resourceName, LAST_NAME, "last"),
 					resource.TestCheckResourceAttr(resourceName, ROLE, "admin"),
@@ -122,7 +122,7 @@ func TestAccTeamMember_UpdateGeneric(t *testing.T) {
 				Config: fmt.Sprintf(testAccTeamMemberCreate, randomName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMemberExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, EMAIL, fmt.Sprintf("%s@example.com", randomName)),
+					resource.TestCheckResourceAttr(resourceName, EMAIL, fmt.Sprintf("%s+wbteste2e@launchdarkly.com", randomName)),
 					resource.TestCheckResourceAttr(resourceName, FIRST_NAME, "first"),
 					resource.TestCheckResourceAttr(resourceName, LAST_NAME, "last"),
 					resource.TestCheckResourceAttr(resourceName, ROLE, "admin"),
@@ -133,7 +133,7 @@ func TestAccTeamMember_UpdateGeneric(t *testing.T) {
 				Config: fmt.Sprintf(testAccTeamMemberUpdate, randomName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMemberExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, EMAIL, fmt.Sprintf("%s@example.com", randomName)),
+					resource.TestCheckResourceAttr(resourceName, EMAIL, fmt.Sprintf("%s+wbteste2e@launchdarkly.com", randomName)),
 					resource.TestCheckResourceAttr(resourceName, FIRST_NAME, "first"),
 					resource.TestCheckResourceAttr(resourceName, LAST_NAME, "last"),
 					resource.TestCheckResourceAttr(resourceName, ROLE, "no_access"),
@@ -160,7 +160,7 @@ func TestAccTeamMember_CreateWithCustomRole(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomRoleExists(roleResourceName),
 					testAccCheckMemberExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, EMAIL, fmt.Sprintf("%s@example.com", randomName)),
+					resource.TestCheckResourceAttr(resourceName, EMAIL, fmt.Sprintf("%s+wbteste2e@launchdarkly.com", randomName)),
 					resource.TestCheckResourceAttr(resourceName, FIRST_NAME, "first"),
 					resource.TestCheckResourceAttr(resourceName, LAST_NAME, "last"),
 					resource.TestCheckResourceAttr(resourceName, "custom_roles.#", "1"),
@@ -194,7 +194,7 @@ func TestAccTeamMember_UpdateWithCustomRole(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomRoleExists(roleResourceName1),
 					testAccCheckMemberExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, EMAIL, fmt.Sprintf("%s@example.com", randomName)),
+					resource.TestCheckResourceAttr(resourceName, EMAIL, fmt.Sprintf("%s+wbteste2e@launchdarkly.com", randomName)),
 					resource.TestCheckResourceAttr(resourceName, FIRST_NAME, "first"),
 					resource.TestCheckResourceAttr(resourceName, LAST_NAME, "last"),
 					resource.TestCheckResourceAttr(resourceName, "custom_roles.#", "1"),
@@ -211,7 +211,7 @@ func TestAccTeamMember_UpdateWithCustomRole(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomRoleExists(roleResourceName2),
 					testAccCheckMemberExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, EMAIL, fmt.Sprintf("%s@example.com", randomName)),
+					resource.TestCheckResourceAttr(resourceName, EMAIL, fmt.Sprintf("%s+wbteste2e@launchdarkly.com", randomName)),
 					resource.TestCheckResourceAttr(resourceName, FIRST_NAME, "first"),
 					resource.TestCheckResourceAttr(resourceName, LAST_NAME, "last"),
 					resource.TestCheckResourceAttr(resourceName, "custom_roles.#", "1"),

--- a/launchdarkly/resource_launchdarkly_team_test.go
+++ b/launchdarkly/resource_launchdarkly_team_test.go
@@ -24,12 +24,12 @@ resource "launchdarkly_custom_role" "terraform_team_test" {
 }
 
 resource "launchdarkly_team_member" "test_member_one" {
-  email = "%s@example.com"
+  email = "%s+wbteste2e@launchdarkly.com"
   role = "reader"
 }
 
 resource "launchdarkly_team_member" "test_member_two" {
-  email = "%s@example.com"
+  email = "%s+wbteste2e@launchdarkly.com"
   role = "reader"
   depends_on = [launchdarkly_team_member.test_member_one]
 }
@@ -56,12 +56,12 @@ resource "launchdarkly_custom_role" "terraform_team_test" {
 }
 
 resource "launchdarkly_team_member" "test_member_one" {
-  email = "%s@example.com"
+  email = "%s+wbteste2e@launchdarkly.com"
   role = "reader"
 }
 
 resource "launchdarkly_team_member" "test_member_two" {
-  email = "%s@example.com"
+  email = "%s+wbteste2e@launchdarkly.com"
   role = "reader"
   depends_on = [launchdarkly_team_member.test_member_one]
 }
@@ -99,12 +99,12 @@ resource "launchdarkly_custom_role" "other_team_test" {
 }
 
 resource "launchdarkly_team_member" "test_member_one" {
-  email = "%s@example.com"
+  email = "%s+wbteste2e@launchdarkly.com"
   role = "reader"
 }
 
 resource "launchdarkly_team_member" "test_member_two" {
-  email = "%s@example.com"
+  email = "%s+wbteste2e@launchdarkly.com"
   role = "reader"
   depends_on = [launchdarkly_team_member.test_member_one]
 }
@@ -131,18 +131,18 @@ resource "launchdarkly_custom_role" "other_team_test" {
 }
 
 resource "launchdarkly_team_member" "test_member_one" {
-  email = "%s@example.com"
+  email = "%s+wbteste2e@launchdarkly.com"
   role = "reader"
 }
 
 resource "launchdarkly_team_member" "test_member_two" {
-  email = "%s@example.com"
+  email = "%s+wbteste2e@launchdarkly.com"
   role = "reader"
   depends_on = [launchdarkly_team_member.test_member_one]
 }
 
 resource "launchdarkly_team_member" "test_member_three" {
-  email = "%s@example.com"
+  email = "%s+wbteste2e@launchdarkly.com"
   role = "reader"
   depends_on = [launchdarkly_team_member.test_member_two]
 }


### PR DESCRIPTION
## [2.9.1] (August 24, 2022)

BUG FIXES:

- Fixes a bug in the `launchdarkly_feature_flag_environment` that prevented users from updating targeting rule clauses when the targeting rule was being used as the fallthrough variation with a percentage rollout.

- Fixes a bug in the `launchdarkly_feature_flag_environment` that resulted in the default `string` rule clause value type not being respected. [#102](https://github.com/launchdarkly/terraform-provider-launchdarkly/issues/102)