### PR TITLE
chore: remove release-please footer

### DIFF
--- a/.github/workflows/generate_integration_config_pr.yml
+++ b/.github/workflows/generate_integration_config_pr.yml
@@ -26,8 +26,8 @@ jobs:
         with:
           branch: regenerate-integration-configs/patch
           delete-branch: true
-          commit-message: "[bot] Regenerate integration configs"
-          title: "[bot] Regenerate integration configs"
+          commit-message: "feat: [bot] Regenerate integration configs"
+          title: "feat: [bot] Regenerate integration configs"
           body: |
             This PR regenerates `launchdarkly/integration_configs_generated.go` based on recent changes to the [integrations manifest endpoint](https://app.launchdarkly.com/api/v2/integration-manifests).
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,6 @@
     }
   },
   "draft-pull-request": false,
-  "pull-request-footer": "**LaunchDarkly Employees:** you must close and reopen this PR to trigger the tests.\n\n---\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).",
   "release-search-depth": 100,
   "commit-search-depth": 100
 }


### PR DESCRIPTION
This PR removes the release please PR footer because this is also getting copied to our releases (we do not want this). I also updated the regenerate-integration-configs bot PRs to use semantic PR titles.
