### PR TITLE
chore: [REL-7676] github action to pull in secrets from SSM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      LAUNCHDARKLY_ACCESS_TOKEN: ${{ needs.configure-aws-credentials.outputs.LAUNCHDARKLY_ACCESS_TOKEN }}
+      LAUNCHDARKLY_ACCESS_TOKEN: ${{ needs.configure-aws-credentials.outputs.LAUNCHDARKLY_ACCESS_TOKEN || secrets.LAUNCHDARKLY_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
@@ -79,7 +79,7 @@ jobs:
     timeout-minutes: 10
     env:
       TF_ACC: "1"
-      LAUNCHDARKLY_ACCESS_TOKEN: ${{ needs.configure-aws-credentials.outputs.LAUNCHDARKLY_ACCESS_TOKEN }}
+      LAUNCHDARKLY_ACCESS_TOKEN: ${{ needs.configure-aws-credentials.outputs.LAUNCHDARKLY_ACCESS_TOKEN || secrets.LAUNCHDARKLY_ACCESS_TOKEN }}
     strategy:
       matrix:
         test_case:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: "go.mod"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,9 @@ jobs:
   configure-aws-credentials:
     name: Configure AWS Credentials
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       LAUNCHDARKLY_ACCESS_TOKEN: ${{ steps.get-launchdarkly-access-token.outputs.LAUNCHDARKLY_ACCESS_TOKEN }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - run: go build -v .
       - name: Run linters
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
-
+  
   generate:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -37,6 +37,16 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
+        with:
+          audience: https://github.com/launchdarkly
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::061661829416:role/github-actions-terraform-provider-launchdarkly
+      - id: get-launchdarkly-access-token
+        uses: dkershner6/aws-ssm-getparameters-action@4fcb4872421f387a6c43058473acc1b22443fe13 # v2.0.3
+        with:
+          parameterPairs: |
+            /global/services/github/terraform-provider/launchdarkly-access-token = LAUNCHDARKLY_ACCESS_TOKEN
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: "go.mod"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,20 @@ jobs:
       - name: Run linters
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
 
+  configure-aws-credentials:
+    name: Configure AWS Credentials
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
+        with:
+          audience: http://github.com/launchdarkly
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::061661829416:role/github-actions-terraform-provider-launchdarkly
+      - uses: dkershner6/aws-ssm-getparameters-action@4fcb4872421f387a6c43058473acc1b22443fe13 # v2.0.3
+        with:
+          parameterPairs: |
+            /global/services/github/terraform-provider/launchdarkly-access-token = secrets.LAUNCHDARKLY_ACCESS_TOKEN
+            
   generate:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      LAUNCHDARKLY_ACCESS_TOKEN: ${{ needs.configure-aws-credentials.outputs.LAUNCHDARKLY_ACCESS_TOKEN || secrets.LAUNCHDARKLY_ACCESS_TOKEN }}
+      LAUNCHDARKLY_ACCESS_TOKEN: ${{ needs.configure-aws-credentials.outputs.LAUNCHDARKLY_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
@@ -79,7 +79,7 @@ jobs:
     timeout-minutes: 10
     env:
       TF_ACC: "1"
-      LAUNCHDARKLY_ACCESS_TOKEN: ${{ needs.configure-aws-credentials.outputs.LAUNCHDARKLY_ACCESS_TOKEN || secrets.LAUNCHDARKLY_ACCESS_TOKEN }}
+      LAUNCHDARKLY_ACCESS_TOKEN: ${{ needs.configure-aws-credentials.outputs.LAUNCHDARKLY_ACCESS_TOKEN }}
     strategy:
       matrix:
         test_case:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
         with:
-          audience: http://github.com/launchdarkly/terraform-provider-launchdarkly
+          audience: https://github.com/launchdarkly
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::061661829416:role/github-actions-terraform-provider-launchdarkly
       - id: get-launchdarkly-access-token

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,8 +111,6 @@ jobs:
           go-version: "1.22.9"
       - run: go mod download
       - name: Run Test
-        env:
-          LAUNCHDARKLY_ACCESS_TOKEN: ${{ steps.get-launchdarkly-access-token.outputs.LAUNCHDARKLY_ACCESS_TOKEN }}
         run: |
           echo "Running test case: ${{ matrix.test_case }}"
           TESTARGS="-run ${{ matrix.test_case }}" make testacc-with-retry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,17 +56,6 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
-        with:
-          audience: https://github.com/launchdarkly
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::061661829416:role/github-actions-terraform-provider-launchdarkly
-      - id: get-launchdarkly-access-token
-        uses: dkershner6/aws-ssm-getparameters-action@4fcb4872421f387a6c43058473acc1b22443fe13 # v2.0.3
-        with:
-          parameterPairs: |
-            /global/services/github/terraform-provider/launchdarkly-access-token = LAUNCHDARKLY_ACCESS_TOKEN
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: "go.mod"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
         with:
-          audience: http://github.com/launchdarkly
+          audience: http://github.com/launchdarkly/terraform-provider-launchdarkly
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::061661829416:role/github-actions-terraform-provider-launchdarkly
       - id: get-launchdarkly-access-token

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,26 +28,6 @@ jobs:
       - run: go build -v .
       - name: Run linters
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
-  
-  configure-aws-credentials:
-    name: Configure AWS Credentials
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    outputs:
-      LAUNCHDARKLY_ACCESS_TOKEN: ${{ steps.get-launchdarkly-access-token.outputs.LAUNCHDARKLY_ACCESS_TOKEN }}
-    steps:
-      - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
-        with:
-          audience: https://github.com/launchdarkly
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::061661829416:role/github-actions-terraform-provider-launchdarkly
-      - id: get-launchdarkly-access-token
-        uses: dkershner6/aws-ssm-getparameters-action@4fcb4872421f387a6c43058473acc1b22443fe13 # v2.0.3
-        with:
-          parameterPairs: |
-            /global/services/github/terraform-provider/launchdarkly-access-token = LAUNCHDARKLY_ACCESS_TOKEN
 
   generate:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,26 +28,30 @@ jobs:
       - run: go build -v .
       - name: Run linters
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
-
+  
   configure-aws-credentials:
     name: Configure AWS Credentials
     runs-on: ubuntu-latest
+    outputs:
+      LAUNCHDARKLY_ACCESS_TOKEN: ${{ steps.get-launchdarkly-access-token.outputs.LAUNCHDARKLY_ACCESS_TOKEN }}
     steps:
       - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
         with:
           audience: http://github.com/launchdarkly
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::061661829416:role/github-actions-terraform-provider-launchdarkly
-      - uses: dkershner6/aws-ssm-getparameters-action@4fcb4872421f387a6c43058473acc1b22443fe13 # v2.0.3
+      - id: get-launchdarkly-access-token
+        uses: dkershner6/aws-ssm-getparameters-action@4fcb4872421f387a6c43058473acc1b22443fe13 # v2.0.3
         with:
           parameterPairs: |
-            /global/services/github/terraform-provider/launchdarkly-access-token = secrets.LAUNCHDARKLY_ACCESS_TOKEN
-            
+            /global/services/github/terraform-provider/launchdarkly-access-token = LAUNCHDARKLY_ACCESS_TOKEN
+
   generate:
+    needs: configure-aws-credentials
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      LAUNCHDARKLY_ACCESS_TOKEN: ${{ secrets.LAUNCHDARKLY_ACCESS_TOKEN }}
+      LAUNCHDARKLY_ACCESS_TOKEN: ${{ needs.configure-aws-credentials.outputs.LAUNCHDARKLY_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
@@ -66,12 +70,13 @@ jobs:
 
   # Run acceptance tests in a matrix with Terraform CLI versions
   test:
+    needs: configure-aws-credentials
     name: Acceptance Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
       TF_ACC: "1"
-      LAUNCHDARKLY_ACCESS_TOKEN: ${{ secrets.LAUNCHDARKLY_ACCESS_TOKEN }}
+      LAUNCHDARKLY_ACCESS_TOKEN: ${{ needs.configure-aws-credentials.outputs.LAUNCHDARKLY_ACCESS_TOKEN }}
     strategy:
       matrix:
         test_case:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,13 +50,23 @@ jobs:
             /global/services/github/terraform-provider/launchdarkly-access-token = LAUNCHDARKLY_ACCESS_TOKEN
 
   generate:
-    needs: configure-aws-credentials
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    env:
-      LAUNCHDARKLY_ACCESS_TOKEN: ${{ needs.configure-aws-credentials.outputs.LAUNCHDARKLY_ACCESS_TOKEN }}
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
+        with:
+          audience: https://github.com/launchdarkly
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::061661829416:role/github-actions-terraform-provider-launchdarkly
+      - id: get-launchdarkly-access-token
+        uses: dkershner6/aws-ssm-getparameters-action@4fcb4872421f387a6c43058473acc1b22443fe13 # v2.0.3
+        with:
+          parameterPairs: |
+            /global/services/github/terraform-provider/launchdarkly-access-token = LAUNCHDARKLY_ACCESS_TOKEN
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: "go.mod"
@@ -73,13 +83,14 @@ jobs:
 
   # Run acceptance tests in a matrix with Terraform CLI versions
   test:
-    needs: configure-aws-credentials
     name: Acceptance Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      id-token: write
+      contents: read
     env:
       TF_ACC: "1"
-      LAUNCHDARKLY_ACCESS_TOKEN: ${{ needs.configure-aws-credentials.outputs.LAUNCHDARKLY_ACCESS_TOKEN }}
     strategy:
       matrix:
         test_case:
@@ -105,11 +116,23 @@ jobs:
           - TestAccWebhook
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
+        with:
+          audience: https://github.com/launchdarkly
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::061661829416:role/github-actions-terraform-provider-launchdarkly
+      - id: get-launchdarkly-access-token
+        uses: dkershner6/aws-ssm-getparameters-action@4fcb4872421f387a6c43058473acc1b22443fe13 # v2.0.3
+        with:
+          parameterPairs: |
+            /global/services/github/terraform-provider/launchdarkly-access-token = LAUNCHDARKLY_ACCESS_TOKEN
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: "1.22.9"
       - run: go mod download
       - name: Run Test
+        env:
+          LAUNCHDARKLY_ACCESS_TOKEN: ${{ steps.get-launchdarkly-access-token.outputs.LAUNCHDARKLY_ACCESS_TOKEN }}
         run: |
           echo "Running test case: ${{ matrix.test_case }}"
           TESTARGS="-run ${{ matrix.test_case }}" make testacc-with-retry


### PR DESCRIPTION
This adds a new GHA to pull in the necessary secrets for running tests on PRs by outside collaborators. It will still require approval by an LD engineer. This should unblock #309.
<!-- ld-jira-link -->
---
Related Jira issue: [REL-7676: investigate and fix failing PR tests on terraform provider repo](https://launchdarkly.atlassian.net/browse/REL-7676)
<!-- end-ld-jira-link -->