### PR TITLE
chore: [REL-8042] fix breaking test build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,7 @@ jobs:
         with:
           parameterPairs: |
             /global/services/github/terraform-provider/launchdarkly-access-token = LAUNCHDARKLY_ACCESS_TOKEN
-      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "1.23.0"
       - run: go mod download


### PR DESCRIPTION
I have legitimately no idea why this broke last week (the go version hasn't been updated in 4 months) or why this fixes it, but here we are.

<!-- ld-jira-link -->
---
Related Jira issue: [REL-8042: investigate and fix breaking terraform GHA](https://launchdarkly.atlassian.net/browse/REL-8042)
<!-- end-ld-jira-link -->