### PR TITLE
fix: improve custom_properties hashing to resolve false / missing diffs

### DIFF
--- a/launchdarkly/custom_properties_helper_test.go
+++ b/launchdarkly/custom_properties_helper_test.go
@@ -46,6 +46,22 @@ func TestCustomPropertiesRoundTripConversion(t *testing.T) {
 				Value: []string{"a cp value1", "a cp value2", "a cp value3"}},
 			},
 		},
+		{
+			name: "Unsorted values get sorted",
+			customProperties: map[string]interface{}{
+				CUSTOM_PROPERTIES: []interface{}{
+					map[string]interface{}{
+						KEY:   "cp3",
+						NAME:  "nameValue3",
+						VALUE: []interface{}{"zebra", "apple", "banana"},
+					},
+				},
+			},
+			expected: map[string]ldapi.CustomProperty{"cp3": {
+				Name:  "nameValue3",
+				Value: []string{"apple", "banana", "zebra"}},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -59,7 +75,130 @@ func TestCustomPropertiesRoundTripConversion(t *testing.T) {
 			require.Equal(t, tc.expected, actual)
 
 			actualRaw := customPropertiesToResourceData(actual)
-			require.Equal(t, tc.customProperties[CUSTOM_PROPERTIES], actualRaw)
+			// After round trip, values should be sorted
+			expectedAfterRoundTrip := tc.customProperties[CUSTOM_PROPERTIES].([]interface{})
+			require.Len(t, actualRaw, len(expectedAfterRoundTrip))
+			for i, item := range actualRaw {
+				actualMap := item.(map[string]interface{})
+				expectedMap := expectedAfterRoundTrip[i].(map[string]interface{})
+				require.Equal(t, expectedMap[KEY], actualMap[KEY])
+				require.Equal(t, expectedMap[NAME], actualMap[NAME])
+				// Values should be sorted after round trip
+				actualValues := actualMap[VALUE].([]interface{})
+				expectedValues := expectedMap[VALUE].([]interface{})
+				require.Equal(t, len(expectedValues), len(actualValues))
+				// Check that values are sorted
+				for j := 0; j < len(actualValues)-1; j++ {
+					require.LessOrEqual(t, actualValues[j].(string), actualValues[j+1].(string), "values should be sorted")
+				}
+			}
+		})
+	}
+}
+
+func TestCustomPropertyHash(t *testing.T) {
+	testCases := []struct {
+		name        string
+		prop1       map[string]interface{}
+		prop2       map[string]interface{}
+		shouldEqual bool
+	}{
+		{
+			name: "identical properties have same hash",
+			prop1: map[string]interface{}{
+				KEY:   "test.key",
+				NAME:  "Test Name",
+				VALUE: []interface{}{"value1", "value2"},
+			},
+			prop2: map[string]interface{}{
+				KEY:   "test.key",
+				NAME:  "Test Name",
+				VALUE: []interface{}{"value1", "value2"},
+			},
+			shouldEqual: true,
+		},
+		{
+			name: "different keys have different hashes",
+			prop1: map[string]interface{}{
+				KEY:   "test.key1",
+				NAME:  "Test Name",
+				VALUE: []interface{}{"value1"},
+			},
+			prop2: map[string]interface{}{
+				KEY:   "test.key2",
+				NAME:  "Test Name",
+				VALUE: []interface{}{"value1"},
+			},
+			shouldEqual: false,
+		},
+		{
+			name: "different names have different hashes",
+			prop1: map[string]interface{}{
+				KEY:   "test.key",
+				NAME:  "Test Name 1",
+				VALUE: []interface{}{"value1"},
+			},
+			prop2: map[string]interface{}{
+				KEY:   "test.key",
+				NAME:  "Test Name 2",
+				VALUE: []interface{}{"value1"},
+			},
+			shouldEqual: false,
+		},
+		{
+			name: "different values have different hashes",
+			prop1: map[string]interface{}{
+				KEY:   "test.key",
+				NAME:  "Test Name",
+				VALUE: []interface{}{"value1"},
+			},
+			prop2: map[string]interface{}{
+				KEY:   "test.key",
+				NAME:  "Test Name",
+				VALUE: []interface{}{"value2"},
+			},
+			shouldEqual: false,
+		},
+		{
+			name: "sorted values produce same hash regardless of input order",
+			prop1: map[string]interface{}{
+				KEY:   "test.key",
+				NAME:  "Test Name",
+				VALUE: []interface{}{"zebra", "apple", "banana"},
+			},
+			prop2: map[string]interface{}{
+				KEY:   "test.key",
+				NAME:  "Test Name",
+				VALUE: []interface{}{"apple", "banana", "zebra"},
+			},
+			shouldEqual: true,
+		},
+		{
+			name: "different value counts have different hashes",
+			prop1: map[string]interface{}{
+				KEY:   "test.key",
+				NAME:  "Test Name",
+				VALUE: []interface{}{"value1", "value2"},
+			},
+			prop2: map[string]interface{}{
+				KEY:   "test.key",
+				NAME:  "Test Name",
+				VALUE: []interface{}{"value1"},
+			},
+			shouldEqual: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hash1 := customPropertyHash(tc.prop1)
+			hash2 := customPropertyHash(tc.prop2)
+
+			if tc.shouldEqual {
+				require.Equal(t, hash1, hash2, "hashes should be equal")
+			} else {
+				require.NotEqual(t, hash1, hash2, "hashes should be different")
+			}
 		})
 	}
 }


### PR DESCRIPTION
Issue:
Terraform does not detect changes during the custom_properties updates.

Solution:
Use field hashing and consistent hashing.

What changed?

1. Complete field hashing: The hash now includes all fields (key, name, value), not just the key. This ensures Terraform can properly identify when any field changes.
2. Consistent hashing: By using a struct and including all fields, the hash remains consistent even when Terraform's internal TypeSet mechanism calls the function multiple times.
3. Sorted values: Values are now consistently sorted in both directions (write and read), ensuring state consistency.

**Wait!**

- Have you added comprehensive tests?
- Have you updated relevant data sources as well as resources?
- Have you updated the docs?

**Testing**

For any changes you make, please ensure your acceptance test conform to the following:

- every single new attribute is tested
- optional attributes revert to null or default values if removed
- attributes that interact interact as expected
- block values behave as expected when reordered
- nested fields on maps or list/set items function as expected. Terraform does not actually enforce most schema attributes on nested items
- each test step for a configuration is followed by a test step where `ImportState` and `ImportStateVerify` are set to true. `ImportStateVerifyIgnore` can be used if we explicitly _expect_ a value to be different when imported, such as in the case of obfuscated values like API keys

## LaunchDarkly Employees
For more information on how to build, test, and release, see the [internal provider runbook](https://launchdarkly.atlassian.net/wiki/spaces/PD/pages/3825598468/LaunchDarkly+Terraform+Provider+Runbook).
