### PR TITLE
chore: add label-gated CI for fork PRs

### DIFF
--- a/.github/workflows/remove-safe-to-test-label.yml
+++ b/.github/workflows/remove-safe-to-test-label.yml
@@ -1,0 +1,24 @@
+# Removes the "safe-to-test" label when new commits are pushed to a fork PR.
+# This forces maintainers to re-review the changes before re-labeling, preventing
+# a bait-and-switch attack where clean code is reviewed but malicious code is pushed after.
+name: "Remove safe-to-test label"
+
+on:
+  pull_request_target:
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  remove-label:
+    if: >-
+      github.event.pull_request.head.repo.full_name != github.repository
+      && contains(github.event.pull_request.labels.*.name, 'safe-to-test')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove safe-to-test label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" --remove-label "safe-to-test"

--- a/.github/workflows/test-fork-pr.yml
+++ b/.github/workflows/test-fork-pr.yml
@@ -1,41 +1,25 @@
-# Terraform Provider testing workflow.
-name: Test
+# Runs generate and acceptance tests on fork PRs after a maintainer adds the "safe-to-test" label.
+# This uses pull_request_target so OIDC tokens are available (fork PRs cannot get OIDC tokens
+# via the regular pull_request trigger). The label gate ensures untrusted code is reviewed
+# before it runs with access to secrets.
+#
+# Security: Only the "labeled" event triggers this workflow. New pushes to the fork do NOT
+# re-trigger tests — see remove-safe-to-test-label.yml which strips the label on new commits,
+# forcing a maintainer to re-review and re-label.
+name: "Test (Fork PRs)"
 
 on:
-  pull_request: # Fork PRs will only run the build job here. See test-fork-pr.yml for the label-gated workflow that runs generate + tests on forks.
-  push:
-    branches: [main]
-  schedule: # runs tests once a day on the main branch
-    - cron: "0 0 * * *"
+  pull_request_target:
+    types: [labeled]
 
-# Testing only needs permissions to read the repository contents.
 permissions:
   contents: read
 
 jobs:
-  # Ensure project builds before running testing matrix
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha}}
-      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
-        with:
-          go-version-file: "go.mod"
-          cache: true
-      - run: go mod download
-      - run: go build -v .
-      - name: Run linters
-        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
-        with:
-          version: v1.64.8
-          install-mode: goinstall
-  
   generate:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event.label.name == 'safe-to-test'
+      && github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -44,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
         with:
           audience: https://github.com/launchdarkly
@@ -60,7 +44,6 @@ jobs:
         with:
           go-version-file: "go.mod"
           cache: true
-      # We need the latest version of Terraform for our documentation generation to use
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_wrapper: false
@@ -70,9 +53,10 @@ jobs:
           git diff --compact-summary --exit-code || \
             (echo; echo "Unexpected difference in directories after code generation. Run 'make generate' command and commit."; exit 1)
 
-  # Run acceptance tests in a matrix with Terraform CLI versions
   test:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event.label.name == 'safe-to-test'
+      && github.event.pull_request.head.repo.full_name != github.repository
     name: Acceptance Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -115,7 +99,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
         with:
           audience: https://github.com/launchdarkly
@@ -142,9 +126,8 @@ jobs:
           TESTARGS="-run ${{ matrix.test_case }}" make testacc-with-retry
 
   check-success:
-    name: Check Success
+    name: "Check Success (Fork)"
     needs:
-      - build
       - generate
       - test
     if: always()
@@ -156,20 +139,3 @@ jobs:
             printf "Tests failed or workflow cancelled:\n\n${{ toJSON(needs) }}"
             exit 1
           fi
-
-  notify-slack-on-failure:
-    name: Notify Slack on Failures
-    if: failure() && github.ref == 'refs/heads/main'
-    needs:
-      - build
-      - generate
-      - test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Send GitHub trigger payload to Slack Workflow Builder
-        id: slack
-        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
-        with:
-          payload-delimiter: "_"
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: webhook-trigger


### PR DESCRIPTION
## Summary

Adds a safe mechanism for running acceptance tests on external/fork PRs using `pull_request_target` with a `safe-to-test` label gate.

- **`test.yml`**: Skip `generate` and `test` jobs for fork PRs (OIDC tokens are unavailable). Build/lint still runs for fast feedback.
- **`test-fork-pr.yml`** (new): Triggered by `pull_request_target` on the `labeled` event only. Runs generate + full acceptance test matrix when a maintainer adds the `safe-to-test` label.
- **`remove-safe-to-test-label.yml`** (new): Strips the label when new commits are pushed to a fork PR, forcing re-review before re-labeling.

## How it works

1. External contributor opens a fork PR → `build` job runs (no secrets needed), `generate`/`test` are skipped
2. Maintainer reviews the code, then adds the `safe-to-test` label
3. `test-fork-pr.yml` fires, running the full generate + acceptance test suite via `pull_request_target` (OIDC works in the base repo context)
4. If the contributor pushes new commits, `remove-safe-to-test-label.yml` strips the label automatically
5. Maintainer must re-review and re-label to run tests again

## Security

- Only the `labeled` event triggers test execution — not `synchronize` or `opened` — so opening a PR or pushing commits never automatically grants secret access.
- Label removal on new pushes prevents bait-and-switch attacks (pushing malicious code after review).
- External contributors cannot add labels (requires triage/write/admin permissions).

## Why the "Approve and run" button doesn't help

GitHub's **"Approve and run"** button (visible in the Actions tab for fork PRs) only controls whether the workflow *starts* — it does not elevate permissions. Once approved, the workflow still runs with fork PR restrictions: `GITHUB_TOKEN` is read-only and **OIDC tokens (`id-token: write`) are not issued**. This is a hard GitHub platform boundary. So clicking the button lets the workflow execute but it still fails immediately at `configure-aws-credentials` because no OIDC token is available to assume the AWS IAM role. This button has never been sufficient to make acceptance tests pass for fork PRs on this repo.

## Context / History

This repo has been through several iterations on fork PR testing:

1. **May 2025** ([#315](https://github.com/launchdarkly/terraform-provider-launchdarkly/pull/315), [#316](https://github.com/launchdarkly/terraform-provider-launchdarkly/pull/316)): `pull_request_target` was added to allow fork PRs to get OIDC tokens. The comment claimed "we have a check in place to ensure an LD user explicitly allows the tests to run for forks" — but no such gate was implemented. The workflow ran unconditionally for all fork PRs.

2. **September 2025** ([#350](https://github.com/launchdarkly/terraform-provider-launchdarkly/pull/350), SEC-7345): Security reverted `pull_request_target` → `pull_request` after a HackerOne report identified the RCE vulnerability. This closed the security hole but broke fork PR testing entirely.

3. **Now**: This PR re-introduces `pull_request_target` with the label gate that was always supposed to exist.

Triggered by [PR #410](https://github.com/launchdarkly/terraform-provider-launchdarkly/pull/410) from an external contributor, where all acceptance tests fail because fork PRs cannot get OIDC tokens.

## Test plan

- [ ] Merge this PR and verify that the `Build` job still passes on PR #410
- [ ] Add `safe-to-test` label to PR #410 and confirm tests run via the new `Test (Fork PRs)` workflow
- [ ] Push a commit to a fork PR with the label and verify the label is removed automatically