### PR TITLE
fix: [REL-12001] incorrect header for views requests and add tests

### DIFF
--- a/launchdarkly/view_helper.go
+++ b/launchdarkly/view_helper.go
@@ -14,6 +14,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// setViewRequestHeaders sets the common headers for View API requests
+func setViewRequestHeaders(req *http.Request, apiKey string) {
+	req.Header.Set("Authorization", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("LD-API-Version", "beta")
+	req.Header.Set("User-Agent", fmt.Sprintf("launchdarkly-terraform-provider/%s", version))
+}
+
 func viewRead(ctx context.Context, d *schema.ResourceData, meta interface{}, isDataSource bool) diag.Diagnostics {
 	var diags diag.Diagnostics
 	client := meta.(*Client)
@@ -160,9 +168,7 @@ func getViewRaw(client *Client, projectKey, viewKey string) (*View, *http.Respon
 		return nil, nil, err
 	}
 
-	req.Header.Set("Authorization", client.apiKey)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("LD-API-Version", "beta")
+	setViewRequestHeaders(req, client.apiKey)
 
 	resp, err := client.ld.GetConfig().HTTPClient.Do(req)
 	if err != nil {
@@ -199,9 +205,7 @@ func createView(client *Client, projectKey string, viewPost map[string]interface
 		return nil, err
 	}
 
-	req.Header.Set("Authorization", client.apiKey)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("LD-API-Version", "beta")
+	setViewRequestHeaders(req, client.apiKey)
 
 	resp, err := client.ld.GetConfig().HTTPClient.Do(req)
 	if err != nil {
@@ -238,9 +242,7 @@ func patchView(client *Client, projectKey, viewKey string, patch map[string]inte
 		return err
 	}
 
-	req.Header.Set("Authorization", client.apiKey)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("LD-API-Version", "beta")
+	setViewRequestHeaders(req, client.apiKey)
 
 	resp, err := client.ld.GetConfig().HTTPClient.Do(req)
 	if err != nil {
@@ -268,9 +270,7 @@ func deleteView(client *Client, projectKey, viewKey string) error {
 		return err
 	}
 
-	req.Header.Set("Authorization", client.apiKey)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("LD-API-Version", "beta")
+	setViewRequestHeaders(req, client.apiKey)
 
 	resp, err := client.ld.GetConfig().HTTPClient.Do(req)
 	if err != nil {
@@ -390,9 +390,7 @@ func performViewLinkOperation(client *Client, projectKey, viewKey, resourceType 
 		return err
 	}
 
-	req.Header.Set("Authorization", client.apiKey)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("LD-API-Version", "beta")
+	setViewRequestHeaders(req, client.apiKey)
 
 	resp, err := client.ld.GetConfig().HTTPClient.Do(req)
 	if err != nil {
@@ -426,9 +424,7 @@ func performViewSegmentLinkOperation(client *Client, projectKey, viewKey string,
 		return err
 	}
 
-	req.Header.Set("Authorization", client.apiKey)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("LD-API-Version", "beta")
+	setViewRequestHeaders(req, client.apiKey)
 
 	resp, err := client.ld.GetConfig().HTTPClient.Do(req)
 	if err != nil {
@@ -558,9 +554,7 @@ func getLinkedResources(client *Client, projectKey, viewKey, resourceType string
 		return nil, err
 	}
 
-	req.Header.Set("Authorization", client.apiKey)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("LD-API-Version", "beta")
+	setViewRequestHeaders(req, client.apiKey)
 
 	resp, err := client.ld.GetConfig().HTTPClient.Do(req)
 	if err != nil {
@@ -622,9 +616,7 @@ func getViewsContainingFlag(client *Client, projectKey, flagKey string) ([]strin
 		return nil, err
 	}
 
-	req.Header.Set("Authorization", client.apiKey)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("LD-API-Version", "beta")
+	setViewRequestHeaders(req, client.apiKey)
 
 	resp, err := client.ld.GetConfig().HTTPClient.Do(req)
 	if err != nil {
@@ -660,9 +652,7 @@ func getViewsContainingSegment(client *Client, projectKey, environmentId, segmen
 		return nil, err
 	}
 
-	req.Header.Set("Authorization", client.apiKey)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("LD-API-Version", "beta")
+	setViewRequestHeaders(req, client.apiKey)
 
 	resp, err := client.ld.GetConfig().HTTPClient.Do(req)
 	if err != nil {

--- a/launchdarkly/view_helper_test.go
+++ b/launchdarkly/view_helper_test.go
@@ -1,0 +1,81 @@
+package launchdarkly
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	ldapi "github.com/launchdarkly/api-client-go/v17"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetViewRequestHeaders(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	require.NoError(t, err)
+
+	setViewRequestHeaders(req, "test-api-key")
+
+	require.Equal(t, "test-api-key", req.Header.Get("Authorization"))
+	require.Equal(t, "application/json", req.Header.Get("Content-Type"))
+	require.Equal(t, "beta", req.Header.Get("LD-API-Version"))
+	require.Equal(t, fmt.Sprintf("launchdarkly-terraform-provider/%s", version), req.Header.Get("User-Agent"))
+}
+
+func TestViewRequestsIncludeUserAgentHeader(t *testing.T) {
+	projectKey := "test-project"
+	viewKey := "test-view"
+	expectedUA := fmt.Sprintf("launchdarkly-terraform-provider/%s", version)
+
+	headerCh := make(chan string, 1)
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case headerCh <- r.Header.Get("User-Agent"):
+		default:
+		}
+
+		if r.URL.Path != fmt.Sprintf("/api/v2/projects/%s/views/%s", projectKey, viewKey) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		err := json.NewEncoder(w).Encode(View{
+			Id:         "view-id",
+			Key:        viewKey,
+			Name:       "Test View",
+			ProjectKey: projectKey,
+		})
+		require.NoError(t, err)
+	}))
+	t.Cleanup(ts.Close)
+
+	cfg := ldapi.NewConfiguration()
+	cfg.Scheme = "https"
+	cfg.Host = strings.TrimPrefix(ts.URL, "https://")
+	cfg.HTTPClient = ts.Client()
+
+	client := &Client{
+		apiKey:  "test-token",
+		apiHost: strings.TrimPrefix(ts.URL, "https://"),
+		ld:      ldapi.NewAPIClient(cfg),
+		ctx: context.WithValue(context.Background(), ldapi.ContextAPIKeys, map[string]ldapi.APIKey{
+			"ApiKey": {Key: "test-token"},
+		}),
+	}
+
+	_, _, err := getViewRaw(client, projectKey, viewKey)
+	require.NoError(t, err)
+
+	select {
+	case ua := <-headerCh:
+		require.Equal(t, expectedUA, ua)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for User-Agent header")
+	}
+}


### PR DESCRIPTION
We weren't properly setting the terraform provider header in our custom requests for views which makes analytics harder.
<!-- ld-jira-link -->
---
Related Jira issue: [REL-12001: Fix Bug with incorrect userAgent header in TF Beta Provider](https://launchdarkly.atlassian.net/browse/REL-12001)
<!-- end-ld-jira-link -->