### PR TITLE
chore: configure release-please to open PRs in draft mode

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,9 +6,10 @@
       "include-v-in-tag": true,
       "extra-files": [],
       "include-component-in-tag": false,
-      "draft": true 
+      "draft": true
     }
   },
+  "draft-pull-request": true,
   "release-search-depth": 100,
   "commit-search-depth": 100
 }


### PR DESCRIPTION
This PR changes the release-please configuration to open release PRs in draft mode. This should make our lives slightly easier as our Github Actions should run when we press "Ready for Review."
