### PR TITLE
chore: [REL-7676] move permissions out of individual jobs to top

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
 # Testing only needs permissions to read the repository contents.
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   # Ensure project builds before running testing matrix
@@ -32,9 +33,6 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      id-token: write
-      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
@@ -66,9 +64,6 @@ jobs:
     name: Acceptance Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      id-token: write
-      contents: read
     env:
       TF_ACC: "1"
     strategy:


### PR DESCRIPTION
**Wait!**

- Have you added comprehensive tests?
- Have you updated relevant data sources as well as resources?
- Have you updated the docs?

**Testing**

For any changes you make, please ensure your acceptance test conform to the following:

- every single new attribute is tested
- optional attributes revert to null or default values if removed
- attributes that interact interact as expected
- block values behave as expected when reordered
- nested fields on maps or list/set items function as expected. Terraform does not actually enforce most schema attributes on nested items
- each test step for a configuration is followed by a test step where `ImportState` and `ImportStateVerify` are set to true. `ImportStateVerifyIgnore` can be used if we explicitly _expect_ a value to be different when imported, such as in the case of obfuscated values like API keys

## LaunchDarkly Employees
For more information on how to build, test, and release, see the [internal README on Confluence](https://launchdarkly.atlassian.net/wiki/spaces/ENG/pages/457379492).
<!-- ld-jira-link -->
---
Related Jira issue: [REL-7676: investigate and fix failing PR tests on terraform provider repo](https://launchdarkly.atlassian.net/browse/REL-7676)
<!-- end-ld-jira-link -->