### PR TITLE
Add Terraform registry manifest file

### DIFF
--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "metadata": {
+    "protocol_versions": ["5.0"]
+  }
+}


### PR DESCRIPTION
This PR adds the `terraform-registry-manifest` per the official documentation [here](https://github.com/launchdarkly/terraform-provider-launchdarkly/pull/new/hbarrow/REL-4482/add-terraform-registry-manifest-file):
> `protocol_versions`: List of strings with supported Terraform protocol versions of the provider. Providers developed using [Terraform Plugin SDK version 2](https://developer.hashicorp.com/terraform/plugin/sdkv2) should set this field to ["5.0"]. Providers developed using [Terraform Plugin Framework](https://developer.hashicorp.com/terraform/plugin/framework) should set this field to ["6.0"] unless the Framework is [explicitly configured for protocol version 5](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/providerserver#ServeOpts.ProtocolVersion). Defaults to ["5.0"].
Given that this was not specified previously, I'm pretty sure we been using the default of 5.0 all along.