### PR TITLE
docs: explain `http_timeout` default value

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -44,5 +44,5 @@ resource "launchdarkly_feature_flag" "terraform" {
 
 - `access_token` (String) The [personal access token](https://docs.launchdarkly.com/home/account-security/api-access-tokens#personal-tokens) or [service token](https://docs.launchdarkly.com/home/account-security/api-access-tokens#service-tokens) used to authenticate with LaunchDarkly. You can also set this with the `LAUNCHDARKLY_ACCESS_TOKEN` environment variable. You must provide either `access_token` or `oauth_token`.
 - `api_host` (String) The LaunchDarkly host address. If this argument is not specified, the default host address is `https://app.launchdarkly.com`
-- `http_timeout` (Number) The HTTP timeout (in seconds) when making API calls to LaunchDarkly. If this argument is not specified, the default http_timeout is `20`.
+- `http_timeout` (Number) The HTTP timeout (in seconds) when making API calls to LaunchDarkly. If this argument is not specified, the default http timeout is `20`.
 - `oauth_token` (String) An OAuth V2 token you use to authenticate with LaunchDarkly. You can also set this with the `LAUNCHDARKLY_OAUTH_TOKEN` environment variable. You must provide either `access_token` or `oauth_token`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,5 +44,5 @@ resource "launchdarkly_feature_flag" "terraform" {
 
 - `access_token` (String) The [personal access token](https://docs.launchdarkly.com/home/account-security/api-access-tokens#personal-tokens) or [service token](https://docs.launchdarkly.com/home/account-security/api-access-tokens#service-tokens) used to authenticate with LaunchDarkly. You can also set this with the `LAUNCHDARKLY_ACCESS_TOKEN` environment variable. You must provide either `access_token` or `oauth_token`.
 - `api_host` (String) The LaunchDarkly host address. If this argument is not specified, the default host address is `https://app.launchdarkly.com`
-- `http_timeout` (Number) The HTTP timeout (in seconds) when making API calls to LaunchDarkly.
+- `http_timeout` (Number) The HTTP timeout (in seconds) when making API calls to LaunchDarkly. If this argument is not specified, the default http_timeout is `20`.
 - `oauth_token` (String) An OAuth V2 token you use to authenticate with LaunchDarkly. You can also set this with the `LAUNCHDARKLY_OAUTH_TOKEN` environment variable. You must provide either `access_token` or `oauth_token`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,5 +44,5 @@ resource "launchdarkly_feature_flag" "terraform" {
 
 - `access_token` (String) The [personal access token](https://docs.launchdarkly.com/home/account-security/api-access-tokens#personal-tokens) or [service token](https://docs.launchdarkly.com/home/account-security/api-access-tokens#service-tokens) used to authenticate with LaunchDarkly. You can also set this with the `LAUNCHDARKLY_ACCESS_TOKEN` environment variable. You must provide either `access_token` or `oauth_token`.
 - `api_host` (String) The LaunchDarkly host address. If this argument is not specified, the default host address is `https://app.launchdarkly.com`
-- `http_timeout` (Number) The HTTP timeout (in seconds) when making API calls to LaunchDarkly. If this argument is not specified, the default http timeout is `20`.
+- `http_timeout` (Number) The HTTP timeout (in seconds) when making API calls to LaunchDarkly. If this argument is not specified, the default HTTP timeout is `20`.
 - `oauth_token` (String) An OAuth V2 token you use to authenticate with LaunchDarkly. You can also set this with the `LAUNCHDARKLY_OAUTH_TOKEN` environment variable. You must provide either `access_token` or `oauth_token`.


### PR DESCRIPTION
Adding the default value of `http_timeout` to the provider docs.
The value is from https://github.com/launchdarkly/terraform-provider-launchdarkly/blob/0ce849e6ad8fd143187ad4cca011679fdbc209dd/launchdarkly/provider.go#L17
