### PR TITLE
Add archived field to launchdarkly_metrics resources

### DIFF
--- a/docs/data-sources/metric.md
+++ b/docs/data-sources/metric.md
@@ -37,6 +37,7 @@ data "launchdarkly_metric" "example" {
 ### Read-Only
 
 - `analysis_type` (String) The method for analyzing metric events. Available choices are `mean` and `percentile`.
+- `archived` (Boolean) Whether the metric is archived.
 - `description` (String) The description of the metric's purpose.
 - `event_key` (String) The event key for your metric (if custom metric)
 - `id` (String) The ID of this resource.

--- a/docs/resources/metric.md
+++ b/docs/resources/metric.md
@@ -46,6 +46,7 @@ resource "launchdarkly_metric" "example" {
 ### Optional
 
 - `analysis_type` (String) The method for analyzing metric events. Available choices are `mean` and `percentile`.
+- `archived` (Boolean) Whether the metric is archived.
 - `description` (String) The description of the metric's purpose.
 - `event_key` (String) The event key for your metric (if custom metric)
 - `include_units_without_events` (Boolean) Include units that did not send any events and set their value to 0.

--- a/launchdarkly/metrics_helper.go
+++ b/launchdarkly/metrics_helper.go
@@ -151,6 +151,12 @@ func baseMetricSchema(isDataSource bool) map[string]*schema.Schema {
 			Computed:    true,
 			Description: "Version of the metric",
 		},
+		ARCHIVED: {
+			Type:        schema.TypeBool,
+			Optional:    !isDataSource,
+			Computed:    true,
+			Description: "Whether the metric is archived.",
+		},
 	}
 
 	if isDataSource {
@@ -210,6 +216,7 @@ func metricRead(ctx context.Context, d *schema.ResourceData, metaRaw interface{}
 	_ = d.Set(ANALYSIS_TYPE, metric.AnalysisType)
 	_ = d.Set(PERCENTILE_VALUE, metric.PercentileValue)
 	_ = d.Set(VERSION, metric.Version)
+	// _ = d.Set(ARCHIVED, metric.Archived) // Uncomment when API client is updated with archived field
 
 	d.SetId(projectKey + "/" + key)
 

--- a/launchdarkly/resource_launchdarkly_metric.go
+++ b/launchdarkly/resource_launchdarkly_metric.go
@@ -203,6 +203,7 @@ func resourceMetricCreate(ctx context.Context, d *schema.ResourceData, metaRaw i
 	analysisType := d.Get(ANALYSIS_TYPE).(string)
 	includeUnitsWithoutEvents := d.Get(INCLUDE_UNITS_WITHOUT_EVENTS).(bool)
 	eventDefaultDisabled := !includeUnitsWithoutEvents
+	// archived := d.Get(ARCHIVED).(bool) // Uncomment when API client is updated with archived field
 
 	metric := ldapi.MetricPost{
 		Name:                &name,
@@ -220,6 +221,7 @@ func resourceMetricCreate(ctx context.Context, d *schema.ResourceData, metaRaw i
 		UnitAggregationType: &unitAggregationType,
 		AnalysisType:        &analysisType,
 		EventDefault:        &ldapi.MetricEventDefaultRep{Disabled: &eventDefaultDisabled},
+		// Archived:            &archived, // Uncomment when API client is updated with archived field
 	}
 	percentileValueData, hasPercentile := d.GetOk(PERCENTILE_VALUE)
 	if hasPercentile {
@@ -310,6 +312,7 @@ func resourceMetricUpdate(ctx context.Context, d *schema.ResourceData, metaRaw i
 	unitAggregationType := d.Get(UNIT_AGGREGATION_TYPE).(string)
 	analysisType := d.Get(ANALYSIS_TYPE).(string)
 	includeUnitsWithoutEvents := d.Get(INCLUDE_UNITS_WITHOUT_EVENTS).(bool)
+	// archived := d.Get(ARCHIVED).(bool) // Uncomment when API client is updated with archived field
 
 	patch := []ldapi.PatchOperation{
 		patchReplace("/name", name),
@@ -325,6 +328,7 @@ func resourceMetricUpdate(ctx context.Context, d *schema.ResourceData, metaRaw i
 		patchReplace("/unitAggregationType", unitAggregationType),
 		patchReplace("/analysisType", analysisType),
 		patchReplace("/eventDefault/disabled", !includeUnitsWithoutEvents),
+		// patchReplace("/archived", archived), // Uncomment when API client is updated with archived field
 	}
 
 	percentileValueData, ok := d.GetOk(PERCENTILE_VALUE)


### PR DESCRIPTION
Adds `archived` boolean field to `launchdarkly_metric` resource to allow users to mark metrics as archived through Terraform.

added TO-DO comments for api client since `ldapi.MetricPost` does not support `Archived` field yet so when LD api client is merged I will uncomment the archived field code in create/update operations

made changes as we have discussed in Tech spec: https://docs.google.com/document/d/1HKRRgdSnHoXjrLnzRY9_7hQw4Q5pW9Q_AQdpO0wTm9w/edit?tab=t.0#heading=h.lcgpt7k0oisq


**Wait!**

- Have you added comprehensive tests?
- Have you updated relevant data sources as well as resources?
- Have you updated the docs?

**Testing**

For any changes you make, please ensure your acceptance test conform to the following:

- every single new attribute is tested
- optional attributes revert to null or default values if removed
- attributes that interact interact as expected
- block values behave as expected when reordered
- nested fields on maps or list/set items function as expected. Terraform does not actually enforce most schema attributes on nested items
- each test step for a configuration is followed by a test step where `ImportState` and `ImportStateVerify` are set to true. `ImportStateVerifyIgnore` can be used if we explicitly _expect_ a value to be different when imported, such as in the case of obfuscated values like API keys

## LaunchDarkly Employees
For more information on how to build, test, and release, see the [internal provider runbook](https://launchdarkly.atlassian.net/wiki/spaces/PD/pages/3825598468/LaunchDarkly+Terraform+Provider+Runbook).
