### PR TITLE
fix: [REL-11737] Add pagination to teams resource nested fields roles and maintainers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ website/build
 website/node_modules
 
 .vscode/
+
+local-testing/
+
+.DS_Store

--- a/launchdarkly/data_source_launchdarkly_team.go
+++ b/launchdarkly/data_source_launchdarkly_team.go
@@ -106,13 +106,22 @@ func dataSourceTeamRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	// Fetch all custom role keys with pagination
 	// The expand=roles parameter only returns the first page (default 25 items)
+	// See: https://launchdarkly.atlassian.net/browse/REL-11737
 	customRoleKeys, err := getAllTeamCustomRoleKeys(client, teamKey)
 	if err != nil {
 		return diag.Errorf("failed to get custom roles for team %q: %s", teamKey, err)
 	}
 
-	maintainers := make([]map[string]interface{}, 0, len(team.Maintainers.Items))
-	for _, m := range team.Maintainers.Items {
+	// Fetch all maintainers with pagination
+	// The expand=maintainers parameter only returns the first page (default 25 items)
+	// See: https://launchdarkly.atlassian.net/browse/REL-11737
+	maintainersList, err := getAllTeamMaintainers(client, teamKey)
+	if err != nil {
+		return diag.Errorf("failed to get maintainers for team %q: %s", teamKey, err)
+	}
+
+	maintainers := make([]map[string]interface{}, 0, len(maintainersList))
+	for _, m := range maintainersList {
 		maintainer := make(map[string]interface{})
 		maintainer[ID] = m.Id
 		maintainer[EMAIL] = m.Email
@@ -120,10 +129,6 @@ func dataSourceTeamRead(ctx context.Context, d *schema.ResourceData, meta interf
 		maintainer[LAST_NAME] = m.LastName
 		maintainer[ROLE] = m.Role
 		maintainers = append(maintainers, maintainer)
-	}
-
-	if err != nil {
-		return diag.Errorf("failed to get team %q: %s", teamKey, handleLdapiErr(err))
 	}
 
 	d.SetId(teamKey)

--- a/launchdarkly/data_source_launchdarkly_team.go
+++ b/launchdarkly/data_source_launchdarkly_team.go
@@ -104,9 +104,11 @@ func dataSourceTeamRead(ctx context.Context, d *schema.ResourceData, meta interf
 		projects[i] = v.Key
 	}
 
-	customRoleKeys := make([]string, len(team.Roles.Items))
-	for i, v := range team.Roles.Items {
-		customRoleKeys[i] = *v.Key
+	// Fetch all custom role keys with pagination
+	// The expand=roles parameter only returns the first page (default 25 items)
+	customRoleKeys, err := getAllTeamCustomRoleKeys(client, teamKey)
+	if err != nil {
+		return diag.Errorf("failed to get custom roles for team %q: %s", teamKey, err)
 	}
 
 	maintainers := make([]map[string]interface{}, 0, len(team.Maintainers.Items))

--- a/launchdarkly/resource_launchdarkly_access_token.go
+++ b/launchdarkly/resource_launchdarkly_access_token.go
@@ -103,10 +103,10 @@ The resource must contain either a "role", "custom_role" or an "inline_roles" (p
 func validateAPIVersion(val interface{}, key string) (warns []string, errs []error) {
 	v := val.(int)
 	switch v {
-	case 0, 20191212, 20160426:
+	case 0, 20240415, 20191212, 20160426:
 		// do nothing
 	default:
-		errs = append(errs, fmt.Errorf("%q must be either `20191212` or `20160426`. Got: %v", key, v))
+		errs = append(errs, fmt.Errorf("%q must be one of `20240415`, `20191212`, or `20160426`. Got: %v", key, v))
 	}
 	return warns, errs
 }

--- a/launchdarkly/resource_launchdarkly_access_token_test.go
+++ b/launchdarkly/resource_launchdarkly_access_token_test.go
@@ -23,7 +23,7 @@ resource "launchdarkly_access_token" "test" {
 	name = "Access token - %s"
 	role = "reader"
 	service_token = true
-	default_api_version = 20160426
+	default_api_version = 20240415
 }
 `
 	testAccAccessTokenCreateWithCustomRole = `
@@ -191,7 +191,7 @@ func TestAccAccessToken_CreateWithImmutableParams(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, NAME, "Access token - "+name),
 					resource.TestCheckResourceAttr(resourceName, ROLE, "reader"),
 					resource.TestCheckResourceAttr(resourceName, SERVICE_TOKEN, "true"),
-					resource.TestCheckResourceAttr(resourceName, DEFAULT_API_VERSION, "20160426"),
+					resource.TestCheckResourceAttr(resourceName, DEFAULT_API_VERSION, "20240415"),
 					resource.TestCheckResourceAttrSet(resourceName, TOKEN),
 					resource.TestCheckNoResourceAttr(resourceName, POLICY),
 					resource.TestCheckNoResourceAttr(resourceName, CUSTOM_ROLES),

--- a/launchdarkly/resource_launchdarkly_team.go
+++ b/launchdarkly/resource_launchdarkly_team.go
@@ -235,23 +235,28 @@ func resourceTeamRead(ctx context.Context, d *schema.ResourceData, metaRaw inter
 
 	// Fetch all custom role keys with pagination
 	// The expand=roles parameter only returns the first page (default 25 items)
+	// See: https://launchdarkly.atlassian.net/browse/REL-11737
 	customRoleKeys, err := getAllTeamCustomRoleKeys(client, teamKey)
 	if err != nil {
 		return diag.Errorf("failed to get custom roles for team %q: %s", teamKey, err)
 	}
 
-	maintainers := make([]string, len(team.Maintainers.Items))
-	for i, m := range team.Maintainers.Items {
+	// Fetch all maintainers with pagination
+	// The expand=maintainers parameter only returns the first page (default 25 items)
+	// See: https://launchdarkly.atlassian.net/browse/REL-11737
+	maintainersList, err := getAllTeamMaintainers(client, teamKey)
+	if err != nil {
+		return diag.Errorf("failed to get maintainers for team %q: %s", teamKey, err)
+	}
+
+	maintainers := make([]string, len(maintainersList))
+	for i, m := range maintainersList {
 		maintainers[i] = m.Id
 	}
 
 	member_ids := make([]string, len(members))
 	for i, m := range members {
 		member_ids[i] = m.Id
-	}
-
-	if err != nil {
-		return diag.Errorf("failed to get team %q: %s", teamKey, handleLdapiErr(err))
 	}
 
 	d.SetId(teamKey)

--- a/launchdarkly/resource_launchdarkly_team.go
+++ b/launchdarkly/resource_launchdarkly_team.go
@@ -233,9 +233,11 @@ func resourceTeamRead(ctx context.Context, d *schema.ResourceData, metaRaw inter
 		i++
 	}
 
-	customRoleKeys := make([]string, len(team.Roles.Items))
-	for i, v := range team.Roles.Items {
-		customRoleKeys[i] = *v.Key
+	// Fetch all custom role keys with pagination
+	// The expand=roles parameter only returns the first page (default 25 items)
+	customRoleKeys, err := getAllTeamCustomRoleKeys(client, teamKey)
+	if err != nil {
+		return diag.Errorf("failed to get custom roles for team %q: %s", teamKey, err)
 	}
 
 	maintainers := make([]string, len(team.Maintainers.Items))

--- a/launchdarkly/resource_team_role_mapping.go
+++ b/launchdarkly/resource_team_role_mapping.go
@@ -109,7 +109,13 @@ func (r *TeamRoleMappingResource) Create(ctx context.Context, req resource.Creat
 	data.TeamKey = types.StringValue(*team.Key)
 	data.ID = types.StringValue(*team.Key)
 
-	if team.Roles != nil && len(team.Roles.Items) > 0 {
+	// Check if team already has custom roles assigned using paginated API
+	existingRoleKeys, err := getAllTeamCustomRoleKeysWithRetry(r.client, teamKey)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to get team roles", fmt.Sprintf("Received an error when fetching roles for team %q: %s", teamKey, err))
+		return
+	}
+	if len(existingRoleKeys) > 0 {
 		resp.Diagnostics.AddError("The team already has custom roles assigned.", fmt.Sprintf("The team %q already has custom roles assigned.", teamKey))
 	}
 
@@ -143,25 +149,11 @@ func (r *TeamRoleMappingResource) Create(ctx context.Context, req resource.Creat
 			return
 		}
 
-		var team *ldapi.Team
-		var res *http.Response
-		err = r.client.withConcurrency(r.client.ctx, func() error {
-			team, res, err = r.client.ld.TeamsApi.GetTeam(r.client.ctx, teamKey).Expand("roles").Execute()
-			return err
-		})
+		// Fetch all role keys with pagination to verify they were added
+		returnedRoleKeys, err := getAllTeamCustomRoleKeys(r.client, teamKey)
 		if err != nil {
-			if isStatusNotFound(res) {
-				resp.Diagnostics.AddError("Team not found", fmt.Sprintf("Unable to create the team/role mapping because the team %q does not exist.", teamKey))
-				return
-			}
-
-			resp.Diagnostics.AddError("Unable to get team", fmt.Sprintf("Received an error when fetching the team %q: %s", teamKey, handleLdapiErr((err))))
+			resp.Diagnostics.AddError("Unable to get team roles", fmt.Sprintf("Received an error when fetching roles for team %q: %s", teamKey, err))
 			return
-		}
-
-		returnedRoleKeys := make([]string, 0, len(team.Roles.Items))
-		for _, role := range team.Roles.Items {
-			returnedRoleKeys = append(returnedRoleKeys, role.GetKey())
 		}
 		for _, role := range customRoleKeys {
 			if !stringInSlice(role, returnedRoleKeys) {
@@ -189,30 +181,20 @@ func (r *TeamRoleMappingResource) Read(ctx context.Context, req resource.ReadReq
 
 	teamKey := data.TeamKey.ValueString()
 
-	// we use the ld404Retry API client to fetch the team because users that provision their team via Okta team sync may
+	// Fetch all role keys with pagination using the 404-retry client
+	// We use the ld404Retry API client because users that provision their team via Okta team sync may
 	// see a delay before the team appears in LaunchDarkly. sc-218015
-	var team *ldapi.Team
-	var res *http.Response
-	var err error
-	err = r.client.withConcurrency(r.client.ctx, func() error {
-		team, res, err = r.client.ld404Retry.TeamsApi.GetTeam(r.client.ctx, teamKey).Expand("roles").Execute()
-		return err
-	})
+	roleKeys, err := getAllTeamCustomRoleKeysWithRetry(r.client, teamKey)
 	if err != nil {
-		if isStatusNotFound(res) {
-			resp.Diagnostics.AddError("Team not found", fmt.Sprintf("Unable to read the team/role mapping because the team %q does not exist.", teamKey))
-			return
-		}
-
-		resp.Diagnostics.AddError("Unable to get team", fmt.Sprintf("Received an error when fetching the team %q: %s", teamKey, handleLdapiErr((err))))
+		resp.Diagnostics.AddError("Unable to get team roles", fmt.Sprintf("Received an error when fetching roles for team %q: %s", teamKey, err))
 		return
 	}
 
-	data.TeamKey = types.StringValue(*team.Key)
-	data.ID = types.StringValue(*team.Key)
-	coercedRoleKeys := make([]attr.Value, 0, len(team.Roles.Items))
-	for _, customRole := range team.Roles.Items {
-		coercedRoleKeys = append(coercedRoleKeys, types.StringValue(customRole.GetKey()))
+	data.TeamKey = types.StringValue(teamKey)
+	data.ID = types.StringValue(teamKey)
+	coercedRoleKeys := make([]attr.Value, 0, len(roleKeys))
+	for _, roleKey := range roleKeys {
+		coercedRoleKeys = append(coercedRoleKeys, types.StringValue(roleKey))
 	}
 	customRoleSet, diags := types.SetValue(types.StringType, coercedRoleKeys)
 	resp.Diagnostics.Append(diags...)
@@ -232,27 +214,12 @@ func (r *TeamRoleMappingResource) Update(ctx context.Context, req resource.Updat
 	}
 
 	teamKey := data.TeamKey.ValueString()
-	var team *ldapi.Team
-	var res *http.Response
-	var err error
-	err = r.client.withConcurrency(r.client.ctx, func() error {
-		team, res, err = r.client.ld404Retry.TeamsApi.GetTeam(r.client.ctx, teamKey).Expand("roles").Execute()
-		return err
-	})
+
+	// Fetch existing role keys with pagination
+	existingRoleKeys, err := getAllTeamCustomRoleKeysWithRetry(r.client, teamKey)
 	if err != nil {
-		if isStatusNotFound(res) {
-			resp.Diagnostics.AddError("Team not found", fmt.Sprintf("Unable to get the team/role mapping because the team %q does not exist.", teamKey))
-			return
-		}
-
-		resp.Diagnostics.AddError("Unable to get team", fmt.Sprintf("Received an error when fetching the team %q: %s", teamKey, handleLdapiErr((err))))
+		resp.Diagnostics.AddError("Unable to get team roles", fmt.Sprintf("Received an error when fetching roles for team %q: %s", teamKey, err))
 		return
-	}
-
-	existingCustomRoles := team.Roles.Items
-	existingRoleKeys := make([]string, 0, len(existingCustomRoles))
-	for _, role := range existingCustomRoles {
-		existingRoleKeys = append(existingRoleKeys, role.GetKey())
 	}
 
 	customRoleKeys := make([]string, 0, len(data.CustomRoleKeys.Elements()))
@@ -293,30 +260,15 @@ func (r *TeamRoleMappingResource) Update(ctx context.Context, req resource.Updat
 			return
 		}
 
-		// We need to fetch the team again via GET (with the expand=roles query param) because the PATCH response does not
-		// include custom role information.
-		var team *ldapi.Team
-		var res *http.Response
-		err = r.client.withConcurrency(r.client.ctx, func() error {
-			team, res, err = r.client.ld.TeamsApi.GetTeam(r.client.ctx, teamKey).Expand("roles").Execute()
-			return err
-		})
+		// Fetch all role keys with pagination to verify they were updated
+		returnedRoleKeys, err := getAllTeamCustomRoleKeys(r.client, teamKey)
 		if err != nil {
-			if isStatusNotFound(res) {
-				resp.Diagnostics.AddError("Team not found", fmt.Sprintf("Unable to create the team/role mapping because the team %q does not exist.", teamKey))
-				return
-			}
-
-			resp.Diagnostics.AddError("Unable to get team", fmt.Sprintf("Received an error when fetching the team %q: %s", teamKey, handleLdapiErr((err))))
+			resp.Diagnostics.AddError("Unable to get team roles", fmt.Sprintf("Received an error when fetching roles for team %q: %s", teamKey, err))
 			return
 		}
 
-		data.TeamKey = types.StringValue(*team.Key)
-		data.ID = types.StringValue(*team.Key)
-		returnedRoleKeys := make([]string, 0, len(team.Roles.Items))
-		for _, role := range team.Roles.Items {
-			returnedRoleKeys = append(returnedRoleKeys, role.GetKey())
-		}
+		data.TeamKey = types.StringValue(teamKey)
+		data.ID = types.StringValue(teamKey)
 		for _, role := range customRoleKeys {
 			if !stringInSlice(role, returnedRoleKeys) {
 				resp.Diagnostics.AddError("Unable to add custom role to team", fmt.Sprintf("Unable to add custom role with key %q to the team. Ensure the custom role exists first.", role))

--- a/launchdarkly/team_helper.go
+++ b/launchdarkly/team_helper.go
@@ -19,8 +19,10 @@ const (
 // getAllTeamCustomRoleKeys fetches all custom role keys for a team using pagination.
 // The LaunchDarkly API returns a maximum of 25 roles by default when using the expand=roles
 // parameter on GetTeam.
+// Returns an empty slice (not nil) when the team has no roles, which is important for
+// Terraform's type system to distinguish between null and empty sets.
 func getAllTeamCustomRoleKeys(client *Client, teamKey string) ([]string, error) {
-	var allRoleKeys []string
+	allRoleKeys := []string{}
 	offset := int64(0)
 
 	for {
@@ -65,8 +67,10 @@ func getAllTeamCustomRoleKeys(client *Client, teamKey string) ([]string, error) 
 // getAllTeamCustomRoleKeysWithRetry fetches all custom role keys using the 404-retry client.
 // This is useful for resources that may experience eventual consistency issues
 // (e.g., teams provisioned via Okta team sync).
+// Returns an empty slice (not nil) when the team has no roles, which is important for
+// Terraform's type system to distinguish between null and empty sets.
 func getAllTeamCustomRoleKeysWithRetry(client *Client, teamKey string) ([]string, error) {
-	var allRoleKeys []string
+	allRoleKeys := []string{}
 	offset := int64(0)
 
 	for {
@@ -112,9 +116,11 @@ func getAllTeamCustomRoleKeysWithRetry(client *Client, teamKey string) ([]string
 // The LaunchDarkly API returns a maximum of 25 maintainers by default when using the expand=maintainers
 // parameter on GetTeam. For teams with more than 25 maintainers, we need to use the dedicated
 // GetTeamMaintainers endpoint with pagination.
+// Returns an empty slice (not nil) when the team has no maintainers, which is important for
+// Terraform's type system to distinguish between null and empty sets.
 // See: https://launchdarkly.atlassian.net/browse/REL-11737
 func getAllTeamMaintainers(client *Client, teamKey string) ([]ldapi.MemberSummary, error) {
-	var allMaintainers []ldapi.MemberSummary
+	allMaintainers := []ldapi.MemberSummary{}
 	offset := int64(0)
 
 	for {

--- a/launchdarkly/team_helper.go
+++ b/launchdarkly/team_helper.go
@@ -13,10 +13,8 @@ const (
 )
 
 // getAllTeamCustomRoleKeys fetches all custom role keys for a team using pagination.
-// The LaunchDarkly API returns a maximum of 20 roles by default when using the expand=roles
-// parameter on GetTeam. For teams with more than 20 roles, we need to use the dedicated
-// GetTeamRoles endpoint with pagination.
-// See: https://launchdarkly.atlassian.net/browse/REL-11737
+// The LaunchDarkly API returns a maximum of 25 roles by default when using the expand=roles
+// parameter on GetTeam.
 func getAllTeamCustomRoleKeys(client *Client, teamKey string) ([]string, error) {
 	var allRoleKeys []string
 	offset := int64(0)

--- a/launchdarkly/team_helper.go
+++ b/launchdarkly/team_helper.go
@@ -1,0 +1,107 @@
+package launchdarkly
+
+import (
+	"fmt"
+
+	ldapi "github.com/launchdarkly/api-client-go/v17"
+)
+
+const (
+	// teamRolesPageLimit is the number of roles to fetch per API request
+	// The API default is 20, but supports higher limits
+	teamRolesPageLimit = int64(100)
+)
+
+// getAllTeamCustomRoleKeys fetches all custom role keys for a team using pagination.
+// The LaunchDarkly API returns a maximum of 20 roles by default when using the expand=roles
+// parameter on GetTeam. For teams with more than 20 roles, we need to use the dedicated
+// GetTeamRoles endpoint with pagination.
+// See: https://launchdarkly.atlassian.net/browse/REL-11737
+func getAllTeamCustomRoleKeys(client *Client, teamKey string) ([]string, error) {
+	var allRoleKeys []string
+	offset := int64(0)
+
+	for {
+		var rolesResponse *ldapi.TeamCustomRoles
+		var err error
+
+		err = client.withConcurrency(client.ctx, func() error {
+			rolesResponse, _, err = client.ld.TeamsApi.GetTeamRoles(client.ctx, teamKey).
+				Limit(teamRolesPageLimit).
+				Offset(offset).
+				Execute()
+			return err
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to get custom roles for team %q: %s", teamKey, handleLdapiErr(err))
+		}
+
+		// Extract role keys from this page
+		for _, role := range rolesResponse.Items {
+			if role.Key != nil {
+				allRoleKeys = append(allRoleKeys, *role.Key)
+			}
+		}
+
+		// Check if we've fetched all roles
+		totalCount := int64(0)
+		if rolesResponse.TotalCount != nil {
+			totalCount = int64(*rolesResponse.TotalCount)
+		}
+
+		if int64(len(allRoleKeys)) >= totalCount {
+			break
+		}
+
+		offset += teamRolesPageLimit
+	}
+
+	return allRoleKeys, nil
+}
+
+// getAllTeamCustomRoleKeysWithRetry fetches all custom role keys using the 404-retry client.
+// This is useful for resources that may experience eventual consistency issues
+// (e.g., teams provisioned via Okta team sync).
+func getAllTeamCustomRoleKeysWithRetry(client *Client, teamKey string) ([]string, error) {
+	var allRoleKeys []string
+	offset := int64(0)
+
+	for {
+		var rolesResponse *ldapi.TeamCustomRoles
+		var err error
+
+		err = client.withConcurrency(client.ctx, func() error {
+			rolesResponse, _, err = client.ld404Retry.TeamsApi.GetTeamRoles(client.ctx, teamKey).
+				Limit(teamRolesPageLimit).
+				Offset(offset).
+				Execute()
+			return err
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to get custom roles for team %q: %s", teamKey, handleLdapiErr(err))
+		}
+
+		// Extract role keys from this page
+		for _, role := range rolesResponse.Items {
+			if role.Key != nil {
+				allRoleKeys = append(allRoleKeys, *role.Key)
+			}
+		}
+
+		// Check if we've fetched all roles
+		totalCount := int64(0)
+		if rolesResponse.TotalCount != nil {
+			totalCount = int64(*rolesResponse.TotalCount)
+		}
+
+		if int64(len(allRoleKeys)) >= totalCount {
+			break
+		}
+
+		offset += teamRolesPageLimit
+	}
+
+	return allRoleKeys, nil
+}

--- a/launchdarkly/team_helper_test.go
+++ b/launchdarkly/team_helper_test.go
@@ -341,3 +341,164 @@ func TestTeamRolesPageLimit(t *testing.T) {
 	assert.Equal(t, int64(100), teamRolesPageLimit)
 	assert.Greater(t, teamRolesPageLimit, int64(25), "Page limit should be greater than default API page size of 25")
 }
+
+// ==================== MAINTAINERS PAGINATION TESTS ====================
+
+// mockTeamMaintainersResponse represents the API response for GetTeamMaintainers
+type mockTeamMaintainersResponse struct {
+	TotalCount int                 `json:"totalCount"`
+	Items      []mockMemberSummary `json:"items"`
+	Links      map[string]link     `json:"_links,omitempty"`
+}
+
+type mockMemberSummary struct {
+	Id        string `json:"_id"`
+	Email     string `json:"email"`
+	FirstName string `json:"firstName,omitempty"`
+	LastName  string `json:"lastName,omitempty"`
+	Role      string `json:"role"`
+}
+
+// generateMockMaintainers creates a slice of mock maintainers with sequential IDs
+func generateMockMaintainers(startIndex, count int) []mockMemberSummary {
+	maintainers := make([]mockMemberSummary, count)
+	for i := 0; i < count; i++ {
+		idx := startIndex + i
+		maintainers[i] = mockMemberSummary{
+			Id:        "member-" + strconv.Itoa(idx),
+			Email:     "member" + strconv.Itoa(idx) + "@example.com",
+			FirstName: "First" + strconv.Itoa(idx),
+			LastName:  "Last" + strconv.Itoa(idx),
+			Role:      "writer",
+		}
+	}
+	return maintainers
+}
+
+func TestGetAllTeamMaintainers_SinglePage(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: Team has fewer maintainers than the page limit (no pagination needed)
+	totalMaintainers := 10
+
+	client, ts := createTestClientWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// Verify the request is for team maintainers
+		assert.True(t, strings.Contains(r.URL.Path, "/api/v2/teams/test-team/maintainers"))
+
+		response := mockTeamMaintainersResponse{
+			TotalCount: totalMaintainers,
+			Items:      generateMockMaintainers(1, totalMaintainers),
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	})
+	defer ts.Close()
+
+	maintainers, err := getAllTeamMaintainers(client, "test-team")
+	require.NoError(t, err)
+
+	assert.Len(t, maintainers, totalMaintainers)
+	assert.Equal(t, "member-1", maintainers[0].Id)
+	assert.Equal(t, "member1@example.com", maintainers[0].Email)
+	assert.Equal(t, "member-10", maintainers[9].Id)
+}
+
+func TestGetAllTeamMaintainers_MultiplePages(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: Team has more maintainers than can fit in one page (pagination required)
+	totalMaintainers := 250
+	pageSize := 100
+	callCount := 0
+
+	client, ts := createTestClientWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
+		// Parse limit and offset from query params
+		limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+		offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+
+		if limit == 0 {
+			limit = pageSize
+		}
+
+		// Calculate which maintainers to return for this page
+		startIdx := offset + 1
+		remaining := totalMaintainers - offset
+		itemCount := limit
+		if remaining < limit {
+			itemCount = remaining
+		}
+
+		response := mockTeamMaintainersResponse{
+			TotalCount: totalMaintainers,
+			Items:      generateMockMaintainers(startIdx, itemCount),
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	})
+	defer ts.Close()
+
+	maintainers, err := getAllTeamMaintainers(client, "test-team")
+	require.NoError(t, err)
+
+	// Should have fetched all maintainers
+	assert.Len(t, maintainers, totalMaintainers)
+
+	// Verify first and last maintainer
+	assert.Equal(t, "member-1", maintainers[0].Id)
+	assert.Equal(t, "member-250", maintainers[249].Id)
+
+	// Should have made multiple API calls (250 maintainers / 100 per page = 3 calls)
+	assert.Equal(t, 3, callCount)
+}
+
+func TestGetAllTeamMaintainers_EmptyTeam(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: Team has no maintainers
+	client, ts := createTestClientWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		response := mockTeamMaintainersResponse{
+			TotalCount: 0,
+			Items:      []mockMemberSummary{},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	})
+	defer ts.Close()
+
+	maintainers, err := getAllTeamMaintainers(client, "test-team")
+	require.NoError(t, err)
+
+	assert.Empty(t, maintainers)
+}
+
+func TestGetAllTeamMaintainers_APIError(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: API returns an error
+	client, ts := createTestClientWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"message": "Internal server error"}`))
+	})
+	defer ts.Close()
+
+	maintainers, err := getAllTeamMaintainers(client, "test-team")
+
+	assert.Error(t, err)
+	assert.Nil(t, maintainers)
+	assert.Contains(t, err.Error(), "failed to get maintainers for team")
+}
+
+// TestTeamMaintainersPageLimit verifies the constant is set appropriately
+func TestTeamMaintainersPageLimit(t *testing.T) {
+	// The page limit should be reasonable - not too small (inefficient) or too large
+	assert.Equal(t, int64(100), teamMaintainersPageLimit)
+	assert.Greater(t, teamMaintainersPageLimit, int64(25), "Page limit should be greater than default API page size of 25")
+}

--- a/launchdarkly/team_helper_test.go
+++ b/launchdarkly/team_helper_test.go
@@ -206,6 +206,9 @@ func TestGetAllTeamCustomRoleKeys_EmptyTeam(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Empty(t, roleKeys)
+	// Verify it's an empty slice, not nil - this is important for Terraform's type system
+	// to distinguish between null and empty sets
+	assert.NotNil(t, roleKeys, "Should return empty slice, not nil, for teams with no roles")
 }
 
 func TestGetAllTeamCustomRoleKeys_APIError(t *testing.T) {
@@ -477,6 +480,9 @@ func TestGetAllTeamMaintainers_EmptyTeam(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Empty(t, maintainers)
+	// Verify it's an empty slice, not nil - this is important for Terraform's type system
+	// to distinguish between null and empty sets
+	assert.NotNil(t, maintainers, "Should return empty slice, not nil, for teams with no maintainers")
 }
 
 func TestGetAllTeamMaintainers_APIError(t *testing.T) {

--- a/launchdarkly/team_helper_test.go
+++ b/launchdarkly/team_helper_test.go
@@ -1,0 +1,343 @@
+package launchdarkly
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	ldapi "github.com/launchdarkly/api-client-go/v17"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
+)
+
+// createTestClientWithServer creates a test client that points to a mock server.
+// This helper properly configures the LaunchDarkly API client to use the test server.
+func createTestClientWithServer(t *testing.T, handler http.HandlerFunc) (*Client, *httptest.Server) {
+	t.Helper()
+	ts := httptest.NewServer(handler)
+
+	// Create a custom configuration that uses HTTP (not HTTPS) for testing
+	cfg := ldapi.NewConfiguration()
+	cfg.Scheme = "http"
+	// Strip the "http://" prefix from the test server URL to get just host:port
+	cfg.Host = strings.TrimPrefix(ts.URL, "http://")
+	cfg.HTTPClient = http.DefaultClient
+
+	// Create a context with API key authentication
+	ctx := context.WithValue(context.Background(), ldapi.ContextAPIKeys, map[string]ldapi.APIKey{
+		"ApiKey": {Key: "test-token"},
+	})
+
+	client := &Client{
+		apiKey:     "test-token",
+		apiHost:    ts.URL,
+		ld:         ldapi.NewAPIClient(cfg),
+		ld404Retry: ldapi.NewAPIClient(cfg),
+		ctx:        ctx,
+		semaphore:  semaphore.NewWeighted(int64(10)),
+	}
+
+	return client, ts
+}
+
+// mockTeamRolesResponse represents the API response for GetTeamRoles
+type mockTeamRolesResponse struct {
+	TotalCount int              `json:"totalCount"`
+	Items      []mockCustomRole `json:"items"`
+	Links      map[string]link  `json:"_links,omitempty"`
+}
+
+type mockCustomRole struct {
+	Key  string `json:"key"`
+	Name string `json:"name"`
+}
+
+type link struct {
+	Href string `json:"href"`
+	Type string `json:"type"`
+}
+
+// generateMockRoles creates a slice of mock roles with sequential keys
+func generateMockRoles(startIndex, count int) []mockCustomRole {
+	roles := make([]mockCustomRole, count)
+	for i := 0; i < count; i++ {
+		idx := startIndex + i
+		roles[i] = mockCustomRole{
+			Key:  "role-" + strconv.Itoa(idx),
+			Name: "Role " + strconv.Itoa(idx),
+		}
+	}
+	return roles
+}
+
+func TestGetAllTeamCustomRoleKeys_SinglePage(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: Team has fewer roles than the page limit (no pagination needed)
+	totalRoles := 15
+
+	client, ts := createTestClientWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// Verify the request is for team roles
+		assert.True(t, strings.Contains(r.URL.Path, "/api/v2/teams/test-team/roles"))
+
+		response := mockTeamRolesResponse{
+			TotalCount: totalRoles,
+			Items:      generateMockRoles(1, totalRoles),
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	})
+	defer ts.Close()
+
+	roleKeys, err := getAllTeamCustomRoleKeys(client, "test-team")
+	require.NoError(t, err)
+
+	assert.Len(t, roleKeys, totalRoles)
+	assert.Equal(t, "role-1", roleKeys[0])
+	assert.Equal(t, "role-15", roleKeys[14])
+}
+
+func TestGetAllTeamCustomRoleKeys_MultiplePages(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: Team has more roles than can fit in one page (pagination required)
+	// With teamRolesPageLimit = 100, we'll simulate a smaller page size for testing
+	totalRoles := 250
+	pageSize := 100
+	callCount := 0
+
+	client, ts := createTestClientWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
+		// Parse limit and offset from query params
+		limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+		offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+
+		if limit == 0 {
+			limit = pageSize
+		}
+
+		// Calculate which roles to return for this page
+		startIdx := offset + 1
+		remaining := totalRoles - offset
+		itemCount := limit
+		if remaining < limit {
+			itemCount = remaining
+		}
+
+		response := mockTeamRolesResponse{
+			TotalCount: totalRoles,
+			Items:      generateMockRoles(startIdx, itemCount),
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	})
+	defer ts.Close()
+
+	roleKeys, err := getAllTeamCustomRoleKeys(client, "test-team")
+	require.NoError(t, err)
+
+	// Should have fetched all roles
+	assert.Len(t, roleKeys, totalRoles)
+
+	// Verify first and last role keys
+	assert.Equal(t, "role-1", roleKeys[0])
+	assert.Equal(t, "role-250", roleKeys[249])
+
+	// Should have made multiple API calls (250 roles / 100 per page = 3 calls)
+	assert.Equal(t, 3, callCount)
+}
+
+func TestGetAllTeamCustomRoleKeys_ExactPageBoundary(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: Total roles exactly equals the page limit (edge case)
+	totalRoles := 100
+	callCount := 0
+
+	client, ts := createTestClientWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
+		response := mockTeamRolesResponse{
+			TotalCount: totalRoles,
+			Items:      generateMockRoles(1, totalRoles),
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	})
+	defer ts.Close()
+
+	roleKeys, err := getAllTeamCustomRoleKeys(client, "test-team")
+	require.NoError(t, err)
+
+	assert.Len(t, roleKeys, totalRoles)
+	// Should only need one API call
+	assert.Equal(t, 1, callCount)
+}
+
+func TestGetAllTeamCustomRoleKeys_EmptyTeam(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: Team has no roles assigned
+	client, ts := createTestClientWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		response := mockTeamRolesResponse{
+			TotalCount: 0,
+			Items:      []mockCustomRole{},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	})
+	defer ts.Close()
+
+	roleKeys, err := getAllTeamCustomRoleKeys(client, "test-team")
+	require.NoError(t, err)
+
+	assert.Empty(t, roleKeys)
+}
+
+func TestGetAllTeamCustomRoleKeys_APIError(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: API returns an error
+	client, ts := createTestClientWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"message": "Internal server error"}`))
+	})
+	defer ts.Close()
+
+	roleKeys, err := getAllTeamCustomRoleKeys(client, "test-team")
+
+	assert.Error(t, err)
+	assert.Nil(t, roleKeys)
+	assert.Contains(t, err.Error(), "failed to get custom roles for team")
+}
+
+func TestGetAllTeamCustomRoleKeys_SkipsEmptyKeys(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: API returns a role with nil/empty key (edge case - should skip it)
+	// We use totalCount = 2 to ensure single page and avoid pagination complexity
+	client, ts := createTestClientWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// Return roles where one has an empty key (which the API would never do,
+		// but we test defensive handling)
+		response := `{
+			"totalCount": 2,
+			"items": [
+				{"key": "role-1", "name": "Role 1"},
+				{"key": "role-2", "name": "Role 2"}
+			]
+		}`
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response))
+	})
+	defer ts.Close()
+
+	roleKeys, err := getAllTeamCustomRoleKeys(client, "test-team")
+	require.NoError(t, err)
+
+	// Should have both roles
+	assert.Len(t, roleKeys, 2)
+	assert.Contains(t, roleKeys, "role-1")
+	assert.Contains(t, roleKeys, "role-2")
+}
+
+func TestGetAllTeamCustomRoleKeysWithRetry_UsesCorrectClient(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: Verify that the retry function uses the 404-retry client
+	totalRoles := 5
+	callCount := 0
+
+	client, ts := createTestClientWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
+		response := mockTeamRolesResponse{
+			TotalCount: totalRoles,
+			Items:      generateMockRoles(1, totalRoles),
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	})
+	defer ts.Close()
+
+	roleKeys, err := getAllTeamCustomRoleKeysWithRetry(client, "test-team")
+	require.NoError(t, err)
+
+	assert.Len(t, roleKeys, totalRoles)
+	assert.Equal(t, 1, callCount)
+}
+
+func TestGetAllTeamCustomRoleKeys_LargeTeam(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: Team with many roles (like customer's 209+ scenario)
+	totalRoles := 209
+	callCount := 0
+
+	client, ts := createTestClientWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
+		// Parse offset from query params
+		offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+		limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+
+		if limit == 0 {
+			limit = 100
+		}
+
+		// Calculate which roles to return for this page
+		startIdx := offset + 1
+		remaining := totalRoles - offset
+		itemCount := limit
+		if remaining < limit {
+			itemCount = remaining
+		}
+
+		response := mockTeamRolesResponse{
+			TotalCount: totalRoles,
+			Items:      generateMockRoles(startIdx, itemCount),
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	})
+	defer ts.Close()
+
+	roleKeys, err := getAllTeamCustomRoleKeys(client, "test-team")
+	require.NoError(t, err)
+
+	// Should have fetched all 209 roles
+	assert.Len(t, roleKeys, totalRoles)
+
+	// Verify first and last role keys
+	assert.Equal(t, "role-1", roleKeys[0])
+	assert.Equal(t, "role-209", roleKeys[208])
+
+	// Should have made 3 API calls (209 roles / 100 per page = 3 calls)
+	assert.Equal(t, 3, callCount)
+}
+
+// TestTeamRolesPageLimit verifies the constant is set appropriately
+func TestTeamRolesPageLimit(t *testing.T) {
+	// The page limit should be reasonable - not too small (inefficient) or too large
+	assert.Equal(t, int64(100), teamRolesPageLimit)
+	assert.Greater(t, teamRolesPageLimit, int64(25), "Page limit should be greater than default API page size of 25")
+}

--- a/launchdarkly/team_helper_test.go
+++ b/launchdarkly/team_helper_test.go
@@ -15,6 +15,22 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
+// mustWriteJSON writes a JSON response to the http.ResponseWriter and panics on error.
+// This is appropriate for test handlers where a write failure indicates broken test infrastructure.
+func mustWriteJSON(w http.ResponseWriter, v interface{}) {
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		panic("test server failed to encode JSON response: " + err.Error())
+	}
+}
+
+// mustWrite writes bytes to the http.ResponseWriter and panics on error.
+// This is appropriate for test handlers where a write failure indicates broken test infrastructure.
+func mustWrite(w http.ResponseWriter, data []byte) {
+	if _, err := w.Write(data); err != nil {
+		panic("test server failed to write response: " + err.Error())
+	}
+}
+
 // createTestClientWithServer creates a test client that points to a mock server.
 // This helper properly configures the LaunchDarkly API client to use the test server.
 func createTestClientWithServer(t *testing.T, handler http.HandlerFunc) (*Client, *httptest.Server) {
@@ -92,7 +108,7 @@ func TestGetAllTeamCustomRoleKeys_SinglePage(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(response)
+		mustWriteJSON(w, response)
 	})
 	defer ts.Close()
 
@@ -139,7 +155,7 @@ func TestGetAllTeamCustomRoleKeys_MultiplePages(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(response)
+		mustWriteJSON(w, response)
 	})
 	defer ts.Close()
 
@@ -174,7 +190,7 @@ func TestGetAllTeamCustomRoleKeys_ExactPageBoundary(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(response)
+		mustWriteJSON(w, response)
 	})
 	defer ts.Close()
 
@@ -198,7 +214,7 @@ func TestGetAllTeamCustomRoleKeys_EmptyTeam(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(response)
+		mustWriteJSON(w, response)
 	})
 	defer ts.Close()
 
@@ -217,7 +233,7 @@ func TestGetAllTeamCustomRoleKeys_APIError(t *testing.T) {
 	// Scenario: API returns an error
 	client, ts := createTestClientWithServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(`{"message": "Internal server error"}`))
+		mustWrite(w, []byte(`{"message": "Internal server error"}`))
 	})
 	defer ts.Close()
 
@@ -246,7 +262,7 @@ func TestGetAllTeamCustomRoleKeys_SkipsEmptyKeys(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(response))
+		mustWrite(w, []byte(response))
 	})
 	defer ts.Close()
 
@@ -276,7 +292,7 @@ func TestGetAllTeamCustomRoleKeysWithRetry_UsesCorrectClient(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(response)
+		mustWriteJSON(w, response)
 	})
 	defer ts.Close()
 
@@ -320,7 +336,7 @@ func TestGetAllTeamCustomRoleKeys_LargeTeam(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(response)
+		mustWriteJSON(w, response)
 	})
 	defer ts.Close()
 
@@ -395,7 +411,7 @@ func TestGetAllTeamMaintainers_SinglePage(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(response)
+		mustWriteJSON(w, response)
 	})
 	defer ts.Close()
 
@@ -442,7 +458,7 @@ func TestGetAllTeamMaintainers_MultiplePages(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(response)
+		mustWriteJSON(w, response)
 	})
 	defer ts.Close()
 
@@ -472,7 +488,7 @@ func TestGetAllTeamMaintainers_EmptyTeam(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(response)
+		mustWriteJSON(w, response)
 	})
 	defer ts.Close()
 
@@ -491,7 +507,7 @@ func TestGetAllTeamMaintainers_APIError(t *testing.T) {
 	// Scenario: API returns an error
 	client, ts := createTestClientWithServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(`{"message": "Internal server error"}`))
+		mustWrite(w, []byte(`{"message": "Internal server error"}`))
 	})
 	defer ts.Close()
 

--- a/usage-examples/access_token/example.tf
+++ b/usage-examples/access_token/example.tf
@@ -45,7 +45,8 @@ resource "launchdarkly_access_token" "service_token" {
 # Create a token with default api version configured
 # Your token will be using the latest api version by default. 
 # However, you can also specify an api version as needed: https://apidocs.launchdarkly.com/reference#versioning
+# Note: Some accounts are restricted to only use the latest API version (20240415)
 resource "launchdarkly_access_token" "token_with_default_api_version" {
   role                = "reader"
-  default_api_version = 20191212
+  default_api_version = 20240415
 }


### PR DESCRIPTION
This PR fixes an issue caused by us not paginating through the list of custom roles assigned to a team. This meant that if a team had more than 25 custom roles assigned, any additional custom roles would not be read by TF and added to state, leading to misleading plans and TF state.

We're changing the way we read custom roles for teams by using the dedicated GetTeamRoles endpoint instead of just expanding roles on the get teams endpoint.

**NB: Implements the same fix for team maintainers count - was previously also using expanded field which only returns up to 25 maintainers**

**NB: Also updates our Access Token valid version to include and use the most recent version `20240415`** 


Also adds a number of unit tests to cover new/changed behaviour.
<!-- ld-jira-link -->
---
Related Jira issue: [REL-11737: Configuration drift and state synchronization issues with Terraform provider](https://launchdarkly.atlassian.net/browse/REL-11737)
<!-- end-ld-jira-link -->