### PR TITLE
Prepare v2.9.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.9.2] (September 1, 2022)
+
+BUG FIXES:
+
+- Fixes a bug in the `launchdarkly_feature_flag` resource where explicit defaults were not getting set for boolean flags upon creation.
+
 ## [2.9.1] (August 24, 2022)
 
 BUG FIXES:

--- a/launchdarkly/default_variations_helper.go
+++ b/launchdarkly/default_variations_helper.go
@@ -9,25 +9,36 @@ import (
 
 func defaultVariationsFromResourceData(d *schema.ResourceData) (*ldapi.Defaults, error) {
 	schemaVariations := d.Get(VARIATIONS).([]interface{})
+	numberOfVariations := len(schemaVariations)
 	variationType := d.Get(VARIATION_TYPE).(string)
-	if len(schemaVariations) == 0 && variationType == BOOL_VARIATION {
-		// default boolean variations
-		return &ldapi.Defaults{OnVariation: int32(0), OffVariation: int32(1)}, nil
-	}
 	rawDefaults, ok := d.GetOk(DEFAULTS)
 	if !ok {
-		return &ldapi.Defaults{OnVariation: int32(0), OffVariation: int32(len(schemaVariations) - 1)}, nil
+		defaultOff := numberOfVariations - 1
+		if variationType == BOOL_VARIATION {
+			defaultOff = 1 // otherwise at this point it would be -1
+		}
+		return &ldapi.Defaults{OnVariation: int32(0), OffVariation: int32(defaultOff)}, nil
 	}
 	defaultList := rawDefaults.([]interface{})
+	if variationType == BOOL_VARIATION {
+		if numberOfVariations == 0 && len(defaultList) == 0 {
+			// default boolean variations
+			return &ldapi.Defaults{OnVariation: int32(0), OffVariation: int32(1)}, nil
+		} else {
+			// this allows us to confidence check the variation indices below
+			numberOfVariations = 2
+		}
+	}
+
 	defaults := defaultList[0].(map[string]interface{})
 	on := defaults[ON_VARIATION].(int)
 	off := defaults[OFF_VARIATION].(int)
 
-	if on >= len(schemaVariations) {
-		return nil, fmt.Errorf("default on_variation %v is out of range, must be between 0 and %v inclusive", on, len(schemaVariations)-1)
+	if on >= numberOfVariations {
+		return nil, fmt.Errorf("default on_variation %v is out of range, must be between 0 and %v inclusive", on, numberOfVariations-1)
 	}
-	if off >= len(schemaVariations) {
-		return nil, fmt.Errorf("default off_variation %v is out of range, must be between 0 and %v inclusive", off, len(schemaVariations)-1)
+	if off >= numberOfVariations {
+		return nil, fmt.Errorf("default off_variation %v is out of range, must be between 0 and %v inclusive", off, numberOfVariations-1)
 	}
 
 	return &ldapi.Defaults{OnVariation: int32(on), OffVariation: int32(off)}, nil

--- a/launchdarkly/default_variations_helper_test.go
+++ b/launchdarkly/default_variations_helper_test.go
@@ -18,7 +18,7 @@ func TestDefaultVariationsFromResourceData(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			name: "no defaults on boolean",
+			name: "automatic boolean defaults",
 			vars: map[string]interface{}{
 				VARIATIONS: []interface{}{
 					map[string]interface{}{
@@ -54,6 +54,28 @@ func TestDefaultVariationsFromResourceData(t *testing.T) {
 			expected: &ldapi.Defaults{
 				OnVariation:  0,
 				OffVariation: 1,
+			},
+		},
+		{
+			name: "explicit defautls overwrite default defaults",
+			vars: map[string]interface{}{
+				VARIATIONS: []interface{}{
+					map[string]interface{}{
+						VALUE: "true",
+					},
+					map[string]interface{}{
+						VALUE: "false",
+					},
+				},
+				DEFAULTS: []interface{}{
+					map[string]interface{}{
+						ON_VARIATION:  1,
+						OFF_VARIATION: 0,
+					}},
+			},
+			expected: &ldapi.Defaults{
+				OnVariation:  1,
+				OffVariation: 0,
 			},
 		},
 		{


### PR DESCRIPTION
## [2.9.2] (September 1, 2022)

BUG FIXES:

- Fixes a bug in the `launchdarkly_feature_flag` resource where explicit defaults were not getting set for boolean flags upon creation.
