### PR TITLE
Map additional fields for BigSegments.

### DIFF
--- a/docs/data-sources/segment.md
+++ b/docs/data-sources/segment.md
@@ -41,6 +41,10 @@ In addition to the arguments above, the resource exports the following attribute
 
 - `tags` - Set of tags for the segment.
 
+- `unbounded` - Whether to create a standard segment (false) or a BigSegment (true).
+
+- `unbounded_context_kind` - For Big Segments, the targeted context kind.
+
 - `included` - List of user keys included in the segment.
 
 - `excluded` - List of user keys excluded from the segment.

--- a/launchdarkly/keys.go
+++ b/launchdarkly/keys.go
@@ -106,6 +106,8 @@ const (
 	TOKEN                            = "token"
 	TRACK_EVENTS                     = "track_events"
 	TRIGGER_URL                      = "trigger_url"
+	UNBOUNDED                        = "unbounded"
+	UNBOUNDED_CONTEXT_KIND           = "unbounded_context_kind"
 	UNIT                             = "unit"
 	URL                              = "url"
 	URLS                             = "urls"

--- a/launchdarkly/resource_launchdarkly_segment.go
+++ b/launchdarkly/resource_launchdarkly_segment.go
@@ -62,12 +62,16 @@ func resourceSegmentCreate(ctx context.Context, d *schema.ResourceData, metaRaw 
 	description := d.Get(DESCRIPTION).(string)
 	segmentName := d.Get(NAME).(string)
 	tags := stringsFromResourceData(d, TAGS)
+	unbounded := d.Get(UNBOUNDED).(bool)
+	unboundedContextKind := d.Get(UNBOUNDED_CONTEXT_KIND).(string)
 
 	segment := ldapi.SegmentBody{
-		Name:        segmentName,
-		Key:         key,
-		Description: &description,
-		Tags:        tags,
+		Name:                 segmentName,
+		Key:                  key,
+		Description:          &description,
+		Tags:                 tags,
+		Unbounded:            &unbounded,
+		UnboundedContextKind: &unboundedContextKind,
 	}
 
 	_, _, err := client.ld.SegmentsApi.PostSegment(client.ctx, projectKey, envKey).SegmentBody(segment).Execute()

--- a/launchdarkly/resource_launchdarkly_segment_test.go
+++ b/launchdarkly/resource_launchdarkly_segment_test.go
@@ -147,6 +147,20 @@ resource "launchdarkly_segment" "test" {
 		context_kind = "eanies"
 	}
 }`
+
+	testAccSegmentCreateWithUnbounded = `
+resource "launchdarkly_segment" "test" {
+    key                    = "segmentKey1"
+	project_key            = launchdarkly_project.test.key
+	env_key                = "test"
+  	name                   = "segment name"
+	description            = "segment description"
+	tags                   = ["segmentTag1", "segmentTag2"]
+	included               = ["user1", "user2"]
+	excluded               = ["user3", "user4"]
+	unbounded              = true
+	unbounded_context_kind = "device"
+}`
 )
 
 func TestAccSegment_CreateAndUpdate(t *testing.T) {
@@ -269,6 +283,35 @@ func TestAccSegment_CreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rules.0.clauses.1.values.0", "test2"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.clauses.1.negate", "true"),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.clauses.1.context_kind", "user"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: withRandomProject(projectKey, testAccSegmentCreateWithUnbounded),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProjectExists("launchdarkly_project.test"),
+					testAccCheckSegmentExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, KEY, "segmentKey1"),
+					resource.TestCheckResourceAttr(resourceName, PROJECT_KEY, projectKey),
+					resource.TestCheckResourceAttr(resourceName, ENV_KEY, "test"),
+					resource.TestCheckResourceAttr(resourceName, NAME, "segment name"),
+					resource.TestCheckResourceAttr(resourceName, DESCRIPTION, "segment description"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "segmentTag1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1", "segmentTag2"),
+					resource.TestCheckResourceAttr(resourceName, "included.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "included.0", "user1"),
+					resource.TestCheckResourceAttr(resourceName, "included.1", "user2"),
+					resource.TestCheckResourceAttr(resourceName, "excluded.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "excluded.0", "user3"),
+					resource.TestCheckResourceAttr(resourceName, "excluded.1", "user4"),
+					resource.TestCheckResourceAttrSet(resourceName, CREATION_DATE),
+					resource.TestCheckResourceAttr(resourceName, UNBOUNDED, "true"),
+					resource.TestCheckResourceAttr(resourceName, UNBOUNDED_CONTEXT_KIND, "device"),
 				),
 			},
 			{

--- a/launchdarkly/segments_helper.go
+++ b/launchdarkly/segments_helper.go
@@ -106,6 +106,16 @@ func segmentRead(ctx context.Context, d *schema.ResourceData, raw interface{}, i
 		return diag.Errorf("failed to set tags on segment with key %q: %v", segmentKey, err)
 	}
 
+	err = d.Set(UNBOUNDED, segment.Unbounded)
+	if err != nil {
+		return diag.Errorf("failed to set unbounded on segment with key %q: %v", segmentKey, err)
+	}
+
+	err = d.Set(UNBOUNDED_CONTEXT_KIND, segment.UnboundedContextKind)
+	if err != nil {
+		return diag.Errorf("failed to set unboundedContextKind on segment with key %q: %v", segmentKey, err)
+	}
+
 	err = d.Set(INCLUDED, segment.Included)
 	if err != nil {
 		return diag.Errorf("failed to set included on segment with key %q: %v", segmentKey, err)


### PR DESCRIPTION
Map additional fields required for provider to support BigSegments.

- [x]  Have you added comprehensive tests?
- [x] Have you updated relevant data sources as well as resources?
- [x] Have you updated the docs?

**Testing**

For any changes you make, please ensure your acceptance test conform to the following:

- every single new attribute is tested
- optional attributes revert to null or default values if removed
- attributes that interact interact as expected
- block values behave as expected when reordered
- nested fields on maps or list/set items function as expected. Terraform does not actually enforce most schema attributes on nested items
- each test step for a configuration is followed by a test step where `ImportState` and `ImportStateVerify` are set to true. `ImportStateVerifyIgnore` can be used if we explicitly _expect_ a value to be different when imported, such as in the case of obfuscated values like API keys

## LaunchDarkly Employees
For more information on how to build, test, and release, see the [internal README on Confluence](https://launchdarkly.atlassian.net/wiki/spaces/ENG/pages/457379492).
