### PR TITLE
ci: Add terraform install step

### DIFF
--- a/.github/workflows/generate_integration_config_pr.yml
+++ b/.github/workflows/generate_integration_config_pr.yml
@@ -16,7 +16,7 @@ jobs:
           cache-dependency-path: |
             scripts/codegen/go.sum
             go.sum
-
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
       - run: make generate
         env:
           LAUNCHDARKLY_ACCESS_TOKEN: ${{secrets.LAUNCHDARKLY_ACCESS_TOKEN}}


### PR DESCRIPTION
GitHub Actions runners are now using ubuntu 24.04 - with this updated runner, comes a condensed toolset, which means terraform must be manually installed in a runner.
This PR adds the official hashicorp action for installing Terraform.

**Wait!**

- Have you added comprehensive tests?
- Have you updated relevant data sources as well as resources?
- Have you updated the docs?

**Testing**

For any changes you make, please ensure your acceptance test conform to the following:

- every single new attribute is tested
- optional attributes revert to null or default values if removed
- attributes that interact interact as expected
- block values behave as expected when reordered
- nested fields on maps or list/set items function as expected. Terraform does not actually enforce most schema attributes on nested items
- each test step for a configuration is followed by a test step where `ImportState` and `ImportStateVerify` are set to true. `ImportStateVerifyIgnore` can be used if we explicitly _expect_ a value to be different when imported, such as in the case of obfuscated values like API keys

## LaunchDarkly Employees
For more information on how to build, test, and release, see the [internal README on Confluence](https://launchdarkly.atlassian.net/wiki/spaces/ENG/pages/457379492).
