### PR TITLE
chore: [REL-7676] remove pull_request and update sha refs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ name: Test
 
 on:
   pull_request_target: # this is for external contributions/forks. we have a check in place to ensure an LD user explicitly allows the tests to run for forks.
-  pull_request:
   push:
     branches: [main]
   schedule: # runs tests once a day on the main branch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: "go.mod"
@@ -37,6 +39,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
         with:
           audience: https://github.com/launchdarkly
@@ -97,6 +101,8 @@ jobs:
           - TestAccWebhook
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
         with:
           audience: https://github.com/launchdarkly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha}}
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: "go.mod"
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
         with:
           audience: https://github.com/launchdarkly
@@ -102,7 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
         with:
           audience: https://github.com/launchdarkly

--- a/launchdarkly/resource_launchdarkly_project_test.go
+++ b/launchdarkly/resource_launchdarkly_project_test.go
@@ -244,7 +244,7 @@ func TestAccProject_Create(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, KEY, projectKey),
-					resource.TestCheckResourceAttr(resourceName, NAME, "test project"),
+					resource.TestCheckResourceAttr(resourceName, NAME, "FAIL THE TEST"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "terraform"),
 					resource.TestCheckResourceAttr(resourceName, "tags.1", "test"),

--- a/launchdarkly/resource_launchdarkly_project_test.go
+++ b/launchdarkly/resource_launchdarkly_project_test.go
@@ -244,7 +244,7 @@ func TestAccProject_Create(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, KEY, projectKey),
-					resource.TestCheckResourceAttr(resourceName, NAME, "FAIL THE TEST"),
+					resource.TestCheckResourceAttr(resourceName, NAME, "test project"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "terraform"),
 					resource.TestCheckResourceAttr(resourceName, "tags.1", "test"),


### PR DESCRIPTION
This just removes the `pull_request` trigger that had to be left in while we pushed `pull_request_target` to main.

## LaunchDarkly Employees
For more information on how to build, test, and release, see the [internal provider runbook](https://launchdarkly.atlassian.net/wiki/spaces/PD/pages/3825598468/LaunchDarkly+Terraform+Provider+Runbook).
<!-- ld-jira-link -->
---
Related Jira issue: [REL-7676: investigate and fix failing PR tests on terraform provider repo](https://launchdarkly.atlassian.net/browse/REL-7676)
<!-- end-ld-jira-link -->