### PR TITLE
fix: set `critical` property on environment resource

### DIFF
--- a/launchdarkly/environments_helper.go
+++ b/launchdarkly/environments_helper.go
@@ -290,7 +290,7 @@ func environmentRead(ctx context.Context, d *schema.ResourceData, meta interface
 	_ = d.Set(DEFAULT_TTL, int(env.DefaultTtl))
 	_ = d.Set(SECURE_MODE, env.SecureMode)
 	_ = d.Set(DEFAULT_TRACK_EVENTS, env.DefaultTrackEvents)
-	_ = d.Set(CRITICAL, env.Critical) // We need to update the LaunchDarkly go api client's version of Environment
+	_ = d.Set(CRITICAL, env.Critical)
 	_ = d.Set(TAGS, env.Tags)
 	_ = d.Set(REQUIRE_COMMENTS, env.RequireComments)
 	_ = d.Set(CONFIRM_CHANGES, env.ConfirmChanges)

--- a/launchdarkly/resource_launchdarkly_environment.go
+++ b/launchdarkly/resource_launchdarkly_environment.go
@@ -48,6 +48,7 @@ func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta
 	tags := stringsFromSchemaSet(d.Get(TAGS).(*schema.Set))
 	requireComments := d.Get(REQUIRE_COMMENTS).(bool)
 	confirmChanges := d.Get(CONFIRM_CHANGES).(bool)
+	critical := d.Get(CRITICAL).(bool)
 
 	envPost := ldapi.EnvironmentPost{
 		Name:               name,
@@ -59,6 +60,7 @@ func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta
 		Tags:               tags,
 		RequireComments:    &requireComments,
 		ConfirmChanges:     &confirmChanges,
+		Critical:           &critical,
 	}
 
 	_, _, err := client.ld.EnvironmentsApi.PostEnvironment(client.ctx, projectKey).EnvironmentPost(envPost).Execute()
@@ -100,6 +102,7 @@ func resourceEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta
 	color := d.Get(COLOR)
 	requireComments := d.Get(REQUIRE_COMMENTS)
 	confirmChanges := d.Get(CONFIRM_CHANGES)
+	critical := d.Get(CRITICAL)
 
 	patch := []ldapi.PatchOperation{
 		patchReplace("/name", &name),
@@ -109,6 +112,7 @@ func resourceEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta
 		patchReplace("/defaultTrackEvents", d.Get(DEFAULT_TRACK_EVENTS)),
 		patchReplace("/requireComments", &requireComments),
 		patchReplace("/confirmChanges", &confirmChanges),
+		patchReplace("/critical", &critical),
 	}
 
 	if d.HasChange(TAGS) {


### PR DESCRIPTION
This PR fixes a bug brought to our attention by a customer via the Support team where the `critical` property was only updating as expected on environments nested on the project resource, but was not functioning as expected on the environment resources themselves.