### PR TITLE
feat: add context_kind to targeting rules with percentage rollouts

### DIFF
--- a/docs/data-sources/feature_flag_environment.md
+++ b/docs/data-sources/feature_flag_environment.md
@@ -79,6 +79,7 @@ Read-Only:
 
 - `bucket_by` (String)
 - `clauses` (List of Object) (see [below for nested schema](#nestedobjatt--rules--clauses))
+- `context_kind` (String)
 - `description` (String)
 - `rollout_weights` (List of Number)
 - `variation` (Number)

--- a/docs/resources/feature_flag_environment.md
+++ b/docs/resources/feature_flag_environment.md
@@ -170,7 +170,9 @@ resource "launchdarkly_feature_flag_environment" "big_flag_environment" {
       op        = "segmentMatch" // Maps to 'Context is in' in the UI
       values    = ["test-segment"]
     }
-    variation = 0
+    rollout_weights = [40000, 60000]
+    bucket_by       = "country"
+    context_kind    = "account"
   }
 
   fallthrough {
@@ -240,6 +242,7 @@ Optional:
 
 - `bucket_by` (String) Group percentage rollout by a custom attribute. This argument is only valid if `rollout_weights` is also specified.
 - `clauses` (Block List) List of nested blocks specifying the logical clauses to evaluate (see [below for nested schema](#nestedblock--rules--clauses))
+- `context_kind` (String) The context kind associated with the specified rollout. This argument is only valid if `rollout_weights` is also specified. Defaults to `user` if omitted.
 - `description` (String) A human-readable description of the targeting rule.
 - `rollout_weights` (List of Number) List of integer percentage rollout weights (in thousandths of a percent) to apply to each variation if the rule clauses evaluates to `true`. The sum of the `rollout_weights` must equal 100000 and the number of rollout weights specified in the array must match the number of flag variations. You must specify either `variation` or `rollout_weights`.
 - `variation` (Number) The integer variation index to serve if the rule clauses evaluate to `true`. You must specify either `variation` or `rollout_weights`

--- a/examples/resources/launchdarkly_feature_flag_environment/resource.tf
+++ b/examples/resources/launchdarkly_feature_flag_environment/resource.tf
@@ -149,7 +149,9 @@ resource "launchdarkly_feature_flag_environment" "big_flag_environment" {
       op        = "segmentMatch" // Maps to 'Context is in' in the UI
       values    = ["test-segment"]
     }
-    variation = 0
+    rollout_weights = [40000, 60000]
+    bucket_by       = "country"
+    context_kind    = "account"
   }
 
   fallthrough {

--- a/launchdarkly/data_source_launchdarkly_feature_flag_environment_test.go
+++ b/launchdarkly/data_source_launchdarkly_feature_flag_environment_test.go
@@ -103,6 +103,24 @@ func TestAccDataSourceFeatureFlagEnvironment_exists(t *testing.T) {
 				},
 			},
 		},
+		{
+			Description: strPtr("test rule with rollout"),
+			Clauses: []ldapi.Clause{
+				{
+					Attribute: "thing",
+					Op:        "contains",
+					Values:    []interface{}{"test-2"},
+				},
+			},
+			Rollout: &ldapi.Rollout{
+				Variations: []ldapi.WeightedVariation{
+					{Variation: int32(0), Weight: int32(20000)},
+					{Variation: int32(1), Weight: int32(80000)},
+				},
+				BucketBy:    strPtr("country"),
+				ContextKind: strPtr("account"),
+			},
+		},
 	}
 	prerequisites := []ldapi.Prerequisite{
 		{
@@ -161,6 +179,10 @@ func TestAccDataSourceFeatureFlagEnvironment_exists(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rules.0.clauses.0.attribute", thisConfig.Rules[0].Clauses[0].Attribute),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.clauses.0.op", thisConfig.Rules[0].Clauses[0].Op),
 					resource.TestCheckResourceAttr(resourceName, "rules.0.clauses.0.values.0", fmt.Sprint(thisConfig.Rules[0].Clauses[0].Values[0])),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.description", *thisConfig.Rules[1].Description),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.rollout_weights.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.bucket_by", *thisConfig.Rules[1].Rollout.BucketBy),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.context_kind", *thisConfig.Rules[1].Rollout.ContextKind),
 					resource.TestCheckResourceAttr(resourceName, "prerequisites.0.flag_key", thisConfig.Prerequisites[0].Key),
 					resource.TestCheckResourceAttr(resourceName, "prerequisites.0.variation", fmt.Sprint(thisConfig.Prerequisites[0].Variation)),
 					resource.TestCheckResourceAttr(resourceName, OFF_VARIATION, fmt.Sprint(*thisConfig.OffVariation)),

--- a/launchdarkly/fallthrough_helper.go
+++ b/launchdarkly/fallthrough_helper.go
@@ -93,7 +93,7 @@ func fallthroughFromResourceData(d *schema.ResourceData) (fallthroughModel, erro
 
 	fall := f[0].(map[string]interface{})
 	if isPercentRollout(f) {
-		rollout := fallthroughModel{Rollout: rolloutFromResourceData(fall[ROLLOUT_WEIGHTS])}
+		rollout := fallthroughModel{Rollout: rolloutFromResourceData(fall[ROLLOUT_WEIGHTS].([]interface{}))}
 		bucketBy := fall[BUCKET_BY].(string)
 		if bucketBy != "" {
 			rollout.Rollout.BucketBy = &bucketBy

--- a/launchdarkly/resource_launchdarkly_feature_flag_environment_test.go
+++ b/launchdarkly/resource_launchdarkly_feature_flag_environment_test.go
@@ -118,6 +118,7 @@ resource "launchdarkly_feature_flag_environment" "basic" {
 		}
 		rollout_weights = [90000, 10000, 0]
 		bucket_by = "email"
+		context_kind = "account"
 	}
 
 	fallthrough {
@@ -737,6 +738,7 @@ func TestAccFeatureFlagEnvironment_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rules.1.rollout_weights.1", "10000"),
 					resource.TestCheckResourceAttr(resourceName, "rules.1.rollout_weights.2", "0"),
 					resource.TestCheckResourceAttr(resourceName, "rules.1.bucket_by", "email"),
+					resource.TestCheckResourceAttr(resourceName, "rules.1.context_kind", "account"),
 					resource.TestCheckResourceAttr(resourceName, "rules.1.clauses.0.attribute", "name"),
 					resource.TestCheckResourceAttr(resourceName, "rules.1.clauses.0.op", "startsWith"),
 					resource.TestCheckResourceAttr(resourceName, "rules.1.clauses.0.values.#", "1"),

--- a/launchdarkly/rollout_helper.go
+++ b/launchdarkly/rollout_helper.go
@@ -23,10 +23,9 @@ func rolloutSchema() *schema.Schema {
 	}
 }
 
-func rolloutFromResourceData(val interface{}) *ldapi.Rollout {
-	rolloutList := val.([]interface{})
-	variations := []ldapi.WeightedVariation{}
-	for idx, k := range rolloutList {
+func rolloutFromResourceData(rolloutWeights []interface{}) *ldapi.Rollout {
+	variations := make([]ldapi.WeightedVariation, 0, len(rolloutWeights))
+	for idx, k := range rolloutWeights {
 		weight := k.(int)
 		variations = append(variations,
 			ldapi.WeightedVariation{
@@ -43,11 +42,11 @@ func rolloutFromResourceData(val interface{}) *ldapi.Rollout {
 	return &r
 }
 
-func rolloutsToResourceData(rollouts *ldapi.Rollout) interface{} {
-	transformed := make([]interface{}, len(rollouts.Variations))
+func rolloutsToResourceData(rollouts *ldapi.Rollout) []interface{} {
+	transformed := make([]interface{}, 0, len(rollouts.Variations))
 
 	for _, r := range rollouts.Variations {
-		transformed[r.Variation] = r.Weight
+		transformed = append(transformed, r.Weight)
 	}
 	return transformed
 }

--- a/launchdarkly/rule_helper_test.go
+++ b/launchdarkly/rule_helper_test.go
@@ -1,0 +1,222 @@
+package launchdarkly
+
+import (
+	"testing"
+
+	ldapi "github.com/launchdarkly/api-client-go/v17"
+)
+
+func TestValidateRuleResourceData(t *testing.T) {
+	tests := []struct {
+		name    string
+		ruleMap map[string]interface{}
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid rule with variation",
+			ruleMap: map[string]interface{}{
+				ROLLOUT_WEIGHTS: []interface{}{},
+				BUCKET_BY:       "",
+				CONTEXT_KIND:    "",
+				VARIATION:       1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid rule with rollout weights",
+			ruleMap: map[string]interface{}{
+				ROLLOUT_WEIGHTS: []interface{}{
+					map[string]interface{}{
+						"variation": 0,
+						"weight":    50000,
+					},
+				},
+				BUCKET_BY:    "email",
+				CONTEXT_KIND: "user",
+				VARIATION:    0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid - bucket_by with variation",
+			ruleMap: map[string]interface{}{
+				ROLLOUT_WEIGHTS: []interface{}{},
+				BUCKET_BY:       "email",
+				CONTEXT_KIND:    "",
+				VARIATION:       1,
+			},
+			wantErr: true,
+			errMsg:  "rules: cannot use bucket_by argument with variation, only with rollout_weights",
+		},
+		{
+			name: "invalid - context_kind with variation",
+			ruleMap: map[string]interface{}{
+				ROLLOUT_WEIGHTS: []interface{}{},
+				BUCKET_BY:       "",
+				CONTEXT_KIND:    "user",
+				VARIATION:       1,
+			},
+			wantErr: true,
+			errMsg:  "rules: cannot use context_kind argument with variation, only with rollout_weights",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRuleResourceData(tt.ruleMap)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateRuleResourceData() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && err.Error() != tt.errMsg {
+				t.Errorf("validateRuleResourceData() error message = %v, want %v", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestRulesToResourceData(t *testing.T) {
+	bucketBy := "email"
+	contextKind := "user"
+	description := "test description"
+	variation := int32(1)
+	tests := []struct {
+		name    string
+		rules   []ldapi.Rule
+		want    []map[string]interface{}
+		wantErr bool
+	}{
+		{
+			name: "rule with variation",
+			rules: []ldapi.Rule{
+				{
+					Description: &description,
+					Variation:   &variation,
+					Clauses: []ldapi.Clause{
+						{
+							Attribute: "email",
+							Op:        "contains",
+							Values:    []interface{}{"test@test.com"},
+						},
+					},
+				},
+			},
+			want: []map[string]interface{}{
+				{
+					DESCRIPTION: description,
+					VARIATION:   &variation,
+					CLAUSES: []interface{}{
+						map[string]interface{}{
+							"attribute": "email",
+							"op":        "contains",
+							"values":    []interface{}{"test@test.com"},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "rule with rollout",
+			rules: []ldapi.Rule{
+				{
+					Description: &description,
+					Rollout: &ldapi.Rollout{
+						BucketBy:    &bucketBy,
+						ContextKind: &contextKind,
+						Variations: []ldapi.WeightedVariation{
+							{
+								Variation: 0,
+								Weight:    50000,
+							},
+						},
+					},
+					Clauses: []ldapi.Clause{
+						{
+							Attribute: "country",
+							Op:        "in",
+							Values:    []interface{}{"US", "CA"},
+						},
+					},
+				},
+			},
+			want: []map[string]interface{}{
+				{
+					DESCRIPTION:  description,
+					BUCKET_BY:    &bucketBy,
+					CONTEXT_KIND: &contextKind,
+					ROLLOUT_WEIGHTS: []interface{}{
+						map[string]interface{}{
+							"variation": 0,
+							"weight":    50000,
+						},
+					},
+					CLAUSES: []interface{}{
+						map[string]interface{}{
+							"attribute": "country",
+							"op":        "in",
+							"values":    []interface{}{"US", "CA"},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "empty rules list",
+			rules:   []ldapi.Rule{},
+			want:    []map[string]interface{}{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := rulesToResourceData(tt.rules)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("rulesToResourceData() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil {
+				return
+			}
+
+			gotSlice, ok := got.([]interface{})
+			if !ok {
+				t.Errorf("rulesToResourceData() returned type = %T, want []interface{}", got)
+				return
+			}
+
+			if len(gotSlice) != len(tt.want) {
+				t.Errorf("rulesToResourceData() returned %d rules, want %d", len(gotSlice), len(tt.want))
+				return
+			}
+
+			for i, rule := range gotSlice {
+				ruleMap, ok := rule.(map[string]interface{})
+				if !ok {
+					t.Errorf("rule %d is not a map[string]interface{}", i)
+					continue
+				}
+
+				// Compare fields that should exist
+				if tt.want[i][DESCRIPTION] != nil && ruleMap[DESCRIPTION] != tt.want[i][DESCRIPTION] {
+					t.Errorf("rule %d description = %v, want %v", i, ruleMap[DESCRIPTION], tt.want[i][DESCRIPTION])
+				}
+
+				if tt.want[i][VARIATION] != nil && ruleMap[VARIATION] != tt.want[i][VARIATION] {
+					t.Errorf("rule %d variation = %v, want %v", i, ruleMap[VARIATION], tt.want[i][VARIATION])
+				}
+
+				if tt.want[i][BUCKET_BY] != nil && ruleMap[BUCKET_BY] != tt.want[i][BUCKET_BY] {
+					t.Errorf("rule %d bucket_by = %v, want %v", i, ruleMap[BUCKET_BY], tt.want[i][BUCKET_BY])
+				}
+
+				if tt.want[i][CONTEXT_KIND] != nil && ruleMap[CONTEXT_KIND] != tt.want[i][CONTEXT_KIND] {
+					t.Errorf("rule %d context_kind = %v, want %v", i, ruleMap[CONTEXT_KIND], tt.want[i][CONTEXT_KIND])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the ability to specify the context kind used in a targeting rule's percentage rollout. This was requested in #265.

Testing:
- Added unit tests for functions in `rule_helper.go`
- Modified a couple of our existing acceptance tests to take advantage of this new attribute. I also 
- Manual

### Manual testing
I used the following config:
```hcl
resource "launchdarkly_feature_flag_environment" "test_flag_environment" {
  flag_id = launchdarkly_feature_flag.test_flag.id
  env_key = "prod"
  on      = true

  rules {
    clauses {
      attribute = "country"
      op        = "in"
      values    = ["uk"]
    }
    rollout_weights = [60000, 40000]
    bucket_by       = "country"
    context_kind    = "account"
  }

  fallthrough {
    variation = 1
  }
  off_variation = 1
}
```

![CleanShot 2025-02-11 at 11  22 55@2x](https://github.com/user-attachments/assets/f8bd9c51-ff20-4f44-868e-e36cddafb022)
