### PR TITLE
update relay documentation to adhere to the proper metadata

### DIFF
--- a/website/docs/r/relay_proxy_configuration.html.markdown
+++ b/website/docs/r/relay_proxy_configuration.html.markdown
@@ -1,6 +1,8 @@
 ---
-title: "launchdarkly_relay_proxy_configuration"
-description: "Create and manage Relay Proxy configurations"
+layout: "launchdarkly"
+page_title: "LaunchDarkly: launchdarkly_relay_proxy_configuration"
+description: |-
+  Create and manage Relay Proxy configurations.
 ---
 
 # launchdarkly_relay_proxy_configuration


### PR DESCRIPTION
This document was not adhering to the proper markdown metadata (or whatever it's called). This made [Crossplane generation](https://github.com/upbound/upjet/blob/main/docs/generating-a-provider.md) crash for exploratory testing of #170 