### PR TITLE
Fix flag patch behavior when CSA or IIS blocks exist

### DIFF
--- a/launchdarkly/resource_launchdarkly_project.go
+++ b/launchdarkly/resource_launchdarkly_project.go
@@ -11,7 +11,8 @@ import (
 )
 
 // We assign a custom diff in cases where the customer has not assigned a default for CSA or IIS in config
-//  in order to respect the LD backend defaults and reflect that in our plans
+//
+//	in order to respect the LD backend defaults and reflect that in our plans
 func customizeProjectDiff(ctx context.Context, diff *schema.ResourceDiff, v interface{}) error {
 	config := diff.GetRawConfig()
 

--- a/launchdarkly/validation_helper.go
+++ b/launchdarkly/validation_helper.go
@@ -9,6 +9,7 @@ import (
 
 // Can't use validation.ToDiagFunc converted validators on TypeList at the moment
 // https://github.com/hashicorp/terraform-plugin-sdk/issues/734
+//
 //nolint:staticcheck // SA1019 TODO: return SchemaValidateDiagFunc type
 func validateKeyNoDiag() schema.SchemaValidateFunc {
 	return validation.StringMatch(
@@ -26,6 +27,7 @@ func validateKey() schema.SchemaValidateDiagFunc {
 
 // Can't use validation.ToDiagFunc converted validators on TypeList at the moment
 // https://github.com/hashicorp/terraform-plugin-sdk/issues/734
+//
 //nolint:staticcheck // SA1019 TODO: return SchemaValidateDiagFunc type
 func validateKeyAndLength(minLength, maxLength int) schema.SchemaValidateFunc {
 	return validation.All(
@@ -46,6 +48,7 @@ func validateID() schema.SchemaValidateDiagFunc {
 
 // Can't use validation.ToDiagFunc converted validators on TypeList at the moment
 // https://github.com/hashicorp/terraform-plugin-sdk/issues/734
+//
 //nolint:staticcheck // SA1019 TODO: return SchemaValidateDiagFunc type
 func validateTagsNoDiag() schema.SchemaValidateFunc {
 	return validation.All(


### PR DESCRIPTION
Patch behavior incorrectly checked for both existence AND changes for both CSA and IIS blocks, and if you didn't BOTH have the block AND change it, fell through to pulling the defaults from the project value.  The net effect of this was that any applied patch to a flag caused the mobile SDK flag to be set back to false (our project default) until a SECOND terraform plan noticed that the flag was unset and then a second apply would set it back again.