### PR TITLE
[SC-174121] Docs bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.9.4] (October 26, 2022)
+
+BUG FIXES:
+
+- Adds `ignore_changes` guide to the documentation sidebar
+- Fixes broken link in `account_members` resource documentation
+
 ## [2.9.3] (October 3, 2022)
 
 BUG FIXES:

--- a/website/docs/r/team_member.html.markdown
+++ b/website/docs/r/team_member.html.markdown
@@ -11,7 +11,7 @@ Provides a LaunchDarkly team member resource.
 
 This resource allows you to create and manage team members within your LaunchDarkly organization.
 
--> **Note:** You can only manage team members with "admin" level personal access tokens. To learn more, read [Managing Teams](https://docs.launchdarkly.com/docs/teams).
+-> **Note:** You can only manage team members with "admin" level personal access tokens. To learn more, read [Managing Teams](https://docs.launchdarkly.com/docs/teams/managing).
 
 ## Example Usage
 

--- a/website/launchdarkly.erb
+++ b/website/launchdarkly.erb
@@ -9,6 +9,13 @@
           <a href="/docs/providers/launchdarkly/index.html">LaunchDarkly Provider</a>
         </li>
         <li>
+          <a href="#">Guides</a>
+          <ul class="nav nav-visible">
+          <li>
+              <a href="/docs/providers/launchdarkly/g/use_ignore_changes.html">Using ignore_changes with LaunchDarkly resources</a>
+          </li>
+        </li>
+        <li>
           <a href="#">Data Sources</a>
           <ul class="nav nav-visible">
           <li>


### PR DESCRIPTION
This adds the `ignore_changes` guide to the sidebar so that it actually appears in the generated Terraform documentation, and adds the `Enterprise plan` note to the `account_members` resource. Also preps for 2.9.4 release to publish the docs.