### PR TITLE
fix: [REL-8605] add documentation note on discrepancy in default base permissions with current API version

### DIFF
--- a/docs/resources/custom_role.md
+++ b/docs/resources/custom_role.md
@@ -47,7 +47,7 @@ resource "launchdarkly_custom_role" "example" {
 
 ### Optional
 
-- `base_permissions` (String) The base permission level - either reader or no_access. Defaults to reader.
+- `base_permissions` (String) The base permission level - either `reader` or `no_access`. While newer API versions default to `no_access`, this field defaults to `reader` in keeping with previous API versions.
 - `description` (String) Description of the custom role.
 - `policy` (Block Set, Deprecated) (see [below for nested schema](#nestedblock--policy))
 - `policy_statements` (Block List) An array of the policy statements that define the permissions for the custom role. This field accepts [role attributes](https://docs.launchdarkly.com/home/getting-started/vocabulary#role-attribute). To use role attributes, use the syntax `$${roleAttribute/<YOUR_ROLE_ATTRIBUTE>}` in lieu of your usual resource keys. (see [below for nested schema](#nestedblock--policy_statements))

--- a/launchdarkly/resource_launchdarkly_custom_role.go
+++ b/launchdarkly/resource_launchdarkly_custom_role.go
@@ -51,7 +51,7 @@ This resource allows you to create and manage custom roles within your LaunchDar
 			BASE_PERMISSIONS: {
 				Type:             schema.TypeString,
 				Optional:         true,
-				Description:      "The base permission level - either reader or no_access. Defaults to reader.",
+				Description:      "The base permission level - either `reader` or `no_access`. While newer API versions default to `no_access`, this field defaults to `reader` in keeping with previous API versions.",
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"reader", "no_access"}, false)),
 				Default:          "reader",
 			},


### PR DESCRIPTION
Since v2 of the provider was released, we have [updated the custom roles API](https://launchdarkly.com/docs/guides/teams-roles/custom-roles#expand-no-access-by-default) to default `base_permissions` to `no_access` instead of `reader`. This PR just adds a note to clarify.

Screenshot from our public docs:
<img width="630" height="544" alt="Screenshot 2025-07-15 at 15 18 37" src="https://github.com/user-attachments/assets/a825c407-9557-4227-a2a3-735677af26cb" />


<!-- ld-jira-link -->
---
Related Jira issue: [REL-8605: Document discrepancy in default base_role settings between UI and TF](https://launchdarkly.atlassian.net/browse/REL-8605)
<!-- end-ld-jira-link -->