### PR TITLE
chore: send Slack notifications when acceptance tests fail on `main`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
 
   notify-slack-on-failure:
     name: Notify Slack on Failures
-    if: failure()
+    if: failure() && github.ref == 'refs/heads/main'
     needs:
       - build
       - generate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
       - run: go build -v .
       - name: Run linters
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
+      - run: exit 1
 
   generate:
     runs-on: ubuntu-latest
@@ -109,8 +110,12 @@ jobs:
           fi
 
   notify-slack-on-failure:
-    name: Notify Slack on Failure
-    if: always()
+    name: Notify Slack on Failures
+    if: failure()
+    needs:
+      - build
+      - generate
+      - test
     runs-on: ubuntu-latest
     steps:
       - name: Send GitHub trigger payload to Slack Workflow Builder

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
 
   notify-slack-on-failure:
     name: Notify Slack on Failures
-    if: failure()
+    if: failure() && github.ref == 'refs/heads/main'
     needs:
       - build
       - generate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,3 +107,16 @@ jobs:
             printf "Tests failed or workflow cancelled:\n\n${{ toJSON(needs) }}"
             exit 1
           fi
+
+  notify-slack-on-failure:
+    name: Notify Slack on Failure
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send GitHub trigger payload to Slack Workflow Builder
+        id: slack
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          payload-delimiter: "_"
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ jobs:
       - run: go build -v .
       - name: Run linters
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
-      - run: exit 1
 
   generate:
     runs-on: ubuntu-latest
@@ -111,7 +110,7 @@ jobs:
 
   notify-slack-on-failure:
     name: Notify Slack on Failures
-    if: failure() && github.ref == 'refs/heads/main'
+    if: failure()
     needs:
       - build
       - generate


### PR DESCRIPTION
This PR sets up Technique 1 of the [Slack Send Github Action](https://github.com/slackapi/slack-github-action). This will send a webhook to invoke a Slack Workflow that will send a message to our project channel.

### Example runs
![CleanShot 2024-12-06 at 3  39 05](https://github.com/user-attachments/assets/a056f2e6-49af-423e-97d3-c14e2e8b6821)

![CleanShot 2024-12-06 at 3  41 40](https://github.com/user-attachments/assets/8123a16f-3b52-4036-b2fc-2d7eeb23d09e)


