### PR TITLE
[SEC-7345] Resolve RCE vulnerability caused by pull_request_target GHA trigger

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,7 +1,7 @@
 name: "Enforce Semantic Pull Request Titles"
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@
 name: Test
 
 on:
-  pull_request_target: # this is for external contributions/forks. we have a check in place to ensure an LD user explicitly allows the tests to run for forks.
+  pull_request: # this is for external contributions/forks. we have a check in place to ensure an LD user explicitly allows the tests to run for forks.
   push:
     branches: [main]
   schedule: # runs tests once a day on the main branch


### PR DESCRIPTION
* Close RCE vulnerability that was reported through Hacker1 (https://launchdarkly.atlassian.net/browse/SEC-7343)
<!-- ld-jira-link -->
---
Related Jira issue: [SEC-7345: Close RCE on terraform-provider-launchdarkly GHA workflows](https://launchdarkly.atlassian.net/browse/SEC-7345)
<!-- end-ld-jira-link -->