### PR TITLE
chore: disable release-please PR draft mode and add footer

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,8 @@
       "draft": true
     }
   },
-  "draft-pull-request": true,
+  "draft-pull-request": false,
+  "pull-request-footer": "**LaunchDarkly Employees:** you must close and reopen this PR to trigger the tests.\n\n---\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).",
   "release-search-depth": 100,
   "commit-search-depth": 100
 }


### PR DESCRIPTION
This PR disables the Release Please draft PR setting and adds a note to the PR footer explaining how to trigger the tests.

Previously we thought taking the release please PR out of draft mode would trigger our tests. Unfortunately that's not the case. The next best thing.

![CleanShot 2025-02-17 at 9  58 54@2x](https://github.com/user-attachments/assets/54fe5c23-420b-4f55-9a41-e7d62f3dd6a2)
