### PR TITLE
Add service kind and config to approval settings

### DIFF
--- a/docs/data-sources/environment.md
+++ b/docs/data-sources/environment.md
@@ -56,3 +56,5 @@ Read-Only:
 - `min_num_approvals` (Number)
 - `required` (Boolean)
 - `required_approval_tags` (List of String)
+- `service_kind` (String)
+- `service_config` (Block List)

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -82,6 +82,19 @@ Optional:
 - `min_num_approvals` (Number) The number of approvals required before an approval request can be applied. This number must be between 1 and 5. Defaults to 1.
 - `required` (Boolean) Set to `true` for changes to flags in this environment to require approval. You may only set `required` to true if `required_approval_tags` is not set and vice versa. Defaults to `false`.
 - `required_approval_tags` (List of String) An array of tags used to specify which flags with those tags require approval. You may only set `required_approval_tags` if `required` is not set to `true` and vice versa.
+- `service_kind` (String) The kind of service to use when requesting an approval. Use this to switch which system approval requests go to. Valid values are `launchdarkly` and `servicenow`. The default is `launchdarkly`.
+- `service_config` (Block List) The config for the approval service. This will differ for different kinds of services. (See [below for nested schema](#nestedblock--approval_settings_service_config))
+
+<a id="nestedblock--approval_settings_service_config"></a>
+### Nested Schema for `service_config`
+The structure of the `service_config` object will be different for each different service kind.
+
+For a `service_kind` of `servicenow`:
+
+- `detail_column` (String) The name of the column to place the details in when creating the change request in ServiceNow.
+- `template` (String) The sys_id of the Standard Change Request Template in ServiceNow to use when creating the change request.
+
+For a `service_kind` of `launchdarkly`: No properties are required.
 
 ## Import
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -98,6 +98,22 @@ Nested environments `approval_settings` blocks have the following structure:
 
 - `required_approval_tags` - An array of tags used to specify which flags with those tags require approval. You may only set `required_approval_tags` if `required` is not set to `true` and vice versa.
 
+- `service_kind` (String) The kind of service to use when requesting an approval. Use this to switch which system approval requests go to. Valid values are `launchdarkly` and `servicenow`. The default is `launchdarkly`.
+-
+- `service_config` (Block List) The config for the approval service. This will differ for different kinds of services. (See [below for nested schema](#nestedblock--approval_settings_service_config))
+
+<a id="nestedblock--approval_settings_service_config"></a>
+### Nested Schema for `service_config`
+
+The structure of the `service_config` object will be different for each different service kind.
+
+For a `service_kind` of `servicenow`:
+
+- `detail_column` (String) The name of the column to place the details in when creating the change request in ServiceNow.
+- `template` (String) The sys_id of the Standard Change Request Template in ServiceNow to use when creating the change request.
+
+For a `service_kind` of `launchdarkly`: No properties are required.
+
 ### Nested Client side Availability Block
 
 The nested `default_client_side_availability` block describes which client-side SDKs can use new flags by default. To learn more about this setting, read [Making flags available to client-side and mobile SDKs](https://docs.launchdarkly.com/home/getting-started/feature-flags#making-flags-available-to-client-side-and-mobile-sdks). This block has the following structure:

--- a/launchdarkly/environments_helper_test.go
+++ b/launchdarkly/environments_helper_test.go
@@ -79,6 +79,8 @@ func TestEnvironmentToResourceData(t *testing.T) {
 					CanApplyDeclinedChanges: true,
 					RequiredApprovalTags:    []string{"approval"},
 					CanReviewOwnRequest:     true,
+					ServiceKind: "launchdarkly",
+					ServiceConfig: map[string]interface{}(nil),
 				},
 			},
 			expected: envResourceData{
@@ -101,6 +103,8 @@ func TestEnvironmentToResourceData(t *testing.T) {
 						CAN_APPLY_DECLINED_CHANGES: true,
 						REQUIRED_APPROVAL_TAGS:     []string{"approval"},
 						REQUIRED:                   true,
+						SERVICE_KIND: "launchdarkly",
+						SERVICE_CONFIG: map[string]interface{}(nil),
 					},
 				},
 			},

--- a/launchdarkly/keys.go
+++ b/launchdarkly/keys.go
@@ -95,6 +95,8 @@ const (
 	SECRET                           = "secret"
 	SECURE_MODE                      = "secure_mode"
 	SELECTOR                         = "selector"
+	SERVICE_CONFIG                   = "service_config"
+	SERVICE_KIND                     = "service_kind"
 	SERVICE_TOKEN                    = "service_token"
 	STATEMENTS                       = "statements"
 	SUBSTRING                        = "substring"


### PR DESCRIPTION
Hello!

This pull request will add support for setting `service_kind` and `service_config` in the approval settings on the project and environment resoures.

It will close #190 
