### PR TITLE
fix: prevent nil-pointer panics in optional schema attributes and harden embedded-schema (Upjet) compatibility (#387)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	github.com/zclconf/go-cty v1.14.4
+	github.com/zclconf/go-cty v1.14.4 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa // indirect
 	golang.org/x/mod v0.29.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	github.com/zclconf/go-cty v1.14.4 // indirect
+	github.com/zclconf/go-cty v1.14.4
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa // indirect
 	golang.org/x/mod v0.29.0 // indirect

--- a/launchdarkly/ai_config_variation_helper.go
+++ b/launchdarkly/ai_config_variation_helper.go
@@ -252,7 +252,7 @@ func aiConfigVariationRead(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func messagesFromResourceData(d *schema.ResourceData) ([]ldapi.Message, error) {
-	raw := d.Get(MESSAGES).([]interface{})
+	raw := getOptionalInterfaceSlice(d, MESSAGES)
 	messages := make([]ldapi.Message, len(raw))
 	for i, v := range raw {
 		m, ok := v.(map[string]interface{})

--- a/launchdarkly/cty_helpers.go
+++ b/launchdarkly/cty_helpers.go
@@ -1,0 +1,51 @@
+package launchdarkly
+
+import (
+	"github.com/hashicorp/go-cty/cty"
+)
+
+func ctyObjectGetAttr(config cty.Value, attr string) cty.Value {
+	if config.IsNull() || !config.IsKnown() {
+		return cty.NullVal(cty.DynamicPseudoType)
+	}
+	ty := config.Type()
+	if !ty.IsObjectType() || !ty.HasAttribute(attr) {
+		return cty.NullVal(cty.DynamicPseudoType)
+	}
+	return config.GetAttr(attr)
+}
+
+func ctyValueListElements(v cty.Value) []cty.Value {
+	if v.IsNull() || !v.IsKnown() {
+		return nil
+	}
+	return v.AsValueSlice()
+}
+
+func ctyBoolTrue(v cty.Value) bool {
+	if v.IsNull() || !v.IsKnown() || v.Type() != cty.Bool {
+		return false
+	}
+	return v.True()
+}
+
+// rawConfigHasAnyAttr reports whether the raw cty config object's *type* on a *schema.ResourceData
+// (or *schema.ResourceDiff) declares at least one of the given top-level attributes. Used to
+// detect when an embedded provider (Upjet) has stripped deprecated attributes from the runtime
+// schema so callers can avoid emitting fallback patches that would overwrite server-side state.
+//
+// The check is intentionally on the value's type, not its null-ness: helper/schema returns a
+// null value of the schema's implied object type when no live config is available, but the type
+// still carries the schema's attributes.
+func rawConfigHasAnyAttr(config cty.Value, attrs ...string) bool {
+	ty := config.Type()
+	if ty == cty.NilType || !ty.IsObjectType() {
+		return false
+	}
+	for _, a := range attrs {
+		if ty.HasAttribute(a) {
+			return true
+		}
+	}
+	return false
+}

--- a/launchdarkly/cty_helpers_test.go
+++ b/launchdarkly/cty_helpers_test.go
@@ -1,0 +1,65 @@
+package launchdarkly
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCtyObjectGetAttr_missingAttributeReturnsNull(t *testing.T) {
+	t.Parallel()
+
+	config := cty.EmptyObjectVal
+	v := ctyObjectGetAttr(config, INCLUDE_IN_SNIPPET)
+	require.True(t, v.IsNull())
+
+	v2 := ctyObjectGetAttr(config, DEFAULT_CLIENT_SIDE_AVAILABILITY)
+	require.True(t, v2.IsNull())
+}
+
+func TestCtyObjectGetAttr_presentAttribute(t *testing.T) {
+	t.Parallel()
+
+	config := cty.ObjectVal(map[string]cty.Value{
+		INCLUDE_IN_SNIPPET: cty.BoolVal(true),
+	})
+	v := ctyObjectGetAttr(config, INCLUDE_IN_SNIPPET)
+	require.False(t, v.IsNull())
+	require.True(t, v.True())
+}
+
+func TestCtyValueListElements_nullOrEmpty(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, ctyValueListElements(cty.NullVal(cty.List(cty.String))))
+	l := cty.ListVal([]cty.Value{cty.StringVal("a")})
+	require.Len(t, ctyValueListElements(l), 1)
+}
+
+func TestCtyBoolTrue(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, ctyBoolTrue(cty.NullVal(cty.Bool)))
+	require.False(t, ctyBoolTrue(cty.StringVal("x")))
+	require.True(t, ctyBoolTrue(cty.True))
+	require.False(t, ctyBoolTrue(cty.False))
+}
+
+func TestRawConfigHasAnyAttr(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, rawConfigHasAnyAttr(cty.NullVal(cty.DynamicPseudoType), "x"))
+	require.False(t, rawConfigHasAnyAttr(cty.EmptyObjectVal, "x"))
+	require.False(t, rawConfigHasAnyAttr(cty.StringVal("nope"), "x"))
+
+	objA := cty.ObjectVal(map[string]cty.Value{"a": cty.BoolVal(true)})
+	require.True(t, rawConfigHasAnyAttr(objA, "a"))
+	require.False(t, rawConfigHasAnyAttr(objA, "b"))
+	require.True(t, rawConfigHasAnyAttr(objA, "missing", "a"))
+
+	// Null value of an object type still carries the type's attribute set.
+	nullTyped := cty.NullVal(cty.Object(map[string]cty.Type{"a": cty.Bool}))
+	require.True(t, rawConfigHasAnyAttr(nullTyped, "a"))
+	require.False(t, rawConfigHasAnyAttr(nullTyped, "b"))
+}

--- a/launchdarkly/custom_properties_helper.go
+++ b/launchdarkly/custom_properties_helper.go
@@ -54,7 +54,10 @@ func customPropertiesSchema(isDataSource bool) *schema.Schema {
 
 func customPropertiesFromResourceData(d *schema.ResourceData) map[string]ldapi.CustomProperty {
 	customPropertiesRaw := d.Get(CUSTOM_PROPERTIES)
-	schemaCustomProperties := customPropertiesRaw.(*schema.Set)
+	schemaCustomProperties := optionalSchemaSetFromInterface(customPropertiesRaw)
+	if schemaCustomProperties == nil {
+		return map[string]ldapi.CustomProperty{}
+	}
 	customProperties := make(map[string]ldapi.CustomProperty)
 	for _, cpRaw := range schemaCustomProperties.List() {
 		key, cp := customPropertyFromResourceData(cpRaw)

--- a/launchdarkly/data_source_launchdarkly_team_members.go
+++ b/launchdarkly/data_source_launchdarkly_team_members.go
@@ -50,7 +50,7 @@ func dataSourceTeamMembersRead(ctx context.Context, d *schema.ResourceData, meta
 	client := meta.(*Client)
 	var members []ldapi.Member
 	expectedCount := 0
-	ignoreMissing := d.Get(IGNORE_MISSING).(bool)
+	ignoreMissing := optionalBoolFromResourceData(d, IGNORE_MISSING, false)
 
 	// Get our members
 	// There are tradeoffs to be had here

--- a/launchdarkly/default_variations_helper.go
+++ b/launchdarkly/default_variations_helper.go
@@ -8,7 +8,7 @@ import (
 )
 
 func defaultVariationsFromResourceData(d *schema.ResourceData) (*ldapi.Defaults, error) {
-	schemaVariations := d.Get(VARIATIONS).([]interface{})
+	schemaVariations := getOptionalInterfaceSlice(d, VARIATIONS)
 	numberOfVariations := len(schemaVariations)
 	variationType := d.Get(VARIATION_TYPE).(string)
 	rawDefaults, ok := d.GetOk(DEFAULTS)

--- a/launchdarkly/embedded_schema_compat_test.go
+++ b/launchdarkly/embedded_schema_compat_test.go
@@ -1,0 +1,172 @@
+package launchdarkly
+
+// Tests for embedded/Upjet-stripped schema compatibility: project CSA fallback guard,
+// nil-safety of optional blocks on custom_role and access_token, and ID-derived fallbacks for
+// env_key / custom-role key. None of these require TF_ACC, an LD access token, or the live API
+// client; they exercise pure helper functions and the extracted patch builders.
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	ldapi "github.com/launchdarkly/api-client-go/v22"
+	"github.com/stretchr/testify/require"
+)
+
+// embeddedProjectSchema simulates an Upjet-stripped schema where the deprecated IIS attribute and
+// the entire DEFAULT_CLIENT_SIDE_AVAILABILITY block are absent from the runtime schema.
+func embeddedProjectSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		KEY:  {Type: schema.TypeString, Required: true, ForceNew: true},
+		NAME: {Type: schema.TypeString, Required: true},
+		TAGS: {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+			Set:      schema.HashString,
+		},
+		REQUIRE_VIEW_ASSOCIATION_FOR_NEW_FLAGS:    {Type: schema.TypeBool, Optional: true, Default: false},
+		REQUIRE_VIEW_ASSOCIATION_FOR_NEW_SEGMENTS: {Type: schema.TypeBool, Optional: true, Default: false},
+	}
+}
+
+// containsCSAOp returns whether the given patch ops include any replace targeting
+// /defaultClientSideAvailability.
+func containsCSAOp(ops []ldapi.PatchOperation) bool {
+	for _, op := range ops {
+		if op.Path == "/defaultClientSideAvailability" {
+			return true
+		}
+	}
+	return false
+}
+
+// When the embedded schema strips IIS and CSA, a tags-only update must NOT emit a fallback
+// /defaultClientSideAvailability patch. This is the regression covered by PR review item 1.
+func TestBuildProjectUpdatePatches_embeddedSchemaOmitsCSAFallback(t *testing.T) {
+	t.Parallel()
+
+	d := schema.TestResourceDataRaw(t, embeddedProjectSchema(), map[string]interface{}{
+		KEY:  "crossplane-project",
+		NAME: "Crossplane Project",
+		TAGS: []interface{}{"managed-by-crossplane"},
+	})
+
+	ops := buildProjectUpdatePatches(d)
+	require.NotEmpty(t, ops)
+	require.False(t, containsCSAOp(ops),
+		"expected no /defaultClientSideAvailability op when embedded schema omits IIS and CSA; got %+v", ops)
+
+	var paths []string
+	for _, op := range ops {
+		paths = append(paths, op.Path)
+	}
+	require.Contains(t, paths, "/name")
+	require.Contains(t, paths, "/tags")
+}
+
+// When the full schema is in use but neither IIS nor CSA is set in config, the provider keeps its
+// historical behavior of forcing /defaultClientSideAvailability to API defaults so downstream
+// reads don't drift. This guards against the regression guard from item 1 going too far.
+func TestBuildProjectUpdatePatches_fullSchemaKeepsCSAFallback(t *testing.T) {
+	t.Parallel()
+
+	d := schema.TestResourceDataRaw(t, resourceProject().Schema, map[string]interface{}{
+		KEY:  "p",
+		NAME: "Project",
+		ENVIRONMENTS: []interface{}{
+			map[string]interface{}{
+				KEY:   "production",
+				NAME:  "Production",
+				COLOR: "417505",
+			},
+		},
+	})
+
+	ops := buildProjectUpdatePatches(d)
+	require.True(t, containsCSAOp(ops),
+		"full schema with no IIS/CSA in config should still emit fallback CSA op; got %+v", ops)
+}
+
+// resourceCustomRole.Schema with no policy/policy_statements blocks must not panic when the
+// nil-safe helpers iterate over their empty values.
+func TestPolicyStatementsFromResourceData_emptyDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	d := schema.TestResourceDataRaw(t, resourceCustomRole().Schema, map[string]interface{}{
+		KEY:              "role",
+		NAME:             "Role",
+		BASE_PERMISSIONS: "reader",
+	})
+
+	require.NotPanics(t, func() {
+		_, _ = policyStatementsFromResourceData(getOptionalInterfaceSlice(d, POLICY_STATEMENTS))
+		_ = policiesFromResourceData(d)
+	})
+}
+
+// Access token has multiple optional set/list blocks (custom_roles, policy_statements,
+// inline_roles). With none configured, validation must succeed without panicking.
+func TestAccessTokenValidate_emptyOptionalBlocksNoPanic(t *testing.T) {
+	t.Parallel()
+
+	d := schema.TestResourceDataRaw(t, resourceAccessToken().Schema, map[string]interface{}{
+		NAME: "tok",
+		ROLE: "reader",
+	})
+
+	require.NotPanics(t, func() {
+		_ = validateAccessTokenResource(d)
+	})
+}
+
+// effectiveEnvKey error path: id is empty AND env_key attribute is empty.
+func TestEffectiveEnvKey_errorWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		ENV_KEY: {Type: schema.TypeString, Optional: true},
+	}, map[string]interface{}{})
+
+	_, err := effectiveEnvKey(d)
+	require.Error(t, err)
+}
+
+// effectiveEnvKey error path: id is malformed (wrong number of slashes).
+func TestEffectiveEnvKey_errorWhenIDMalformed(t *testing.T) {
+	t.Parallel()
+
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		ENV_KEY: {Type: schema.TypeString, Optional: true},
+	}, map[string]interface{}{})
+	d.SetId("not-a-triple")
+
+	_, err := effectiveEnvKey(d)
+	require.Error(t, err)
+}
+
+// Happy path: id parses cleanly into project/env/key, env_key attribute is empty.
+func TestEffectiveEnvKey_recoversFromID(t *testing.T) {
+	t.Parallel()
+
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		ENV_KEY: {Type: schema.TypeString, Optional: true},
+	}, map[string]interface{}{})
+	d.SetId("crossplane-project/name-dev/my-flag")
+
+	got, err := effectiveEnvKey(d)
+	require.NoError(t, err)
+	require.Equal(t, "name-dev", got)
+}
+
+// effectiveCustomRoleKeyOrError error path: nothing to fall back to.
+func TestEffectiveCustomRoleKeyOrError_errorWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		KEY: {Type: schema.TypeString, Optional: true},
+	}, map[string]interface{}{})
+
+	_, err := effectiveCustomRoleKeyOrError(d)
+	require.Error(t, err)
+}

--- a/launchdarkly/embedded_schema_compat_test.go
+++ b/launchdarkly/embedded_schema_compat_test.go
@@ -6,9 +6,12 @@ package launchdarkly
 // client; they exercise pure helper functions and the extracted patch builders.
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	ldapi "github.com/launchdarkly/api-client-go/v22"
 	"github.com/stretchr/testify/require"
 )
@@ -157,6 +160,77 @@ func TestEffectiveEnvKey_recoversFromID(t *testing.T) {
 	got, err := effectiveEnvKey(d)
 	require.NoError(t, err)
 	require.Equal(t, "name-dev", got)
+}
+
+// customizeProjectDiff must early-return without writing IIS or CSA into the planned diff when the
+// runtime schema is embedded (Upjet) and lacks both attributes. Without the guard at project.go:21-25,
+// the function would unconditionally call SetNew on those keys; even though the missing-key shim
+// swallows the resulting SDK error, taking that path is wasted work and obscures real schema bugs.
+// This test exercises Resource.Diff end-to-end so the early-return is hit through the real SDK path,
+// not just by calling customizeProjectDiff in isolation.
+func TestCustomizeProjectDiff_embeddedSchemaEarlyReturn(t *testing.T) {
+	t.Parallel()
+
+	r := &schema.Resource{
+		Schema:        embeddedProjectSchema(),
+		CustomizeDiff: customizeProjectDiff,
+	}
+
+	cfg := terraform.NewResourceConfigRaw(map[string]interface{}{
+		KEY:  "crossplane-project",
+		NAME: "Crossplane Project",
+		TAGS: []interface{}{"managed-by-crossplane"},
+	})
+
+	require.NotPanics(t, func() {
+		instanceDiff, err := r.Diff(context.Background(), &terraform.InstanceState{}, cfg, nil)
+		require.NoError(t, err, "embedded-schema Diff must not surface a SetNew error")
+		require.NotNil(t, instanceDiff)
+
+		for k := range instanceDiff.Attributes {
+			require.False(t, strings.HasPrefix(k, INCLUDE_IN_SNIPPET),
+				"embedded schema must not produce %q diff entries; got %q", INCLUDE_IN_SNIPPET, k)
+			require.False(t, strings.HasPrefix(k, DEFAULT_CLIENT_SIDE_AVAILABILITY),
+				"embedded schema must not produce %q diff entries; got %q", DEFAULT_CLIENT_SIDE_AVAILABILITY, k)
+		}
+	})
+}
+
+// Counterpart for the full schema: when neither IIS nor CSA appears in config, customizeProjectDiff
+// forces an UPDATE by SetNew-ing both, so the resulting plan should include CSA attribute changes.
+// Guards against the embedded-schema guard (TestCustomizeProjectDiff_embeddedSchemaEarlyReturn)
+// going too far and disabling the fallback under the full Terraform CLI schema.
+func TestCustomizeProjectDiff_fullSchemaForcesCSAUpdate(t *testing.T) {
+	t.Parallel()
+
+	r := resourceProject()
+
+	cfg := terraform.NewResourceConfigRaw(map[string]interface{}{
+		KEY:  "p",
+		NAME: "Project",
+		ENVIRONMENTS: []interface{}{
+			map[string]interface{}{
+				KEY:   "production",
+				NAME:  "Production",
+				COLOR: "417505",
+			},
+		},
+	})
+
+	instanceDiff, err := r.Diff(context.Background(), &terraform.InstanceState{}, cfg, nil)
+	require.NoError(t, err)
+	require.NotNil(t, instanceDiff)
+
+	var sawCSA bool
+	for k := range instanceDiff.Attributes {
+		if strings.HasPrefix(k, DEFAULT_CLIENT_SIDE_AVAILABILITY) {
+			sawCSA = true
+			break
+		}
+	}
+	require.True(t, sawCSA,
+		"full-schema customizeProjectDiff must SetNew on %q to force an UPDATE; got attrs %v",
+		DEFAULT_CLIENT_SIDE_AVAILABILITY, instanceDiff.Attributes)
 }
 
 // effectiveCustomRoleKeyOrError error path: nothing to fall back to.

--- a/launchdarkly/environments_helper.go
+++ b/launchdarkly/environments_helper.go
@@ -144,7 +144,7 @@ func getEnvironmentUpdatePatches(oldConfig, config map[string]interface{}) ([]ld
 
 	tags, ok := config[TAGS]
 	if ok {
-		envTags := stringsFromSchemaSet(tags.(*schema.Set))
+		envTags := stringsFromSchemaSet(optionalSchemaSetFromInterface(tags))
 		patches = append(patches, patchReplace("/tags", &envTags))
 	}
 
@@ -195,7 +195,7 @@ func dataSourceEnvironmentSchema(forProject bool) map[string]*schema.Schema {
 }
 
 func environmentPostsFromResourceData(d *schema.ResourceData) []ldapi.EnvironmentPost {
-	schemaEnvList := d.Get(ENVIRONMENTS).([]interface{})
+	schemaEnvList := getOptionalInterfaceSlice(d, ENVIRONMENTS)
 	envs := make([]ldapi.EnvironmentPost, len(schemaEnvList))
 	for i, env := range schemaEnvList {
 		envs[i] = environmentPostFromResourceData(env)

--- a/launchdarkly/fallthrough_helper.go
+++ b/launchdarkly/fallthrough_helper.go
@@ -58,8 +58,11 @@ type fallthroughModel struct {
 }
 
 func validateFallThroughResourceData(f []interface{}) error {
-	for _, f := range f {
-		if f == nil {
+	if f == nil || len(f) == 0 {
+		return errors.New("feature flag fallthrough block cannot be empty. Please specify at least one of variation or rollout_weights")
+	}
+	for _, block := range f {
+		if block == nil {
 			return errors.New("feature flag fallthrough block cannot be empty. Please specify at least one of variation or rollout_weights")
 		}
 	}
@@ -85,7 +88,7 @@ func isPercentRollout(fall []interface{}) bool {
 }
 
 func fallthroughFromResourceData(d *schema.ResourceData) (fallthroughModel, error) {
-	f := d.Get(FALLTHROUGH).([]interface{})
+	f := getOptionalInterfaceSlice(d, FALLTHROUGH)
 	err := validateFallThroughResourceData(f)
 	if err != nil {
 		return fallthroughModel{}, err

--- a/launchdarkly/fallthrough_helper.go
+++ b/launchdarkly/fallthrough_helper.go
@@ -58,7 +58,7 @@ type fallthroughModel struct {
 }
 
 func validateFallThroughResourceData(f []interface{}) error {
-	if f == nil || len(f) == 0 {
+	if len(f) == 0 {
 		return errors.New("feature flag fallthrough block cannot be empty. Please specify at least one of variation or rollout_weights")
 	}
 	for _, block := range f {

--- a/launchdarkly/feature_flag_environment_helper.go
+++ b/launchdarkly/feature_flag_environment_helper.go
@@ -86,7 +86,12 @@ func featureFlagEnvironmentRead(ctx context.Context, d *schema.ResourceData, raw
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	envKey := d.Get(ENV_KEY).(string)
+	envKey := effectiveEnvKeyFromIDOrAttr(d)
+	if envKey == "" {
+		return diag.Errorf(
+			"%s is required. Set it to the LaunchDarkly environment **key** for this project, or use resource id form project_key/env_key/flag_key (embedded schemas may omit %s).",
+			ENV_KEY, ENV_KEY)
+	}
 
 	envExists, err := environmentExists(projectKey, envKey, client)
 
@@ -183,9 +188,8 @@ func featureFlagEnvironmentRead(ctx context.Context, d *schema.ResourceData, raw
 }
 
 func patchFlagEnvPath(d *schema.ResourceData, op string) string {
-	path := []string{"/environments"}
-	path = append(path, d.Get(ENV_KEY).(string))
-	path = append(path, op)
+	envKey := effectiveEnvKeyFromIDOrAttr(d)
+	path := []string{"/environments", envKey, op}
 
 	return strings.Join(path, "/")
 }

--- a/launchdarkly/feature_flags_helper.go
+++ b/launchdarkly/feature_flags_helper.go
@@ -202,7 +202,7 @@ func featureFlagRead(ctx context.Context, d *schema.ResourceData, raw interface{
 	}}
 	// Always set both CSA and IIS to state in order to correctly represent the flag resource as it exists in LD
 	_ = d.Set(CLIENT_SIDE_AVAILABILITY, clientSideAvailability)
-	_ = d.Set(INCLUDE_IN_SNIPPET, CSA.UsingEnvironmentId)
+	_ = resourceDataSetSkipMissingKey(d, INCLUDE_IN_SNIPPET, CSA.UsingEnvironmentId)
 
 	// Only set the maintainer if is specified in the schema
 	_, maintainerIdOk := d.GetOk(MAINTAINER_ID)

--- a/launchdarkly/flag_templates_helper.go
+++ b/launchdarkly/flag_templates_helper.go
@@ -170,7 +170,7 @@ func getCurrentCSA(client *Client, projectKey string) (*ldapi.DefaultClientSideA
 
 func flagTemplatesPayloadFromResourceData(d *schema.ResourceData, csa ldapi.DefaultClientSideAvailability) ldapi.UpsertFlagDefaultsPayload {
 	tags := stringsFromResourceData(d, TAGS)
-	temporary := d.Get(TEMPORARY).(bool)
+	temporary := optionalBoolFromResourceData(d, TEMPORARY, false)
 
 	trueDisplayName := d.Get(fmt.Sprintf("%s.0.%s", BOOLEAN_DEFAULTS, TRUE_DISPLAY_NAME)).(string)
 	falseDisplayName := d.Get(fmt.Sprintf("%s.0.%s", BOOLEAN_DEFAULTS, FALSE_DISPLAY_NAME)).(string)

--- a/launchdarkly/flag_trigger_helper.go
+++ b/launchdarkly/flag_trigger_helper.go
@@ -132,7 +132,7 @@ func flagTriggerRead(ctx context.Context, d *schema.ResourceData, metaRaw interf
 }
 
 func instructionsFromResourceData(d *schema.ResourceData, method string) []map[string]interface{} {
-	rawInstructions := d.Get(INSTRUCTIONS).([]interface{})
+	rawInstructions := getOptionalInterfaceSlice(d, INSTRUCTIONS)
 	var instructions []map[string]interface{}
 	switch method {
 	case "POST":

--- a/launchdarkly/metrics_helper.go
+++ b/launchdarkly/metrics_helper.go
@@ -243,7 +243,7 @@ func metricUrlSchema() map[string]*schema.Schema {
 }
 
 func metricUrlsFromResourceData(d *schema.ResourceData) []ldapi.UrlPost {
-	schemaUrlList := d.Get(URLS).([]interface{})
+	schemaUrlList := getOptionalInterfaceSlice(d, URLS)
 	urls := make([]ldapi.UrlPost, len(schemaUrlList))
 	for i, url := range schemaUrlList {
 		urls[i] = metricUrlPostFromResourceData(url)

--- a/launchdarkly/policies_helper.go
+++ b/launchdarkly/policies_helper.go
@@ -41,8 +41,10 @@ func policyArraySchema() *schema.Schema {
 }
 
 func policiesFromResourceData(d *schema.ResourceData) []ldapi.StatementPost {
-	schemaPolicies := d.Get(POLICY).(*schema.Set)
-
+	schemaPolicies := getOptionalSet(d, POLICY)
+	if schemaPolicies == nil {
+		return []ldapi.StatementPost{}
+	}
 	policies := make([]ldapi.StatementPost, schemaPolicies.Len())
 	list := schemaPolicies.List()
 	for i, policy := range list {

--- a/launchdarkly/prerequisite_helper.go
+++ b/launchdarkly/prerequisite_helper.go
@@ -35,7 +35,7 @@ func prerequisitesSchema(isDataSource bool) *schema.Schema {
 }
 
 func prerequisitesFromResourceData(d *schema.ResourceData, metaRaw interface{}) []ldapi.Prerequisite {
-	schemaPrerequisites := d.Get(PREREQUISITES).([]interface{})
+	schemaPrerequisites := getOptionalInterfaceSlice(d, PREREQUISITES)
 	prerequisites := make([]ldapi.Prerequisite, len(schemaPrerequisites))
 	for i, prerequisite := range schemaPrerequisites {
 		v := prerequisiteFromResourceData(prerequisite)

--- a/launchdarkly/project_helper.go
+++ b/launchdarkly/project_helper.go
@@ -80,7 +80,7 @@ func projectRead(ctx context.Context, d *schema.ResourceData, meta interface{}, 
 
 		// iterate over the environment keys in the order defined by the config and look up the environment returned by
 		// LD's API
-		rawEnvs := d.Get(ENVIRONMENTS).([]interface{})
+		rawEnvs := getOptionalInterfaceSlice(d, ENVIRONMENTS)
 
 		envConfigKeys := rawEnvironmentConfigsToKeyList(rawEnvs)
 		envAddedMap := make(map[string]bool, len(project.Environments.Items))
@@ -106,7 +106,7 @@ func projectRead(ctx context.Context, d *schema.ResourceData, meta interface{}, 
 			return diag.Errorf("could not set environments on project with key %q: %v", project.Key, err)
 		}
 
-		err = d.Set(INCLUDE_IN_SNIPPET, project.IncludeInSnippetByDefault)
+		err = resourceDataSetSkipMissingKey(d, INCLUDE_IN_SNIPPET, project.IncludeInSnippetByDefault)
 		if err != nil {
 			return diag.Errorf("could not set include_in_snippet on project with key %q: %v", project.Key, err)
 		}
@@ -117,7 +117,7 @@ func projectRead(ctx context.Context, d *schema.ResourceData, meta interface{}, 
 		return diag.Errorf("could not set tags on project with key %q: %v", project.Key, err)
 	}
 
-	err = d.Set(DEFAULT_CLIENT_SIDE_AVAILABILITY, clientSideAvailability)
+	err = resourceDataSetSkipMissingKey(d, DEFAULT_CLIENT_SIDE_AVAILABILITY, clientSideAvailability)
 	if err != nil {
 		return diag.Errorf("could not set default_client_side_availability on project with key %q: %v", project.Key, err)
 	}

--- a/launchdarkly/provider.go
+++ b/launchdarkly/provider.go
@@ -124,7 +124,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	if host == "" {
 		host = DEFAULT_LAUNCHDARKLY_HOST
 	}
-	configHost := trimmedStringAttr(d, API_HOST)
+	configHost := optionalStringAttr(d, API_HOST)
 	if configHost != "" {
 		host = configHost
 	}
@@ -136,11 +136,11 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 
 	// Check configuration data, which should take precedence over
 	// environment variable data, if found.
-	configAccessToken := trimmedStringAttr(d, ACCESS_TOKEN)
+	configAccessToken := optionalStringAttr(d, ACCESS_TOKEN)
 	if configAccessToken != "" {
 		accessToken = configAccessToken
 	}
-	configOAuthToken := trimmedStringAttr(d, OAUTH_TOKEN)
+	configOAuthToken := optionalStringAttr(d, OAUTH_TOKEN)
 	if configOAuthToken != "" {
 		oauthToken = configOAuthToken
 	}

--- a/launchdarkly/provider.go
+++ b/launchdarkly/provider.go
@@ -124,7 +124,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	if host == "" {
 		host = DEFAULT_LAUNCHDARKLY_HOST
 	}
-	configHost := d.Get(API_HOST).(string)
+	configHost := trimmedStringAttr(d, API_HOST)
 	if configHost != "" {
 		host = configHost
 	}
@@ -136,11 +136,11 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 
 	// Check configuration data, which should take precedence over
 	// environment variable data, if found.
-	configAccessToken := d.Get(ACCESS_TOKEN).(string)
+	configAccessToken := trimmedStringAttr(d, ACCESS_TOKEN)
 	if configAccessToken != "" {
 		accessToken = configAccessToken
 	}
-	configOAuthToken := d.Get(OAUTH_TOKEN).(string)
+	configOAuthToken := trimmedStringAttr(d, OAUTH_TOKEN)
 	if configOAuthToken != "" {
 		oauthToken = configOAuthToken
 	}
@@ -148,7 +148,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		return nil, diag.Errorf("either an %q or %q must be specified", ACCESS_TOKEN, OAUTH_TOKEN)
 	}
 
-	httpTimeoutSeconds := d.Get(HTTP_TIMEOUT).(int)
+	httpTimeoutSeconds := optionalIntFromResourceData(d, HTTP_TIMEOUT, 0)
 	if httpTimeoutSeconds == 0 {
 		httpTimeoutSeconds = DEFAULT_HTTP_TIMEOUT_S
 	}

--- a/launchdarkly/resource_data_helpers.go
+++ b/launchdarkly/resource_data_helpers.go
@@ -8,16 +8,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// emptyInterfaceSlice is returned in place of nil for list-shaped helpers so callers can iterate
-// without nil checks and JSON marshalling stays deterministic.
 func emptyInterfaceSlice() []interface{} { return []interface{}{} }
 
 func getOptionalSet(d *schema.ResourceData, key string) *schema.Set {
 	return optionalSchemaSetFromInterface(d.Get(key))
 }
 
-// optionalSetList returns the contents of a TypeSet attribute as []interface{}.
-// Returns an empty (non-nil) slice when the key is missing/unset/wrong type.
 func optionalSetList(d *schema.ResourceData, key string) []interface{} {
 	s := getOptionalSet(d, key)
 	if s == nil {
@@ -26,15 +22,12 @@ func optionalSetList(d *schema.ResourceData, key string) []interface{} {
 	return s.List()
 }
 
-// getOptionalInterfaceSlice returns a TypeList attribute as []interface{}.
-// Returns an empty (non-nil) slice when the key is missing/unset/wrong type.
 func getOptionalInterfaceSlice(d *schema.ResourceData, key string) []interface{} {
 	return interfaceSliceFromAny(d.Get(key))
 }
 
-// optionalSchemaSetFromInterface returns nil when v is nil or not a *schema.Set; otherwise the set.
-// Sets retain nil semantics so callers that pass them straight back into helpers (e.g. .List()) can
-// branch on a nil set without an extra zero-length allocation.
+// optionalSchemaSetFromInterface preserves nil for absent/wrong-type values so callers can
+// distinguish "not set" from "set to empty" — list-shaped helpers normalize to empty.
 func optionalSchemaSetFromInterface(v interface{}) *schema.Set {
 	if v == nil {
 		return nil
@@ -46,9 +39,8 @@ func optionalSchemaSetFromInterface(v interface{}) *schema.Set {
 	return s
 }
 
-// interfaceSliceFromAny normalizes any-shaped list values to []interface{}.
-// Nil or wrong-type input yields an empty (non-nil) slice; the wrong-type case is logged so a
-// schema regression is observable instead of silently coerced.
+// interfaceSliceFromAny logs at WARN on type mismatch so embedded-schema regressions surface
+// instead of silently coercing to empty.
 func interfaceSliceFromAny(v interface{}) []interface{} {
 	if v == nil {
 		return emptyInterfaceSlice()
@@ -61,19 +53,16 @@ func interfaceSliceFromAny(v interface{}) []interface{} {
 	return s
 }
 
-// stringListFromOptionalSetValue converts a *schema.Set wrapped in interface{} (e.g. diff.Get / GetChange)
-// to a []string for LaunchDarkly API calls. Nil or wrong type yields nil (preserves prior behavior;
-// LD API calls treat nil and empty []string identically and a few callers depend on the nil signal).
+// stringListFromOptionalSetValue returns nil (not empty) for nil sets — LD API treats nil and
+// empty []string identically and a few callers depend on the nil signal.
 func stringListFromOptionalSetValue(v interface{}) []string {
 	s := optionalSchemaSetFromInterface(v)
 	if s == nil {
 		return nil
 	}
-	return interfaceSliceToStringSlice(s.List())
+	return stringsFromSchemaSet(s)
 }
 
-// optionalSetListFromAny returns the contents of a *schema.Set value as []interface{}.
-// Returns an empty (non-nil) slice when the input is nil or wrong type.
 func optionalSetListFromAny(v interface{}) []interface{} {
 	s := optionalSchemaSetFromInterface(v)
 	if s == nil {
@@ -82,10 +71,24 @@ func optionalSetListFromAny(v interface{}) []interface{} {
 	return s.List()
 }
 
-// optionalBoolFromResourceData returns d.Get(key) as bool when it is a non-nil bool value.
-// When the key is missing from the schema or Get returns nil (e.g. Upjet-embedded provider),
-// defaultVal is used. A wrong-type value (schema regression) is logged at WARN and treated as
-// missing so callers do not accidentally observe schema misconfiguration as a real "false".
+// optionalIntFromResourceData uses defaultVal when the schema is missing the key (Upjet-embedded
+// provider returns nil from d.Get). Wrong-type values log at WARN so regressions stay visible.
+func optionalIntFromResourceData(d *schema.ResourceData, key string, defaultVal int) int {
+	v := d.Get(key)
+	if v == nil {
+		return defaultVal
+	}
+	i, ok := v.(int)
+	if !ok {
+		log.Printf("[WARN] optionalIntFromResourceData: %q is not an int (got %T); using default %v", key, v, defaultVal)
+		return defaultVal
+	}
+	return i
+}
+
+// optionalBoolFromResourceData uses defaultVal for missing keys (Upjet-embedded provider returns
+// nil from d.Get). Wrong-type values log at WARN and fall back to defaultVal — without this guard
+// callers would observe a schema regression as a real "false".
 func optionalBoolFromResourceData(d *schema.ResourceData, key string, defaultVal bool) bool {
 	v := d.Get(key)
 	if v == nil {
@@ -99,8 +102,8 @@ func optionalBoolFromResourceData(d *schema.ResourceData, key string, defaultVal
 	return b
 }
 
-// trimmedStringAttr returns strings.TrimSpace(d.Get(key)) for string attributes.
-// Returns "" for missing keys; logs at WARN for wrong types so schema regressions are visible.
+// trimmedStringAttr returns "" for missing keys; logs at WARN on wrong type so schema regressions
+// are visible.
 func trimmedStringAttr(d *schema.ResourceData, key string) string {
 	v := d.Get(key)
 	if v == nil {
@@ -114,10 +117,9 @@ func trimmedStringAttr(d *schema.ResourceData, key string) string {
 	return strings.TrimSpace(s)
 }
 
-// effectiveEnvKey returns ENV_KEY from config when set; otherwise parses env_key from the resource
-// id "project_key/env_key/flag_key" (or "/segment_key"). Returns an explicit error when env_key is
-// neither in the attributes nor recoverable from a well-formed id; callers should propagate via
-// diag.FromErr so an unset env_key is a real failure rather than an ambient empty string.
+// effectiveEnvKey falls back to the env_key embedded in resource id "project_key/env_key/<key>"
+// when the attribute is missing — required for the Crossplane / Upjet external-name flow where
+// the schema may strip env_key from the resource view.
 func effectiveEnvKey(d *schema.ResourceData) (string, error) {
 	if k := trimmedStringAttr(d, ENV_KEY); k != "" {
 		return k, nil
@@ -137,9 +139,8 @@ func effectiveEnvKey(d *schema.ResourceData) (string, error) {
 	return envKey, nil
 }
 
-// effectiveEnvKeyFromIDOrAttr is the legacy ergonomic wrapper around effectiveEnvKey for callsites
-// (notably patch path builders) that cannot return an error. Logs at WARN when the lookup fails so
-// the underlying issue still surfaces; prefer effectiveEnvKey in new code.
+// effectiveEnvKeyFromIDOrAttr is the no-error wrapper for callsites (e.g. patch-path builders)
+// that cannot return one. Prefer effectiveEnvKey in new code.
 func effectiveEnvKeyFromIDOrAttr(d *schema.ResourceData) string {
 	k, err := effectiveEnvKey(d)
 	if err != nil {
@@ -149,9 +150,8 @@ func effectiveEnvKeyFromIDOrAttr(d *schema.ResourceData) string {
 	return k
 }
 
-// effectiveCustomRoleKeyOrError returns KEY from config when set; otherwise the Terraform resource
-// id (Crossplane external-name / observe id), which must be the LaunchDarkly custom role key.
-// Returns an error when both are empty.
+// effectiveCustomRoleKeyOrError falls back to d.Id() (Crossplane external-name) when KEY is unset
+// — under embedded schemas the LD custom role key is set via the Terraform id, not the attribute.
 func effectiveCustomRoleKeyOrError(d *schema.ResourceData) (string, error) {
 	if k := trimmedStringAttr(d, KEY); k != "" {
 		return k, nil
@@ -163,8 +163,7 @@ func effectiveCustomRoleKeyOrError(d *schema.ResourceData) (string, error) {
 	return id, nil
 }
 
-// effectiveCustomRoleKey is the legacy ergonomic wrapper around effectiveCustomRoleKeyOrError.
-// Returns "" on failure; callers in this provider check for empty and emit a diag.
+// effectiveCustomRoleKey is the no-error wrapper. Callers check for empty and emit a diag.
 func effectiveCustomRoleKey(d *schema.ResourceData) string {
 	k, err := effectiveCustomRoleKeyOrError(d)
 	if err != nil {

--- a/launchdarkly/resource_data_helpers.go
+++ b/launchdarkly/resource_data_helpers.go
@@ -1,0 +1,175 @@
+package launchdarkly
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// emptyInterfaceSlice is returned in place of nil for list-shaped helpers so callers can iterate
+// without nil checks and JSON marshalling stays deterministic.
+func emptyInterfaceSlice() []interface{} { return []interface{}{} }
+
+func getOptionalSet(d *schema.ResourceData, key string) *schema.Set {
+	return optionalSchemaSetFromInterface(d.Get(key))
+}
+
+// optionalSetList returns the contents of a TypeSet attribute as []interface{}.
+// Returns an empty (non-nil) slice when the key is missing/unset/wrong type.
+func optionalSetList(d *schema.ResourceData, key string) []interface{} {
+	s := getOptionalSet(d, key)
+	if s == nil {
+		return emptyInterfaceSlice()
+	}
+	return s.List()
+}
+
+// getOptionalInterfaceSlice returns a TypeList attribute as []interface{}.
+// Returns an empty (non-nil) slice when the key is missing/unset/wrong type.
+func getOptionalInterfaceSlice(d *schema.ResourceData, key string) []interface{} {
+	return interfaceSliceFromAny(d.Get(key))
+}
+
+// optionalSchemaSetFromInterface returns nil when v is nil or not a *schema.Set; otherwise the set.
+// Sets retain nil semantics so callers that pass them straight back into helpers (e.g. .List()) can
+// branch on a nil set without an extra zero-length allocation.
+func optionalSchemaSetFromInterface(v interface{}) *schema.Set {
+	if v == nil {
+		return nil
+	}
+	s, ok := v.(*schema.Set)
+	if !ok || s == nil {
+		return nil
+	}
+	return s
+}
+
+// interfaceSliceFromAny normalizes any-shaped list values to []interface{}.
+// Nil or wrong-type input yields an empty (non-nil) slice; the wrong-type case is logged so a
+// schema regression is observable instead of silently coerced.
+func interfaceSliceFromAny(v interface{}) []interface{} {
+	if v == nil {
+		return emptyInterfaceSlice()
+	}
+	s, ok := v.([]interface{})
+	if !ok {
+		log.Printf("[WARN] interfaceSliceFromAny: expected []interface{}, got %T", v)
+		return emptyInterfaceSlice()
+	}
+	return s
+}
+
+// stringListFromOptionalSetValue converts a *schema.Set wrapped in interface{} (e.g. diff.Get / GetChange)
+// to a []string for LaunchDarkly API calls. Nil or wrong type yields nil (preserves prior behavior;
+// LD API calls treat nil and empty []string identically and a few callers depend on the nil signal).
+func stringListFromOptionalSetValue(v interface{}) []string {
+	s := optionalSchemaSetFromInterface(v)
+	if s == nil {
+		return nil
+	}
+	return interfaceSliceToStringSlice(s.List())
+}
+
+// optionalSetListFromAny returns the contents of a *schema.Set value as []interface{}.
+// Returns an empty (non-nil) slice when the input is nil or wrong type.
+func optionalSetListFromAny(v interface{}) []interface{} {
+	s := optionalSchemaSetFromInterface(v)
+	if s == nil {
+		return emptyInterfaceSlice()
+	}
+	return s.List()
+}
+
+// optionalBoolFromResourceData returns d.Get(key) as bool when it is a non-nil bool value.
+// When the key is missing from the schema or Get returns nil (e.g. Upjet-embedded provider),
+// defaultVal is used. A wrong-type value (schema regression) is logged at WARN and treated as
+// missing so callers do not accidentally observe schema misconfiguration as a real "false".
+func optionalBoolFromResourceData(d *schema.ResourceData, key string, defaultVal bool) bool {
+	v := d.Get(key)
+	if v == nil {
+		return defaultVal
+	}
+	b, ok := v.(bool)
+	if !ok {
+		log.Printf("[WARN] optionalBoolFromResourceData: %q is not a bool (got %T); using default %v", key, v, defaultVal)
+		return defaultVal
+	}
+	return b
+}
+
+// trimmedStringAttr returns strings.TrimSpace(d.Get(key)) for string attributes.
+// Returns "" for missing keys; logs at WARN for wrong types so schema regressions are visible.
+func trimmedStringAttr(d *schema.ResourceData, key string) string {
+	v := d.Get(key)
+	if v == nil {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		log.Printf("[WARN] trimmedStringAttr: %q is not a string (got %T)", key, v)
+		return ""
+	}
+	return strings.TrimSpace(s)
+}
+
+// effectiveEnvKey returns ENV_KEY from config when set; otherwise parses env_key from the resource
+// id "project_key/env_key/flag_key" (or "/segment_key"). Returns an explicit error when env_key is
+// neither in the attributes nor recoverable from a well-formed id; callers should propagate via
+// diag.FromErr so an unset env_key is a real failure rather than an ambient empty string.
+func effectiveEnvKey(d *schema.ResourceData) (string, error) {
+	if k := trimmedStringAttr(d, ENV_KEY); k != "" {
+		return k, nil
+	}
+	id := strings.TrimSpace(d.Id())
+	if id == "" {
+		return "", fmt.Errorf("%s is required and resource id is empty", ENV_KEY)
+	}
+	if strings.Count(id, "/") != 2 {
+		return "", fmt.Errorf("%s is empty and resource id %q is not in the form project_key/env_key/<key>", ENV_KEY, id)
+	}
+	parts := strings.SplitN(id, "/", 3)
+	envKey := strings.TrimSpace(parts[1])
+	if envKey == "" {
+		return "", fmt.Errorf("%s is empty and parsed env_key from id %q is empty", ENV_KEY, id)
+	}
+	return envKey, nil
+}
+
+// effectiveEnvKeyFromIDOrAttr is the legacy ergonomic wrapper around effectiveEnvKey for callsites
+// (notably patch path builders) that cannot return an error. Logs at WARN when the lookup fails so
+// the underlying issue still surfaces; prefer effectiveEnvKey in new code.
+func effectiveEnvKeyFromIDOrAttr(d *schema.ResourceData) string {
+	k, err := effectiveEnvKey(d)
+	if err != nil {
+		log.Printf("[WARN] effectiveEnvKeyFromIDOrAttr: %s", err)
+		return ""
+	}
+	return k
+}
+
+// effectiveCustomRoleKeyOrError returns KEY from config when set; otherwise the Terraform resource
+// id (Crossplane external-name / observe id), which must be the LaunchDarkly custom role key.
+// Returns an error when both are empty.
+func effectiveCustomRoleKeyOrError(d *schema.ResourceData) (string, error) {
+	if k := trimmedStringAttr(d, KEY); k != "" {
+		return k, nil
+	}
+	id := strings.TrimSpace(d.Id())
+	if id == "" {
+		return "", fmt.Errorf("%s is required and resource id is empty; set %s or the Terraform resource id to the LaunchDarkly custom role key", KEY, KEY)
+	}
+	return id, nil
+}
+
+// effectiveCustomRoleKey is the legacy ergonomic wrapper around effectiveCustomRoleKeyOrError.
+// Returns "" on failure; callers in this provider check for empty and emit a diag.
+func effectiveCustomRoleKey(d *schema.ResourceData) string {
+	k, err := effectiveCustomRoleKeyOrError(d)
+	if err != nil {
+		log.Printf("[WARN] effectiveCustomRoleKey: %s", err)
+		return ""
+	}
+	return k
+}

--- a/launchdarkly/resource_data_helpers.go
+++ b/launchdarkly/resource_data_helpers.go
@@ -102,26 +102,27 @@ func optionalBoolFromResourceData(d *schema.ResourceData, key string, defaultVal
 	return b
 }
 
-// trimmedStringAttr returns "" for missing keys; logs at WARN on wrong type so schema regressions
-// are visible.
-func trimmedStringAttr(d *schema.ResourceData, key string) string {
+// optionalStringAttr returns "" for missing keys; logs at WARN on wrong type so schema regressions
+// are visible. Does NOT trim — preserves whatever the user typed so config↔state stay equal and
+// terraform doesn't show permanent drift on whitespace-laden inputs.
+func optionalStringAttr(d *schema.ResourceData, key string) string {
 	v := d.Get(key)
 	if v == nil {
 		return ""
 	}
 	s, ok := v.(string)
 	if !ok {
-		log.Printf("[WARN] trimmedStringAttr: %q is not a string (got %T)", key, v)
+		log.Printf("[WARN] optionalStringAttr: %q is not a string (got %T)", key, v)
 		return ""
 	}
-	return strings.TrimSpace(s)
+	return s
 }
 
 // effectiveEnvKey falls back to the env_key embedded in resource id "project_key/env_key/<key>"
 // when the attribute is missing — required for the Crossplane / Upjet external-name flow where
 // the schema may strip env_key from the resource view.
 func effectiveEnvKey(d *schema.ResourceData) (string, error) {
-	if k := trimmedStringAttr(d, ENV_KEY); k != "" {
+	if k := strings.TrimSpace(optionalStringAttr(d, ENV_KEY)); k != "" {
 		return k, nil
 	}
 	id := strings.TrimSpace(d.Id())
@@ -153,7 +154,7 @@ func effectiveEnvKeyFromIDOrAttr(d *schema.ResourceData) string {
 // effectiveCustomRoleKeyOrError falls back to d.Id() (Crossplane external-name) when KEY is unset
 // — under embedded schemas the LD custom role key is set via the Terraform id, not the attribute.
 func effectiveCustomRoleKeyOrError(d *schema.ResourceData) (string, error) {
-	if k := trimmedStringAttr(d, KEY); k != "" {
+	if k := optionalStringAttr(d, KEY); k != "" {
 		return k, nil
 	}
 	id := strings.TrimSpace(d.Id())

--- a/launchdarkly/resource_data_helpers_test.go
+++ b/launchdarkly/resource_data_helpers_test.go
@@ -1,0 +1,131 @@
+package launchdarkly
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptionalSchemaSetFromInterface(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, optionalSchemaSetFromInterface(nil))
+	require.Nil(t, optionalSchemaSetFromInterface("not-a-set"))
+	require.Nil(t, optionalSchemaSetFromInterface(42))
+
+	valid := schema.NewSet(schema.HashString, []interface{}{"a", "b"})
+	got := optionalSchemaSetFromInterface(valid)
+	require.NotNil(t, got)
+	require.Equal(t, 2, got.Len())
+}
+
+func TestInterfaceSliceFromAny(t *testing.T) {
+	t.Parallel()
+
+	require.NotNil(t, interfaceSliceFromAny(nil), "nil should normalize to empty slice, not nil")
+	require.Empty(t, interfaceSliceFromAny(nil))
+	require.Empty(t, interfaceSliceFromAny(42))
+	require.Empty(t, interfaceSliceFromAny("slice"))
+
+	sl := []interface{}{"a", "b"}
+	require.Equal(t, sl, interfaceSliceFromAny(sl))
+}
+
+// Simulates embedded provider behavior: optional blocks unset → nil from d.Get (issue #387).
+func TestOptionalSetListAndGetOptionalInterfaceSlice_unsetOptionalBlocks(t *testing.T) {
+	t.Parallel()
+
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"custom_roles": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+			Set:      schema.HashString,
+		},
+		"policy_statements": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"effect": {Type: schema.TypeString, Required: true},
+				},
+			},
+		},
+	}, map[string]interface{}{})
+
+	require.Empty(t, optionalSetList(d, "custom_roles"))
+	require.Empty(t, getOptionalInterfaceSlice(d, "policy_statements"))
+}
+
+func TestOptionalBoolFromResourceData(t *testing.T) {
+	t.Parallel()
+	withTrue := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"x": {Type: schema.TypeBool, Optional: true},
+	}, map[string]interface{}{"x": true})
+	require.True(t, optionalBoolFromResourceData(withTrue, "x", false))
+
+	unset := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"x": {Type: schema.TypeBool, Optional: true},
+	}, map[string]interface{}{})
+	require.False(t, optionalBoolFromResourceData(unset, "x", true))
+
+	wrongType := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"x": {Type: schema.TypeString, Optional: true},
+	}, map[string]interface{}{"x": "yes"})
+	// Non-bool value: use default
+	require.True(t, optionalBoolFromResourceData(wrongType, "x", true))
+}
+
+func TestPoliciesFromResourceData_nilPolicyNoPanic(t *testing.T) {
+	t.Parallel()
+
+	d := schema.TestResourceDataRaw(t, resourceCustomRole().Schema, map[string]interface{}{
+		KEY:               "k",
+		NAME:              "n",
+		BASE_PERMISSIONS:  "reader",
+		POLICY_STATEMENTS: []interface{}{},
+	})
+	// Omit POLICY — Terraform CLI often yields an empty set; helpers must tolerate nil like embedded SDK.
+	require.NotPanics(t, func() {
+		_ = policiesFromResourceData(d)
+	})
+}
+
+func TestEffectiveEnvKeyFromIDOrAttr(t *testing.T) {
+	t.Parallel()
+
+	withAttr := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		ENV_KEY: {Type: schema.TypeString, Required: true},
+	}, map[string]interface{}{ENV_KEY: "  name-dev  "})
+	require.Equal(t, "name-dev", effectiveEnvKeyFromIDOrAttr(withAttr))
+
+	fromID := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		ENV_KEY: {Type: schema.TypeString, Optional: true},
+	}, map[string]interface{}{})
+	fromID.SetId("crossplane-project/name-dev/my-flag")
+	require.Equal(t, "name-dev", effectiveEnvKeyFromIDOrAttr(fromID))
+
+	attrWins := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		ENV_KEY: {Type: schema.TypeString, Optional: true},
+	}, map[string]interface{}{ENV_KEY: "production"})
+	attrWins.SetId("proj/other-env/flag")
+	require.Equal(t, "production", effectiveEnvKeyFromIDOrAttr(attrWins))
+}
+
+func TestEffectiveCustomRoleKey(t *testing.T) {
+	t.Parallel()
+
+	withKey := schema.TestResourceDataRaw(t, resourceCustomRole().Schema, map[string]interface{}{
+		KEY:              "my-role",
+		NAME:             "n",
+		BASE_PERMISSIONS: "reader",
+	})
+	require.Equal(t, "my-role", effectiveCustomRoleKey(withKey))
+
+	fromID := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		KEY: {Type: schema.TypeString, Optional: true},
+	}, map[string]interface{}{})
+	fromID.SetId("  allow-product-manager-tag  ")
+	require.Equal(t, "allow-product-manager-tag", effectiveCustomRoleKey(fromID))
+}

--- a/launchdarkly/resource_data_helpers_test.go
+++ b/launchdarkly/resource_data_helpers_test.go
@@ -77,6 +77,26 @@ func TestOptionalBoolFromResourceData(t *testing.T) {
 	require.True(t, optionalBoolFromResourceData(wrongType, "x", true))
 }
 
+func TestOptionalIntFromResourceData(t *testing.T) {
+	t.Parallel()
+	withVal := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"x": {Type: schema.TypeInt, Optional: true},
+	}, map[string]interface{}{"x": 42})
+	require.Equal(t, 42, optionalIntFromResourceData(withVal, "x", -1))
+
+	// schema present, value unset → returns int zero value (the default arg only applies when d.Get returns nil)
+	unset := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"x": {Type: schema.TypeInt, Optional: true},
+	}, map[string]interface{}{})
+	require.Equal(t, 0, optionalIntFromResourceData(unset, "x", 7))
+
+	// wrong type at the schema layer → default applies via the type-assertion guard
+	wrongType := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"x": {Type: schema.TypeString, Optional: true},
+	}, map[string]interface{}{"x": "not-an-int"})
+	require.Equal(t, 99, optionalIntFromResourceData(wrongType, "x", 99))
+}
+
 func TestPoliciesFromResourceData_nilPolicyNoPanic(t *testing.T) {
 	t.Parallel()
 

--- a/launchdarkly/resource_data_helpers_test.go
+++ b/launchdarkly/resource_data_helpers_test.go
@@ -77,6 +77,28 @@ func TestOptionalBoolFromResourceData(t *testing.T) {
 	require.True(t, optionalBoolFromResourceData(wrongType, "x", true))
 }
 
+// optionalStringAttr must not trim — trimming would create permanent plan drift if a user's
+// config has whitespace and the LD API does not normalize it server-side: terraform would compare
+// config "  test  " vs state "test" and want to update on every plan.
+func TestOptionalStringAttr_doesNotTrim(t *testing.T) {
+	t.Parallel()
+
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"x": {Type: schema.TypeString, Optional: true},
+	}, map[string]interface{}{"x": "  has space  "})
+	require.Equal(t, "  has space  ", optionalStringAttr(d, "x"))
+
+	missing := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"y": {Type: schema.TypeString, Optional: true},
+	}, map[string]interface{}{})
+	require.Equal(t, "", optionalStringAttr(missing, "y"))
+
+	wrongType := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"x": {Type: schema.TypeBool, Optional: true},
+	}, map[string]interface{}{"x": true})
+	require.Equal(t, "", optionalStringAttr(wrongType, "x"))
+}
+
 func TestOptionalIntFromResourceData(t *testing.T) {
 	t.Parallel()
 	withVal := schema.TestResourceDataRaw(t, map[string]*schema.Schema{

--- a/launchdarkly/resource_launchdarkly_access_token.go
+++ b/launchdarkly/resource_launchdarkly_access_token.go
@@ -112,7 +112,7 @@ func validateAPIVersion(val interface{}, key string) (warns []string, errs []err
 }
 
 func validateAccessTokenResource(d *schema.ResourceData) error {
-	accessTokenRole := d.Get(ROLE).(string)
+	accessTokenRole := trimmedStringAttr(d, ROLE)
 	customRolesRaw := optionalSetList(d, CUSTOM_ROLES)
 	policyStatements, err := policyStatementsFromResourceData(getOptionalInterfaceSlice(d, POLICY_STATEMENTS))
 	if err != nil {
@@ -138,8 +138,8 @@ func resourceAccessTokenCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	client := metaRaw.(*Client)
-	accessTokenName := d.Get(NAME).(string)
-	serviceToken := d.Get(SERVICE_TOKEN).(bool)
+	accessTokenName := trimmedStringAttr(d, NAME)
+	serviceToken := optionalBoolFromResourceData(d, SERVICE_TOKEN, false)
 
 	accessTokenBody := ldapi.AccessTokenPost{
 		Name:         ldapi.PtrString(accessTokenName),
@@ -248,8 +248,8 @@ func resourceAccessTokenUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 	client := metaRaw.(*Client)
 	accessTokenID := d.Id()
-	accessTokenName := d.Get(NAME).(string)
-	accessTokenRole := d.Get(ROLE).(string)
+	accessTokenName := trimmedStringAttr(d, NAME)
+	accessTokenRole := trimmedStringAttr(d, ROLE)
 	customRolesRaw := optionalSetList(d, CUSTOM_ROLES)
 
 	customRoleKeys := make([]string, len(customRolesRaw))
@@ -310,8 +310,8 @@ func resourceAccessTokenUpdate(ctx context.Context, d *schema.ResourceData, meta
 	// Reset the access token if the expire field has been updated
 	if d.HasChange(EXPIRE) {
 		oldExpireRaw, newExpireRaw := d.GetChange(EXPIRE)
-		oldExpire := oldExpireRaw.(int)
-		newExpire := newExpireRaw.(int)
+		oldExpire, _ := oldExpireRaw.(int)
+		newExpire, _ := newExpireRaw.(int)
 		if oldExpire != newExpire && newExpire != 0 {
 			token, err := resetAccessToken(client, accessTokenID, newExpire)
 			if err != nil {

--- a/launchdarkly/resource_launchdarkly_access_token.go
+++ b/launchdarkly/resource_launchdarkly_access_token.go
@@ -112,7 +112,7 @@ func validateAPIVersion(val interface{}, key string) (warns []string, errs []err
 }
 
 func validateAccessTokenResource(d *schema.ResourceData) error {
-	accessTokenRole := trimmedStringAttr(d, ROLE)
+	accessTokenRole := optionalStringAttr(d, ROLE)
 	customRolesRaw := optionalSetList(d, CUSTOM_ROLES)
 	policyStatements, err := policyStatementsFromResourceData(getOptionalInterfaceSlice(d, POLICY_STATEMENTS))
 	if err != nil {
@@ -138,7 +138,7 @@ func resourceAccessTokenCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	client := metaRaw.(*Client)
-	accessTokenName := trimmedStringAttr(d, NAME)
+	accessTokenName := optionalStringAttr(d, NAME)
 	serviceToken := optionalBoolFromResourceData(d, SERVICE_TOKEN, false)
 
 	accessTokenBody := ldapi.AccessTokenPost{
@@ -248,8 +248,8 @@ func resourceAccessTokenUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 	client := metaRaw.(*Client)
 	accessTokenID := d.Id()
-	accessTokenName := trimmedStringAttr(d, NAME)
-	accessTokenRole := trimmedStringAttr(d, ROLE)
+	accessTokenName := optionalStringAttr(d, NAME)
+	accessTokenRole := optionalStringAttr(d, ROLE)
 	customRolesRaw := optionalSetList(d, CUSTOM_ROLES)
 
 	customRoleKeys := make([]string, len(customRolesRaw))

--- a/launchdarkly/resource_launchdarkly_access_token.go
+++ b/launchdarkly/resource_launchdarkly_access_token.go
@@ -113,13 +113,13 @@ func validateAPIVersion(val interface{}, key string) (warns []string, errs []err
 
 func validateAccessTokenResource(d *schema.ResourceData) error {
 	accessTokenRole := d.Get(ROLE).(string)
-	customRolesRaw := d.Get(CUSTOM_ROLES).(*schema.Set).List()
-	policyStatements, err := policyStatementsFromResourceData(d.Get(POLICY_STATEMENTS).([]interface{}))
+	customRolesRaw := optionalSetList(d, CUSTOM_ROLES)
+	policyStatements, err := policyStatementsFromResourceData(getOptionalInterfaceSlice(d, POLICY_STATEMENTS))
 	if err != nil {
 		return err
 	}
 
-	inlineRoles, err := policyStatementsFromResourceData(d.Get(INLINE_ROLES).([]interface{}))
+	inlineRoles, err := policyStatementsFromResourceData(getOptionalInterfaceSlice(d, INLINE_ROLES))
 	if err != nil {
 		return err
 	}
@@ -150,12 +150,12 @@ func resourceAccessTokenCreate(ctx context.Context, d *schema.ResourceData, meta
 		accessTokenBody.DefaultApiVersion = ldapi.PtrInt32(int32(defaultApiVersion.(int)))
 	}
 
-	inlineRoles, _ := policyStatementsFromResourceData(d.Get(POLICY_STATEMENTS).([]interface{}))
+	inlineRoles, _ := policyStatementsFromResourceData(getOptionalInterfaceSlice(d, POLICY_STATEMENTS))
 	if len(inlineRoles) == 0 {
-		inlineRoles, _ = policyStatementsFromResourceData(d.Get(INLINE_ROLES).([]interface{}))
+		inlineRoles, _ = policyStatementsFromResourceData(getOptionalInterfaceSlice(d, INLINE_ROLES))
 	}
 
-	customRolesRaw := d.Get(CUSTOM_ROLES).(*schema.Set).List()
+	customRolesRaw := optionalSetList(d, CUSTOM_ROLES)
 	if len(inlineRoles) == 0 && len(customRolesRaw) > 0 {
 		customRoles := make([]string, len(customRolesRaw))
 		for i, cr := range customRolesRaw {
@@ -226,7 +226,7 @@ func resourceAccessTokenRead(ctx context.Context, d *schema.ResourceData, metaRa
 
 	policies := accessToken.InlineRole
 	if len(policies) > 0 {
-		policyStatements, _ := policyStatementsFromResourceData(d.Get(POLICY_STATEMENTS).([]interface{}))
+		policyStatements, _ := policyStatementsFromResourceData(getOptionalInterfaceSlice(d, POLICY_STATEMENTS))
 		if len(policyStatements) > 0 {
 			err = d.Set(POLICY_STATEMENTS, policyStatementsToResourceData(policies))
 		} else {
@@ -250,7 +250,7 @@ func resourceAccessTokenUpdate(ctx context.Context, d *schema.ResourceData, meta
 	accessTokenID := d.Id()
 	accessTokenName := d.Get(NAME).(string)
 	accessTokenRole := d.Get(ROLE).(string)
-	customRolesRaw := d.Get(CUSTOM_ROLES).(*schema.Set).List()
+	customRolesRaw := optionalSetList(d, CUSTOM_ROLES)
 
 	customRoleKeys := make([]string, len(customRolesRaw))
 	for i, cr := range customRolesRaw {
@@ -261,9 +261,9 @@ func resourceAccessTokenUpdate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	inlineRoles, _ := policyStatementsFromResourceData(d.Get(POLICY_STATEMENTS).([]interface{}))
+	inlineRoles, _ := policyStatementsFromResourceData(getOptionalInterfaceSlice(d, POLICY_STATEMENTS))
 	if len(inlineRoles) == 0 {
-		inlineRoles, _ = policyStatementsFromResourceData(d.Get(INLINE_ROLES).([]interface{}))
+		inlineRoles, _ = policyStatementsFromResourceData(getOptionalInterfaceSlice(d, INLINE_ROLES))
 	}
 	iRoles := inlineRoles
 

--- a/launchdarkly/resource_launchdarkly_ai_config.go
+++ b/launchdarkly/resource_launchdarkly_ai_config.go
@@ -85,12 +85,12 @@ func resourceAIConfigCreate(ctx context.Context, d *schema.ResourceData, metaRaw
 		// meaningless without a metric. Use d.Get() instead of d.GetOk() because
 		// GetOk returns ok=false for bool(false), which would silently drop an
 		// explicit is_inverted = false.
-		isInverted := d.Get(IS_INVERTED).(bool)
+		isInverted := optionalBoolFromResourceData(d, IS_INVERTED, false)
 		post.IsInverted = &isInverted
 	}
 
 	if v, ok := d.GetOk(TAGS); ok {
-		post.Tags = interfaceSliceToStringSlice(v.(*schema.Set).List())
+		post.Tags = stringsFromSchemaSet(optionalSchemaSetFromInterface(v))
 	}
 
 	var err error
@@ -127,7 +127,7 @@ func resourceAIConfigUpdate(ctx context.Context, d *schema.ResourceData, metaRaw
 	}
 
 	if d.HasChange(DESCRIPTION) {
-		description := d.Get(DESCRIPTION).(string)
+		description := trimmedStringAttr(d, DESCRIPTION)
 		patch.Description = &description
 		hasChanges = true
 	}
@@ -135,13 +135,13 @@ func resourceAIConfigUpdate(ctx context.Context, d *schema.ResourceData, metaRaw
 	// Use d.Get() instead of d.GetOk() so removing a maintainer from config
 	// sends an empty string to the API, clearing it server-side.
 	if d.HasChange(MAINTAINER_ID) {
-		maintainerId := d.Get(MAINTAINER_ID).(string)
+		maintainerId := trimmedStringAttr(d, MAINTAINER_ID)
 		patch.MaintainerId = &maintainerId
 		hasChanges = true
 	}
 
 	if d.HasChange(MAINTAINER_TEAM_KEY) {
-		maintainerTeamKey := d.Get(MAINTAINER_TEAM_KEY).(string)
+		maintainerTeamKey := trimmedStringAttr(d, MAINTAINER_TEAM_KEY)
 		patch.MaintainerTeamKey = &maintainerTeamKey
 		hasChanges = true
 	}
@@ -154,7 +154,7 @@ func resourceAIConfigUpdate(ctx context.Context, d *schema.ResourceData, metaRaw
 
 	if d.HasChange(EVALUATION_METRIC_KEY) {
 		// Use d.Get() instead of d.GetOk() so users can unset to empty string.
-		evaluationMetricKey := d.Get(EVALUATION_METRIC_KEY).(string)
+		evaluationMetricKey := trimmedStringAttr(d, EVALUATION_METRIC_KEY)
 		patch.EvaluationMetricKey = &evaluationMetricKey
 		hasChanges = true
 	}
@@ -162,7 +162,7 @@ func resourceAIConfigUpdate(ctx context.Context, d *schema.ResourceData, metaRaw
 	if d.HasChange(IS_INVERTED) {
 		// Use d.Get() instead of d.GetOk() because GetOk returns ok=false
 		// for bool(false), silently dropping true→false changes.
-		isInverted := d.Get(IS_INVERTED).(bool)
+		isInverted := optionalBoolFromResourceData(d, IS_INVERTED, false)
 		patch.IsInverted = &isInverted
 		hasChanges = true
 	}

--- a/launchdarkly/resource_launchdarkly_ai_config.go
+++ b/launchdarkly/resource_launchdarkly_ai_config.go
@@ -127,7 +127,7 @@ func resourceAIConfigUpdate(ctx context.Context, d *schema.ResourceData, metaRaw
 	}
 
 	if d.HasChange(DESCRIPTION) {
-		description := trimmedStringAttr(d, DESCRIPTION)
+		description := optionalStringAttr(d, DESCRIPTION)
 		patch.Description = &description
 		hasChanges = true
 	}
@@ -135,13 +135,13 @@ func resourceAIConfigUpdate(ctx context.Context, d *schema.ResourceData, metaRaw
 	// Use d.Get() instead of d.GetOk() so removing a maintainer from config
 	// sends an empty string to the API, clearing it server-side.
 	if d.HasChange(MAINTAINER_ID) {
-		maintainerId := trimmedStringAttr(d, MAINTAINER_ID)
+		maintainerId := optionalStringAttr(d, MAINTAINER_ID)
 		patch.MaintainerId = &maintainerId
 		hasChanges = true
 	}
 
 	if d.HasChange(MAINTAINER_TEAM_KEY) {
-		maintainerTeamKey := trimmedStringAttr(d, MAINTAINER_TEAM_KEY)
+		maintainerTeamKey := optionalStringAttr(d, MAINTAINER_TEAM_KEY)
 		patch.MaintainerTeamKey = &maintainerTeamKey
 		hasChanges = true
 	}
@@ -154,7 +154,7 @@ func resourceAIConfigUpdate(ctx context.Context, d *schema.ResourceData, metaRaw
 
 	if d.HasChange(EVALUATION_METRIC_KEY) {
 		// Use d.Get() instead of d.GetOk() so users can unset to empty string.
-		evaluationMetricKey := trimmedStringAttr(d, EVALUATION_METRIC_KEY)
+		evaluationMetricKey := optionalStringAttr(d, EVALUATION_METRIC_KEY)
 		patch.EvaluationMetricKey = &evaluationMetricKey
 		hasChanges = true
 	}

--- a/launchdarkly/resource_launchdarkly_ai_config_variation.go
+++ b/launchdarkly/resource_launchdarkly_ai_config_variation.go
@@ -120,17 +120,17 @@ func resourceAIConfigVariationUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if d.HasChange(DESCRIPTION) {
-		description := trimmedStringAttr(d, DESCRIPTION)
+		description := optionalStringAttr(d, DESCRIPTION)
 		patch.Description = &description
 	}
 
 	if d.HasChange(INSTRUCTIONS) {
-		instructions := trimmedStringAttr(d, INSTRUCTIONS)
+		instructions := optionalStringAttr(d, INSTRUCTIONS)
 		patch.Instructions = &instructions
 	}
 
 	if d.HasChange(MODEL) {
-		modelMap, err := jsonStringToMap(trimmedStringAttr(d, MODEL))
+		modelMap, err := jsonStringToMap(optionalStringAttr(d, MODEL))
 		if err != nil {
 			return diag.Errorf("failed to parse model JSON: %s", err)
 		}
@@ -138,7 +138,7 @@ func resourceAIConfigVariationUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if d.HasChange(MODEL_CONFIG_KEY) {
-		modelConfigKey := trimmedStringAttr(d, MODEL_CONFIG_KEY)
+		modelConfigKey := optionalStringAttr(d, MODEL_CONFIG_KEY)
 		patch.ModelConfigKey = &modelConfigKey
 	}
 
@@ -151,7 +151,7 @@ func resourceAIConfigVariationUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if d.HasChange(STATE) {
-		state := trimmedStringAttr(d, STATE)
+		state := optionalStringAttr(d, STATE)
 		patch.State = &state
 	}
 

--- a/launchdarkly/resource_launchdarkly_ai_config_variation.go
+++ b/launchdarkly/resource_launchdarkly_ai_config_variation.go
@@ -83,7 +83,7 @@ func resourceAIConfigVariationCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if v, ok := d.GetOk(TOOL_KEYS); ok {
-		toolKeys := stringsFromSchemaSet(v.(*schema.Set))
+		toolKeys := stringsFromSchemaSet(optionalSchemaSetFromInterface(v))
 		post.ToolKeys = toolKeys
 	}
 
@@ -120,17 +120,17 @@ func resourceAIConfigVariationUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if d.HasChange(DESCRIPTION) {
-		description := d.Get(DESCRIPTION).(string)
+		description := trimmedStringAttr(d, DESCRIPTION)
 		patch.Description = &description
 	}
 
 	if d.HasChange(INSTRUCTIONS) {
-		instructions := d.Get(INSTRUCTIONS).(string)
+		instructions := trimmedStringAttr(d, INSTRUCTIONS)
 		patch.Instructions = &instructions
 	}
 
 	if d.HasChange(MODEL) {
-		modelMap, err := jsonStringToMap(d.Get(MODEL).(string))
+		modelMap, err := jsonStringToMap(trimmedStringAttr(d, MODEL))
 		if err != nil {
 			return diag.Errorf("failed to parse model JSON: %s", err)
 		}
@@ -138,7 +138,7 @@ func resourceAIConfigVariationUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if d.HasChange(MODEL_CONFIG_KEY) {
-		modelConfigKey := d.Get(MODEL_CONFIG_KEY).(string)
+		modelConfigKey := trimmedStringAttr(d, MODEL_CONFIG_KEY)
 		patch.ModelConfigKey = &modelConfigKey
 	}
 
@@ -151,12 +151,12 @@ func resourceAIConfigVariationUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if d.HasChange(STATE) {
-		state := d.Get(STATE).(string)
+		state := trimmedStringAttr(d, STATE)
 		patch.State = &state
 	}
 
 	if d.HasChange(TOOL_KEYS) {
-		toolKeys := stringsFromSchemaSet(d.Get(TOOL_KEYS).(*schema.Set))
+		toolKeys := stringsFromSchemaSet(getOptionalSet(d, TOOL_KEYS))
 		patch.ToolKeys = toolKeys
 	}
 

--- a/launchdarkly/resource_launchdarkly_ai_tool.go
+++ b/launchdarkly/resource_launchdarkly_ai_tool.go
@@ -89,12 +89,12 @@ func resourceAIToolUpdate(ctx context.Context, d *schema.ResourceData, metaRaw i
 	patch := ldapi.NewAIToolPatch()
 
 	if d.HasChange(DESCRIPTION) {
-		description := trimmedStringAttr(d, DESCRIPTION)
+		description := optionalStringAttr(d, DESCRIPTION)
 		patch.Description = &description
 	}
 
 	if d.HasChange(SCHEMA_JSON) {
-		schemaMap, err := jsonStringToMap(trimmedStringAttr(d, SCHEMA_JSON))
+		schemaMap, err := jsonStringToMap(optionalStringAttr(d, SCHEMA_JSON))
 		if err != nil {
 			return diag.Errorf("failed to parse schema_json: %s", err)
 		}
@@ -102,7 +102,7 @@ func resourceAIToolUpdate(ctx context.Context, d *schema.ResourceData, metaRaw i
 	}
 
 	if d.HasChange(CUSTOM_PARAMETERS) {
-		customParamsStr := trimmedStringAttr(d, CUSTOM_PARAMETERS)
+		customParamsStr := optionalStringAttr(d, CUSTOM_PARAMETERS)
 		customParamsMap, err := jsonStringToMap(customParamsStr)
 		if err != nil {
 			return diag.Errorf("failed to parse custom_parameters: %s", err)
@@ -113,11 +113,11 @@ func resourceAIToolUpdate(ctx context.Context, d *schema.ResourceData, metaRaw i
 	// Use d.Get() instead of d.GetOk() so removing a maintainer from config
 	// sends an empty string to the API, clearing it server-side.
 	if d.HasChange(MAINTAINER_ID) {
-		patch.MaintainerId = ldapi.PtrString(trimmedStringAttr(d, MAINTAINER_ID))
+		patch.MaintainerId = ldapi.PtrString(optionalStringAttr(d, MAINTAINER_ID))
 	}
 
 	if d.HasChange(MAINTAINER_TEAM_KEY) {
-		patch.MaintainerTeamKey = ldapi.PtrString(trimmedStringAttr(d, MAINTAINER_TEAM_KEY))
+		patch.MaintainerTeamKey = ldapi.PtrString(optionalStringAttr(d, MAINTAINER_TEAM_KEY))
 	}
 
 	var err error

--- a/launchdarkly/resource_launchdarkly_ai_tool.go
+++ b/launchdarkly/resource_launchdarkly_ai_tool.go
@@ -89,12 +89,12 @@ func resourceAIToolUpdate(ctx context.Context, d *schema.ResourceData, metaRaw i
 	patch := ldapi.NewAIToolPatch()
 
 	if d.HasChange(DESCRIPTION) {
-		description := d.Get(DESCRIPTION).(string)
+		description := trimmedStringAttr(d, DESCRIPTION)
 		patch.Description = &description
 	}
 
 	if d.HasChange(SCHEMA_JSON) {
-		schemaMap, err := jsonStringToMap(d.Get(SCHEMA_JSON).(string))
+		schemaMap, err := jsonStringToMap(trimmedStringAttr(d, SCHEMA_JSON))
 		if err != nil {
 			return diag.Errorf("failed to parse schema_json: %s", err)
 		}
@@ -102,7 +102,7 @@ func resourceAIToolUpdate(ctx context.Context, d *schema.ResourceData, metaRaw i
 	}
 
 	if d.HasChange(CUSTOM_PARAMETERS) {
-		customParamsStr := d.Get(CUSTOM_PARAMETERS).(string)
+		customParamsStr := trimmedStringAttr(d, CUSTOM_PARAMETERS)
 		customParamsMap, err := jsonStringToMap(customParamsStr)
 		if err != nil {
 			return diag.Errorf("failed to parse custom_parameters: %s", err)
@@ -113,11 +113,11 @@ func resourceAIToolUpdate(ctx context.Context, d *schema.ResourceData, metaRaw i
 	// Use d.Get() instead of d.GetOk() so removing a maintainer from config
 	// sends an empty string to the API, clearing it server-side.
 	if d.HasChange(MAINTAINER_ID) {
-		patch.MaintainerId = ldapi.PtrString(d.Get(MAINTAINER_ID).(string))
+		patch.MaintainerId = ldapi.PtrString(trimmedStringAttr(d, MAINTAINER_ID))
 	}
 
 	if d.HasChange(MAINTAINER_TEAM_KEY) {
-		patch.MaintainerTeamKey = ldapi.PtrString(d.Get(MAINTAINER_TEAM_KEY).(string))
+		patch.MaintainerTeamKey = ldapi.PtrString(trimmedStringAttr(d, MAINTAINER_TEAM_KEY))
 	}
 
 	var err error

--- a/launchdarkly/resource_launchdarkly_audit_log_subscription.go
+++ b/launchdarkly/resource_launchdarkly_audit_log_subscription.go
@@ -36,13 +36,13 @@ func resourceAuditLogSubscriptionCreate(ctx context.Context, d *schema.ResourceD
 	integrationKey := d.Get(INTEGRATION_KEY).(string)
 	name := d.Get(NAME).(string)
 	on := d.Get(ON).(bool)
-	tags := stringsFromSchemaSet(d.Get(TAGS).(*schema.Set))
+	tags := stringsFromSchemaSet(getOptionalSet(d, TAGS))
 	config, err := configFromResourceData(d)
 	if err != nil {
 		return diag.Errorf("failed to create %s integration with name %s: %v", integrationKey, name, err.Error())
 	}
 
-	statements, err := policyStatementsFromResourceData(d.Get(STATEMENTS).([]interface{}))
+	statements, err := policyStatementsFromResourceData(getOptionalInterfaceSlice(d, STATEMENTS))
 	if err != nil {
 		return diag.Errorf("failed to create %s integration with name %s: %v", integrationKey, name, err.Error())
 	}
@@ -80,7 +80,7 @@ func resourceAuditLogSubscriptionUpdate(ctx context.Context, d *schema.ResourceD
 	}
 	id := d.Id()
 
-	statements, err := policyStatementsFromResourceData(d.Get(STATEMENTS).([]interface{}))
+	statements, err := policyStatementsFromResourceData(getOptionalInterfaceSlice(d, STATEMENTS))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/launchdarkly/resource_launchdarkly_custom_role.go
+++ b/launchdarkly/resource_launchdarkly_custom_role.go
@@ -76,8 +76,8 @@ func resourceCustomRoleCreate(ctx context.Context, d *schema.ResourceData, metaR
 			"%s is required for custom role creation. If the embedded schema omits it, set the Terraform resource id (Crossplane external-name) to the LaunchDarkly role key before create.", KEY)
 	}
 	customRoleName := d.Get(NAME).(string)
-	customRoleDescription := d.Get(DESCRIPTION).(string)
-	customRoleBasePermissions := d.Get(BASE_PERMISSIONS).(string)
+	customRoleDescription := trimmedStringAttr(d, DESCRIPTION)
+	customRoleBasePermissions := trimmedStringAttr(d, BASE_PERMISSIONS)
 	customRolePolicies := policiesFromResourceData(d)
 	policyStatements, err := policyStatementsFromResourceData(getOptionalInterfaceSlice(d, POLICY_STATEMENTS))
 	if err != nil {
@@ -185,8 +185,8 @@ func resourceCustomRoleUpdate(ctx context.Context, d *schema.ResourceData, metaR
 		return diag.Errorf("cannot update custom role: %s is empty and resource id is empty", KEY)
 	}
 	customRoleName := d.Get(NAME).(string)
-	customRoleDescription := d.Get(DESCRIPTION).(string)
-	customRoleBasePermissions := d.Get(BASE_PERMISSIONS).(string)
+	customRoleDescription := trimmedStringAttr(d, DESCRIPTION)
+	customRoleBasePermissions := trimmedStringAttr(d, BASE_PERMISSIONS)
 	customRolePolicies := policiesFromResourceData(d)
 	policyStatements, err := policyStatementsFromResourceData(getOptionalInterfaceSlice(d, POLICY_STATEMENTS))
 	if err != nil {

--- a/launchdarkly/resource_launchdarkly_custom_role.go
+++ b/launchdarkly/resource_launchdarkly_custom_role.go
@@ -76,8 +76,8 @@ func resourceCustomRoleCreate(ctx context.Context, d *schema.ResourceData, metaR
 			"%s is required for custom role creation. If the embedded schema omits it, set the Terraform resource id (Crossplane external-name) to the LaunchDarkly role key before create.", KEY)
 	}
 	customRoleName := d.Get(NAME).(string)
-	customRoleDescription := trimmedStringAttr(d, DESCRIPTION)
-	customRoleBasePermissions := trimmedStringAttr(d, BASE_PERMISSIONS)
+	customRoleDescription := optionalStringAttr(d, DESCRIPTION)
+	customRoleBasePermissions := optionalStringAttr(d, BASE_PERMISSIONS)
 	customRolePolicies := policiesFromResourceData(d)
 	policyStatements, err := policyStatementsFromResourceData(getOptionalInterfaceSlice(d, POLICY_STATEMENTS))
 	if err != nil {
@@ -185,8 +185,8 @@ func resourceCustomRoleUpdate(ctx context.Context, d *schema.ResourceData, metaR
 		return diag.Errorf("cannot update custom role: %s is empty and resource id is empty", KEY)
 	}
 	customRoleName := d.Get(NAME).(string)
-	customRoleDescription := trimmedStringAttr(d, DESCRIPTION)
-	customRoleBasePermissions := trimmedStringAttr(d, BASE_PERMISSIONS)
+	customRoleDescription := optionalStringAttr(d, DESCRIPTION)
+	customRoleBasePermissions := optionalStringAttr(d, BASE_PERMISSIONS)
 	customRolePolicies := policiesFromResourceData(d)
 	policyStatements, err := policyStatementsFromResourceData(getOptionalInterfaceSlice(d, POLICY_STATEMENTS))
 	if err != nil {

--- a/launchdarkly/resource_launchdarkly_custom_role.go
+++ b/launchdarkly/resource_launchdarkly_custom_role.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -69,12 +70,16 @@ This resource allows you to create and manage custom roles within your LaunchDar
 
 func resourceCustomRoleCreate(ctx context.Context, d *schema.ResourceData, metaRaw interface{}) diag.Diagnostics {
 	client := metaRaw.(*Client)
-	customRoleKey := d.Get(KEY).(string)
+	customRoleKey := effectiveCustomRoleKey(d)
+	if customRoleKey == "" {
+		return diag.Errorf(
+			"%s is required for custom role creation. If the embedded schema omits it, set the Terraform resource id (Crossplane external-name) to the LaunchDarkly role key before create.", KEY)
+	}
 	customRoleName := d.Get(NAME).(string)
 	customRoleDescription := d.Get(DESCRIPTION).(string)
 	customRoleBasePermissions := d.Get(BASE_PERMISSIONS).(string)
 	customRolePolicies := policiesFromResourceData(d)
-	policyStatements, err := policyStatementsFromResourceData(d.Get(POLICY_STATEMENTS).([]interface{}))
+	policyStatements, err := policyStatementsFromResourceData(getOptionalInterfaceSlice(d, POLICY_STATEMENTS))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -92,15 +97,20 @@ func resourceCustomRoleCreate(ctx context.Context, d *schema.ResourceData, metaR
 		customRoleBody.BasePermissions = ldapi.PtrString(customRoleBasePermissions)
 	}
 
+	var created *ldapi.CustomRole
 	err = client.withConcurrency(client.ctx, func() error {
-		_, _, err = client.ld.CustomRolesApi.PostCustomRole(client.ctx).CustomRolePost(customRoleBody).Execute()
+		created, _, err = client.ld.CustomRolesApi.PostCustomRole(client.ctx).CustomRolePost(customRoleBody).Execute()
 		return err
 	})
 	if err != nil {
 		return diag.Errorf("failed to create custom role with name %q: %s", customRoleName, handleLdapiErr(err))
 	}
 
-	d.SetId(customRoleKey)
+	id := customRoleKey
+	if created != nil && created.Key != "" {
+		id = created.Key
+	}
+	d.SetId(id)
 	return resourceCustomRoleRead(ctx, d, metaRaw)
 }
 
@@ -131,10 +141,22 @@ func resourceCustomRoleRead(ctx context.Context, d *schema.ResourceData, metaRaw
 		return diag.Errorf("failed to get custom role with id %q: %s", customRoleID, handleLdapiErr(err))
 	}
 
-	_ = d.Set(KEY, customRole.Key)
-	_ = d.Set(NAME, customRole.Name)
-	_ = d.Set(DESCRIPTION, customRole.Description)
-	_ = d.Set(BASE_PERMISSIONS, customRole.BasePermissions)
+	if customRole.Key != "" {
+		d.SetId(customRole.Key)
+	}
+
+	_ = resourceDataSetSkipMissingKey(d, KEY, customRole.Key)
+	_ = resourceDataSetSkipMissingKey(d, NAME, customRole.Name)
+	desc := ""
+	if customRole.Description != nil {
+		desc = *customRole.Description
+	}
+	_ = resourceDataSetSkipMissingKey(d, DESCRIPTION, desc)
+	basePerms := ""
+	if customRole.BasePermissions != nil {
+		basePerms = *customRole.BasePermissions
+	}
+	_ = resourceDataSetSkipMissingKey(d, BASE_PERMISSIONS, basePerms)
 
 	// Because "policy" is now deprecated in favor of "policy_statements", only set "policy" if it has
 	// already been set by the user.
@@ -145,9 +167,9 @@ func resourceCustomRoleRead(ctx context.Context, d *schema.ResourceData, metaRaw
 	// 	  }
 	if _, ok := d.GetOk(POLICY); ok {
 		policies := policiesToResourceData(customRole.Policy)
-		err = d.Set(POLICY, policies)
+		err = resourceDataSetSkipMissingKey(d, POLICY, policies)
 	} else {
-		err = d.Set(POLICY_STATEMENTS, policyStatementsToResourceData(statementsToStatementReps(customRole.Policy)))
+		err = resourceDataSetSkipMissingKey(d, POLICY_STATEMENTS, policyStatementsToResourceData(statementsToStatementReps(customRole.Policy)))
 	}
 
 	if err != nil {
@@ -158,12 +180,15 @@ func resourceCustomRoleRead(ctx context.Context, d *schema.ResourceData, metaRaw
 
 func resourceCustomRoleUpdate(ctx context.Context, d *schema.ResourceData, metaRaw interface{}) diag.Diagnostics {
 	client := metaRaw.(*Client)
-	customRoleKey := d.Get(KEY).(string)
+	customRoleKey := effectiveCustomRoleKey(d)
+	if customRoleKey == "" {
+		return diag.Errorf("cannot update custom role: %s is empty and resource id is empty", KEY)
+	}
 	customRoleName := d.Get(NAME).(string)
 	customRoleDescription := d.Get(DESCRIPTION).(string)
 	customRoleBasePermissions := d.Get(BASE_PERMISSIONS).(string)
 	customRolePolicies := policiesFromResourceData(d)
-	policyStatements, err := policyStatementsFromResourceData(d.Get(POLICY_STATEMENTS).([]interface{}))
+	policyStatements, err := policyStatementsFromResourceData(getOptionalInterfaceSlice(d, POLICY_STATEMENTS))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -233,7 +258,8 @@ func customRoleExists(customRoleKey string, client *Client) (bool, error) {
 }
 
 func resourceCustomRoleImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	_ = d.Set(KEY, d.Id())
+	key := strings.TrimSpace(d.Id())
+	_ = d.Set(KEY, key)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/launchdarkly/resource_launchdarkly_destination.go
+++ b/launchdarkly/resource_launchdarkly_destination.go
@@ -83,7 +83,7 @@ func resourceDestinationCreate(ctx context.Context, d *schema.ResourceData, meta
 	destinationEnvKey := d.Get(ENV_KEY).(string)
 	destinationName := d.Get(NAME).(string)
 	destinationKind := d.Get(KIND).(string)
-	destinationOn := d.Get(ON).(bool)
+	destinationOn := optionalBoolFromResourceData(d, ON, false)
 
 	destinationConfig, err := destinationConfigFromResourceData(d)
 	if err != nil {
@@ -170,7 +170,7 @@ func resourceDestinationUpdate(ctx context.Context, d *schema.ResourceData, meta
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	destinationOn := d.Get(ON).(bool)
+	destinationOn := optionalBoolFromResourceData(d, ON, false)
 
 	patch := []ldapi.PatchOperation{
 		patchReplace("/name", &destinationName),

--- a/launchdarkly/resource_launchdarkly_environment.go
+++ b/launchdarkly/resource_launchdarkly_environment.go
@@ -46,7 +46,7 @@ func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta
 	defaultTTL := int32(d.Get(DEFAULT_TTL).(int))
 	secureMode := d.Get(SECURE_MODE).(bool)
 	defaultTrackEvents := d.Get(DEFAULT_TRACK_EVENTS).(bool)
-	tags := stringsFromSchemaSet(d.Get(TAGS).(*schema.Set))
+	tags := stringsFromSchemaSet(getOptionalSet(d, TAGS))
 	requireComments := d.Get(REQUIRE_COMMENTS).(bool)
 	confirmChanges := d.Get(CONFIRM_CHANGES).(bool)
 	critical := d.Get(CRITICAL).(bool)
@@ -73,8 +73,8 @@ func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.Errorf("failed to create environment: [%+v] for project key: %s: %s", envPost, projectKey, handleLdapiErr(err))
 	}
 
-	approvalSettings := d.Get(APPROVAL_SETTINGS)
-	if len(approvalSettings.([]interface{})) > 0 {
+	approvalSettings := interfaceSliceFromAny(d.Get(APPROVAL_SETTINGS))
+	if len(approvalSettings) > 0 {
 		updateDiags := resourceEnvironmentUpdate(ctx, d, metaRaw)
 		if updateDiags.HasError() {
 			// if there was a problem in the update state, we need to clean up completely by deleting the env

--- a/launchdarkly/resource_launchdarkly_environment.go
+++ b/launchdarkly/resource_launchdarkly_environment.go
@@ -43,13 +43,13 @@ func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta
 	key := d.Get(KEY).(string)
 	name := d.Get(NAME).(string)
 	color := d.Get(COLOR).(string)
-	defaultTTL := int32(d.Get(DEFAULT_TTL).(int))
-	secureMode := d.Get(SECURE_MODE).(bool)
-	defaultTrackEvents := d.Get(DEFAULT_TRACK_EVENTS).(bool)
+	defaultTTL := int32(optionalIntFromResourceData(d, DEFAULT_TTL, 0))
+	secureMode := optionalBoolFromResourceData(d, SECURE_MODE, false)
+	defaultTrackEvents := optionalBoolFromResourceData(d, DEFAULT_TRACK_EVENTS, false)
 	tags := stringsFromSchemaSet(getOptionalSet(d, TAGS))
-	requireComments := d.Get(REQUIRE_COMMENTS).(bool)
-	confirmChanges := d.Get(CONFIRM_CHANGES).(bool)
-	critical := d.Get(CRITICAL).(bool)
+	requireComments := optionalBoolFromResourceData(d, REQUIRE_COMMENTS, false)
+	confirmChanges := optionalBoolFromResourceData(d, CONFIRM_CHANGES, false)
+	critical := optionalBoolFromResourceData(d, CRITICAL, false)
 
 	envPost := ldapi.EnvironmentPost{
 		Name:               name,

--- a/launchdarkly/resource_launchdarkly_feature_flag.go
+++ b/launchdarkly/resource_launchdarkly_feature_flag.go
@@ -30,9 +30,8 @@ func customizeFeatureFlagDiff(ctx context.Context, diff *schema.ResourceDiff, me
 	}
 
 	if viewSettings.RequireViewAssociationForNewFlags {
-		viewKeysRaw := diff.Get(VIEW_KEYS)
-		viewKeys, ok := viewKeysRaw.(*schema.Set)
-		if !ok || viewKeys == nil || viewKeys.Len() == 0 {
+		viewKeys := optionalSchemaSetFromInterface(diff.Get(VIEW_KEYS))
+		if viewKeys == nil || viewKeys.Len() == 0 {
 			return fmt.Errorf("project %q requires new flags to be associated with at least one view. Please set the 'view_keys' attribute", projectKey)
 		}
 	}
@@ -85,17 +84,17 @@ func resourceFeatureFlagCreate(ctx context.Context, d *schema.ResourceData, meta
 	description := d.Get(DESCRIPTION).(string)
 	flagName := d.Get(NAME).(string)
 	tags := stringsFromResourceData(d, TAGS)
-	includeInSnippet := d.Get(INCLUDE_IN_SNIPPET).(bool)
+	includeInSnippet := optionalBoolFromResourceData(d, INCLUDE_IN_SNIPPET, false)
 	// GetOkExists is 'deprecated', but needed as optional booleans set to false return a 'false' ok value from GetOk
 	// Also not really deprecated as they are keeping it around pending a replacement https://github.com/hashicorp/terraform-plugin-sdk/pull/350#issuecomment-597888969
 	//nolint:staticcheck // SA1019
 	_, includeInSnippetOk := d.GetOkExists(INCLUDE_IN_SNIPPET)
 	_, clientSideAvailabilityOk := d.GetOk(CLIENT_SIDE_AVAILABILITY)
 	clientSideAvailability := &ldapi.ClientSideAvailabilityPost{
-		UsingEnvironmentId: d.Get("client_side_availability.0.using_environment_id").(bool),
-		UsingMobileKey:     d.Get("client_side_availability.0.using_mobile_key").(bool),
+		UsingEnvironmentId: optionalBoolFromResourceData(d, "client_side_availability.0.using_environment_id", false),
+		UsingMobileKey:     optionalBoolFromResourceData(d, "client_side_availability.0.using_mobile_key", false),
 	}
-	temporary := d.Get(TEMPORARY).(bool)
+	temporary := optionalBoolFromResourceData(d, TEMPORARY, false)
 
 	variations, err := variationsFromResourceData(d)
 	if err != nil {
@@ -140,9 +139,10 @@ func resourceFeatureFlagCreate(ctx context.Context, d *schema.ResourceData, meta
 	// Check if view_keys is specified - if so, we need to use raw HTTP to include it in creation
 	var viewKeys []string
 	if viewKeysRaw, ok := d.GetOk(VIEW_KEYS); ok {
-		viewKeysSet := viewKeysRaw.(*schema.Set)
-		for _, v := range viewKeysSet.List() {
-			viewKeys = append(viewKeys, v.(string))
+		if viewKeysSet := optionalSchemaSetFromInterface(viewKeysRaw); viewKeysSet != nil {
+			for _, v := range viewKeysSet.List() {
+				viewKeys = append(viewKeys, v.(string))
+			}
 		}
 	}
 
@@ -218,7 +218,7 @@ func featureFlagUpdate(ctx context.Context, d *schema.ResourceData, metaRaw inte
 	description := d.Get(DESCRIPTION).(string)
 	name := d.Get(NAME).(string)
 	tags := stringsFromResourceData(d, TAGS)
-	includeInSnippet := d.Get(INCLUDE_IN_SNIPPET).(bool)
+	includeInSnippet := optionalBoolFromResourceData(d, INCLUDE_IN_SNIPPET, false)
 
 	snippetHasChange := d.HasChange(INCLUDE_IN_SNIPPET)
 	clientSideHasChange := d.HasChange(CLIENT_SIDE_AVAILABILITY)
@@ -227,13 +227,13 @@ func featureFlagUpdate(ctx context.Context, d *schema.ResourceData, metaRaw inte
 	//nolint:staticcheck // SA1019
 	_, includeInSnippetOk := d.GetOkExists(INCLUDE_IN_SNIPPET)
 	_, clientSideAvailabilityOk := d.GetOk(CLIENT_SIDE_AVAILABILITY)
-	temporary := d.Get(TEMPORARY).(bool)
+	temporary := optionalBoolFromResourceData(d, TEMPORARY, false)
 	customProperties := customPropertiesFromResourceData(d)
-	archived := d.Get(ARCHIVED).(bool)
-	deprecated := d.Get(DEPRECATED).(bool)
+	archived := optionalBoolFromResourceData(d, ARCHIVED, false)
+	deprecated := optionalBoolFromResourceData(d, DEPRECATED, false)
 	clientSideAvailability := &ldapi.ClientSideAvailabilityPost{
-		UsingEnvironmentId: d.Get("client_side_availability.0.using_environment_id").(bool),
-		UsingMobileKey:     d.Get("client_side_availability.0.using_mobile_key").(bool),
+		UsingEnvironmentId: optionalBoolFromResourceData(d, "client_side_availability.0.using_environment_id", false),
+		UsingMobileKey:     optionalBoolFromResourceData(d, "client_side_availability.0.using_mobile_key", false),
 	}
 
 	comment := "Terraform"
@@ -342,7 +342,7 @@ func featureFlagUpdate(ctx context.Context, d *schema.ResourceData, metaRaw inte
 				return diag.Errorf("failed to create beta client for view linking: %v", err)
 			}
 
-			desiredViewKeys := interfaceSliceToStringSlice(viewKeysRaw.(*schema.Set).List())
+			desiredViewKeys := stringListFromOptionalSetValue(viewKeysRaw)
 
 			// Validate that all specified views exist
 			for _, viewKey := range desiredViewKeys {
@@ -371,7 +371,7 @@ func featureFlagUpdate(ctx context.Context, d *schema.ResourceData, metaRaw inte
 			if len(viewsToRemove) > 0 && !isCreate {
 				oldViewKeysRaw, _ := d.GetChange(VIEW_KEYS)
 				if oldViewKeysRaw != nil {
-					oldViewKeys := interfaceSliceToStringSlice(oldViewKeysRaw.(*schema.Set).List())
+					oldViewKeys := stringListFromOptionalSetValue(oldViewKeysRaw)
 					unexpectedViews := difference(viewsToRemove, oldViewKeys)
 					if len(unexpectedViews) > 0 {
 						log.Printf(
@@ -409,7 +409,7 @@ func featureFlagUpdate(ctx context.Context, d *schema.ResourceData, metaRaw inte
 
 			oldViewKeysRaw, _ := d.GetChange(VIEW_KEYS)
 			if oldViewKeysRaw != nil {
-				oldViewKeys := interfaceSliceToStringSlice(oldViewKeysRaw.(*schema.Set).List())
+				oldViewKeys := stringListFromOptionalSetValue(oldViewKeysRaw)
 				for _, viewKey := range oldViewKeys {
 					err = unlinkResourcesFromView(betaClient, projectKey, viewKey, FLAGS, []string{key})
 					if err != nil {

--- a/launchdarkly/resource_launchdarkly_feature_flag.go
+++ b/launchdarkly/resource_launchdarkly_feature_flag.go
@@ -81,7 +81,7 @@ func resourceFeatureFlagCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	key := d.Get(KEY).(string)
-	description := d.Get(DESCRIPTION).(string)
+	description := trimmedStringAttr(d, DESCRIPTION)
 	flagName := d.Get(NAME).(string)
 	tags := stringsFromResourceData(d, TAGS)
 	includeInSnippet := optionalBoolFromResourceData(d, INCLUDE_IN_SNIPPET, false)
@@ -215,7 +215,7 @@ func featureFlagUpdate(ctx context.Context, d *schema.ResourceData, metaRaw inte
 	client := metaRaw.(*Client)
 	key := d.Get(KEY).(string)
 	projectKey := d.Get(PROJECT_KEY).(string)
-	description := d.Get(DESCRIPTION).(string)
+	description := trimmedStringAttr(d, DESCRIPTION)
 	name := d.Get(NAME).(string)
 	tags := stringsFromResourceData(d, TAGS)
 	includeInSnippet := optionalBoolFromResourceData(d, INCLUDE_IN_SNIPPET, false)

--- a/launchdarkly/resource_launchdarkly_feature_flag.go
+++ b/launchdarkly/resource_launchdarkly_feature_flag.go
@@ -81,7 +81,7 @@ func resourceFeatureFlagCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	key := d.Get(KEY).(string)
-	description := trimmedStringAttr(d, DESCRIPTION)
+	description := optionalStringAttr(d, DESCRIPTION)
 	flagName := d.Get(NAME).(string)
 	tags := stringsFromResourceData(d, TAGS)
 	includeInSnippet := optionalBoolFromResourceData(d, INCLUDE_IN_SNIPPET, false)
@@ -215,7 +215,7 @@ func featureFlagUpdate(ctx context.Context, d *schema.ResourceData, metaRaw inte
 	client := metaRaw.(*Client)
 	key := d.Get(KEY).(string)
 	projectKey := d.Get(PROJECT_KEY).(string)
-	description := trimmedStringAttr(d, DESCRIPTION)
+	description := optionalStringAttr(d, DESCRIPTION)
 	name := d.Get(NAME).(string)
 	tags := stringsFromResourceData(d, TAGS)
 	includeInSnippet := optionalBoolFromResourceData(d, INCLUDE_IN_SNIPPET, false)

--- a/launchdarkly/resource_launchdarkly_feature_flag_environment.go
+++ b/launchdarkly/resource_launchdarkly_feature_flag_environment.go
@@ -81,9 +81,10 @@ func resourceFeatureFlagEnvironmentCreate(ctx context.Context, d *schema.Resourc
 	offVariation := d.Get(OFF_VARIATION)
 	patches = append(patches, patchReplace(patchFlagEnvPath(d, "offVariation"), offVariation.(int)))
 
-	trackEvents, ok := d.GetOk(TRACK_EVENTS)
+	_, ok := d.GetOk(TRACK_EVENTS)
 	if ok {
-		patches = append(patches, patchReplace(patchFlagEnvPath(d, "trackEvents"), trackEvents.(bool)))
+		trackEvents := optionalBoolFromResourceData(d, TRACK_EVENTS, false)
+		patches = append(patches, patchReplace(patchFlagEnvPath(d, "trackEvents"), trackEvents))
 	}
 
 	_, ok = d.GetOk(RULES)
@@ -188,7 +189,7 @@ func resourceFeatureFlagEnvironmentUpdate(ctx context.Context, d *schema.Resourc
 	}
 
 	if d.HasChange(TRACK_EVENTS) {
-		trackEvents := d.Get(TRACK_EVENTS).(bool)
+		trackEvents := optionalBoolFromResourceData(d, TRACK_EVENTS, false)
 		patchOperations = append(patchOperations, patchReplace(patchFlagEnvPath(d, "trackEvents"), trackEvents))
 	}
 

--- a/launchdarkly/resource_launchdarkly_feature_flag_environment.go
+++ b/launchdarkly/resource_launchdarkly_feature_flag_environment.go
@@ -49,7 +49,12 @@ func resourceFeatureFlagEnvironmentCreate(ctx context.Context, d *schema.Resourc
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	envKey := d.Get(ENV_KEY).(string)
+	envKey := effectiveEnvKeyFromIDOrAttr(d)
+	if envKey == "" {
+		return diag.Errorf(
+			"%s is required and must be the LaunchDarkly environment key (not the display name). If the embedded schema omits it, set resource id to project_key/env_key/flag_key before create.",
+			ENV_KEY)
+	}
 
 	if exists, err := projectExists(projectKey, client); !exists {
 		if err != nil {
@@ -62,7 +67,9 @@ func resourceFeatureFlagEnvironmentCreate(ctx context.Context, d *schema.Resourc
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		return diag.Errorf("failed to find environment with key %q", envKey)
+		return diag.Errorf(
+			"environment %q not found in project %q — env_key must be the LaunchDarkly environment **key**, not its display name. Create the environment first.",
+			envKey, projectKey)
 	}
 
 	patches := make([]ldapi.PatchOperation, 0)
@@ -145,7 +152,10 @@ func resourceFeatureFlagEnvironmentUpdate(ctx context.Context, d *schema.Resourc
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	envKey := d.Get(ENV_KEY).(string)
+	envKey := effectiveEnvKeyFromIDOrAttr(d)
+	if envKey == "" {
+		return diag.Errorf("%s is empty and resource id %q is not project_key/env_key/flag_key", ENV_KEY, d.Id())
+	}
 
 	if exists, err := projectExists(projectKey, client); !exists {
 		if err != nil {
@@ -158,7 +168,9 @@ func resourceFeatureFlagEnvironmentUpdate(ctx context.Context, d *schema.Resourc
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		return diag.Errorf("failed to find environment with key %q", envKey)
+		return diag.Errorf(
+			"environment %q not found in project %q — env_key must be the LaunchDarkly environment **key**. Create the environment first or correct env_key.",
+			envKey, projectKey)
 	}
 
 	patchOperations := make([]ldapi.PatchOperation, 0, 7)
@@ -234,7 +246,10 @@ func resourceFeatureFlagEnvironmentDelete(ctx context.Context, d *schema.Resourc
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	envKey := d.Get(ENV_KEY).(string)
+	envKey := effectiveEnvKeyFromIDOrAttr(d)
+	if envKey == "" {
+		return diag.Errorf("%s is empty and resource id %q is not project_key/env_key/flag_key", ENV_KEY, d.Id())
+	}
 
 	if exists, err := projectExists(projectKey, client); !exists {
 		if err != nil {
@@ -247,7 +262,9 @@ func resourceFeatureFlagEnvironmentDelete(ctx context.Context, d *schema.Resourc
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		return diag.Errorf("failed to find environment with key %q", envKey)
+		return diag.Errorf(
+			"environment %q not found in project %q — env_key must be the LaunchDarkly environment **key**.",
+			envKey, projectKey)
 	}
 
 	var flag *ldapi.FeatureFlag
@@ -299,7 +316,9 @@ func resourceFeatureFlagEnvironmentImport(d *schema.ResourceData, meta interface
 		return nil, fmt.Errorf("found unexpected flag id format: %q expected format: 'project_key/env_key/flag_key'", id)
 	}
 	parts := strings.SplitN(id, "/", 3)
-	projectKey, envKey, flagKey := parts[0], parts[1], parts[2]
+	projectKey := strings.TrimSpace(parts[0])
+	envKey := strings.TrimSpace(parts[1])
+	flagKey := strings.TrimSpace(parts[2])
 	_ = d.Set(FLAG_ID, projectKey+"/"+flagKey)
 	_ = d.Set(ENV_KEY, envKey)
 

--- a/launchdarkly/resource_launchdarkly_ip_allowlist_config.go
+++ b/launchdarkly/resource_launchdarkly_ip_allowlist_config.go
@@ -49,8 +49,8 @@ This resource allows you to manage the IP allowlist configuration for your Launc
 func resourceIpAllowlistConfigCreate(ctx context.Context, d *schema.ResourceData, metaRaw interface{}) diag.Diagnostics {
 	client := metaRaw.(*Client)
 
-	sessionEnabled := d.Get(SESSION_ALLOWLIST_ENABLED).(bool)
-	scopedEnabled := d.Get(SCOPED_ALLOWLIST_ENABLED).(bool)
+	sessionEnabled := optionalBoolFromResourceData(d, SESSION_ALLOWLIST_ENABLED, false)
+	scopedEnabled := optionalBoolFromResourceData(d, SCOPED_ALLOWLIST_ENABLED, false)
 
 	_, err := patchIpAllowlistConfig(client, &sessionEnabled, &scopedEnabled)
 	if err != nil {
@@ -80,8 +80,8 @@ func resourceIpAllowlistConfigRead(ctx context.Context, d *schema.ResourceData, 
 func resourceIpAllowlistConfigUpdate(ctx context.Context, d *schema.ResourceData, metaRaw interface{}) diag.Diagnostics {
 	client := metaRaw.(*Client)
 
-	sessionEnabled := d.Get(SESSION_ALLOWLIST_ENABLED).(bool)
-	scopedEnabled := d.Get(SCOPED_ALLOWLIST_ENABLED).(bool)
+	sessionEnabled := optionalBoolFromResourceData(d, SESSION_ALLOWLIST_ENABLED, false)
+	scopedEnabled := optionalBoolFromResourceData(d, SCOPED_ALLOWLIST_ENABLED, false)
 
 	_, err := patchIpAllowlistConfig(client, &sessionEnabled, &scopedEnabled)
 	if err != nil {

--- a/launchdarkly/resource_launchdarkly_ip_allowlist_entry.go
+++ b/launchdarkly/resource_launchdarkly_ip_allowlist_entry.go
@@ -93,7 +93,7 @@ func resourceIpAllowlistEntryUpdate(ctx context.Context, d *schema.ResourceData,
 	client := metaRaw.(*Client)
 
 	if d.HasChange(DESCRIPTION) {
-		description := d.Get(DESCRIPTION).(string)
+		description := trimmedStringAttr(d, DESCRIPTION)
 		_, err := patchIpAllowlistEntry(client, d.Id(), description)
 		if err != nil {
 			return diag.Errorf("failed to update IP allowlist entry %q: %s", d.Id(), err)

--- a/launchdarkly/resource_launchdarkly_ip_allowlist_entry.go
+++ b/launchdarkly/resource_launchdarkly_ip_allowlist_entry.go
@@ -93,7 +93,7 @@ func resourceIpAllowlistEntryUpdate(ctx context.Context, d *schema.ResourceData,
 	client := metaRaw.(*Client)
 
 	if d.HasChange(DESCRIPTION) {
-		description := trimmedStringAttr(d, DESCRIPTION)
+		description := optionalStringAttr(d, DESCRIPTION)
 		_, err := patchIpAllowlistEntry(client, d.Id(), description)
 		if err != nil {
 			return diag.Errorf("failed to update IP allowlist entry %q: %s", d.Id(), err)

--- a/launchdarkly/resource_launchdarkly_metric.go
+++ b/launchdarkly/resource_launchdarkly_metric.go
@@ -22,14 +22,14 @@ func customizeMetricDiff(ctx context.Context, diff *schema.ResourceDiff, v inter
 
 	// Kind enum is validated using validateFunc
 	kindInConfig := diff.Get(KIND).(string)
-	selectorInConfig := config.GetAttr(SELECTOR)
-	urlsInConfig := config.GetAttr(URLS)
-	successCriteriaInConfig := config.GetAttr(SUCCESS_CRITERIA)
-	unitInConfig := config.GetAttr(UNIT)
-	eventKeyInConfig := config.GetAttr(EVENT_KEY)
+	selectorInConfig := ctyObjectGetAttr(config, SELECTOR)
+	urlsInConfig := ctyObjectGetAttr(config, URLS)
+	successCriteriaInConfig := ctyObjectGetAttr(config, SUCCESS_CRITERIA)
+	unitInConfig := ctyObjectGetAttr(config, UNIT)
+	eventKeyInConfig := ctyObjectGetAttr(config, EVENT_KEY)
 	analysisTypeInConfig := diff.Get(ANALYSIS_TYPE).(string)
-	percentileValueInConfig := config.GetAttr(PERCENTILE_VALUE)
-	includeUnitsWithoutEventsInConfig := config.GetAttr(INCLUDE_UNITS_WITHOUT_EVENTS)
+	percentileValueInConfig := ctyObjectGetAttr(config, PERCENTILE_VALUE)
+	includeUnitsWithoutEventsInConfig := ctyObjectGetAttr(config, INCLUDE_UNITS_WITHOUT_EVENTS)
 
 	// Different validation logic depending on which kind of metric we are creating
 	switch kindInConfig {
@@ -38,7 +38,7 @@ func customizeMetricDiff(ctx context.Context, diff *schema.ResourceDiff, v inter
 			return fmt.Errorf("click metrics require 'selector' to be set")
 		}
 		// If we have no keys in the URLS block in the config (length is 0) we know the customer hasn't set any URL values
-		urlsSlice := urlsInConfig.AsValueSlice()
+		urlsSlice := ctyValueListElements(urlsInConfig)
 		if len(urlsSlice) == 0 {
 			return fmt.Errorf("click metrics require an 'urls' block to be set")
 		}
@@ -65,9 +65,9 @@ func customizeMetricDiff(ctx context.Context, diff *schema.ResourceDiff, v inter
 				return err
 			}
 		}
-		isNumericInConfig := config.GetAttr(IS_NUMERIC)
+		isNumericInConfig := ctyObjectGetAttr(config, IS_NUMERIC)
 		// numeric custom metrics have extra required fields
-		if isNumericInConfig.True() {
+		if ctyBoolTrue(isNumericInConfig) {
 			if successCriteriaInConfig.IsNull() {
 				return fmt.Errorf("numeric custom metrics require 'success_criteria' to be set")
 
@@ -80,7 +80,7 @@ func customizeMetricDiff(ctx context.Context, diff *schema.ResourceDiff, v inter
 			return fmt.Errorf("custom meterics require 'event_key' to be set")
 		}
 		// Disallow keys specific to other 'kind' values - these updates are ignored by the backend and lead to misleading plans being generated
-		urlsSlice := urlsInConfig.AsValueSlice()
+		urlsSlice := ctyValueListElements(urlsInConfig)
 		if len(urlsSlice) != 0 {
 			return fmt.Errorf("custom metrics do not accept a 'urls' block")
 		}
@@ -89,7 +89,7 @@ func customizeMetricDiff(ctx context.Context, diff *schema.ResourceDiff, v inter
 		}
 	case "pageview":
 		// If we have no keys in the URLS block in the config (length is 0) we know the customer hasn't set any URL values
-		urlsSlice := urlsInConfig.AsValueSlice()
+		urlsSlice := ctyValueListElements(urlsInConfig)
 		if len(urlsSlice) == 0 {
 			return fmt.Errorf("pageview metrics require an 'urls' block to be set")
 		}
@@ -119,7 +119,7 @@ func customizeMetricDiff(ctx context.Context, diff *schema.ResourceDiff, v inter
 		if percentileValueInConfig.IsNull() {
 			return fmt.Errorf("percentile_value is required when analysis_type is percentile")
 		}
-		if includeUnitsWithoutEventsInConfig.True() {
+		if ctyBoolTrue(includeUnitsWithoutEventsInConfig) {
 			return fmt.Errorf("include_units_without_events is not supported for percentile metrics")
 		}
 	} else if !percentileValueInConfig.IsNull() {

--- a/launchdarkly/resource_launchdarkly_metric.go
+++ b/launchdarkly/resource_launchdarkly_metric.go
@@ -189,18 +189,18 @@ func resourceMetricCreate(ctx context.Context, d *schema.ResourceData, metaRaw i
 	key := d.Get(KEY).(string)
 	name := d.Get(NAME).(string)
 	kind := d.Get(KIND).(string)
-	description := d.Get(DESCRIPTION).(string)
+	description := trimmedStringAttr(d, DESCRIPTION)
 	tags := stringsFromResourceData(d, TAGS)
-	isNumeric := d.Get(IS_NUMERIC).(bool)
+	isNumeric := optionalBoolFromResourceData(d, IS_NUMERIC, false)
 	urls := metricUrlsFromResourceData(d)
 	randomizationUnits := stringsFromResourceData(d, RANDOMIZATION_UNITS)
 	// Required depending on type
-	unit := d.Get(UNIT).(string)
-	selector := d.Get(SELECTOR).(string)
-	eventKey := d.Get(EVENT_KEY).(string)
-	unitAggregationType := d.Get(UNIT_AGGREGATION_TYPE).(string)
-	analysisType := d.Get(ANALYSIS_TYPE).(string)
-	includeUnitsWithoutEvents := d.Get(INCLUDE_UNITS_WITHOUT_EVENTS).(bool)
+	unit := trimmedStringAttr(d, UNIT)
+	selector := trimmedStringAttr(d, SELECTOR)
+	eventKey := trimmedStringAttr(d, EVENT_KEY)
+	unitAggregationType := trimmedStringAttr(d, UNIT_AGGREGATION_TYPE)
+	analysisType := trimmedStringAttr(d, ANALYSIS_TYPE)
+	includeUnitsWithoutEvents := optionalBoolFromResourceData(d, INCLUDE_UNITS_WITHOUT_EVENTS, false)
 	eventDefaultDisabled := !includeUnitsWithoutEvents
 
 	metric := ldapi.MetricPost{
@@ -227,7 +227,7 @@ func resourceMetricCreate(ctx context.Context, d *schema.ResourceData, metaRaw i
 	// Only add successCriteria if it has a value - empty string causes API errors
 	_, ok := d.GetOk(SUCCESS_CRITERIA)
 	if ok {
-		successCriteria := d.Get(SUCCESS_CRITERIA).(string)
+		successCriteria := trimmedStringAttr(d, SUCCESS_CRITERIA)
 		metric.SuccessCriteria = &successCriteria
 	} else {
 		if kind == "custom" {
@@ -296,18 +296,18 @@ func resourceMetricUpdate(ctx context.Context, d *schema.ResourceData, metaRaw i
 	key := d.Get(KEY).(string)
 	name := d.Get(NAME).(string)
 	kind := d.Get(KIND).(string)
-	description := d.Get(DESCRIPTION).(string)
+	description := trimmedStringAttr(d, DESCRIPTION)
 	tags := stringsFromResourceData(d, TAGS)
-	isActive := d.Get(IS_ACTIVE).(bool)
-	isNumeric := d.Get(IS_NUMERIC).(bool)
+	isActive := optionalBoolFromResourceData(d, IS_ACTIVE, false)
+	isNumeric := optionalBoolFromResourceData(d, IS_NUMERIC, false)
 	urls := metricUrlsFromResourceData(d)
 	// Required depending on type
-	unit := d.Get(UNIT).(string)
-	selector := d.Get(SELECTOR).(string)
-	eventKey := d.Get(EVENT_KEY).(string)
-	unitAggregationType := d.Get(UNIT_AGGREGATION_TYPE).(string)
-	analysisType := d.Get(ANALYSIS_TYPE).(string)
-	includeUnitsWithoutEvents := d.Get(INCLUDE_UNITS_WITHOUT_EVENTS).(bool)
+	unit := trimmedStringAttr(d, UNIT)
+	selector := trimmedStringAttr(d, SELECTOR)
+	eventKey := trimmedStringAttr(d, EVENT_KEY)
+	unitAggregationType := trimmedStringAttr(d, UNIT_AGGREGATION_TYPE)
+	analysisType := trimmedStringAttr(d, ANALYSIS_TYPE)
+	includeUnitsWithoutEvents := optionalBoolFromResourceData(d, INCLUDE_UNITS_WITHOUT_EVENTS, false)
 
 	patch := []ldapi.PatchOperation{
 		patchReplace("/name", name),

--- a/launchdarkly/resource_launchdarkly_metric.go
+++ b/launchdarkly/resource_launchdarkly_metric.go
@@ -189,17 +189,17 @@ func resourceMetricCreate(ctx context.Context, d *schema.ResourceData, metaRaw i
 	key := d.Get(KEY).(string)
 	name := d.Get(NAME).(string)
 	kind := d.Get(KIND).(string)
-	description := trimmedStringAttr(d, DESCRIPTION)
+	description := optionalStringAttr(d, DESCRIPTION)
 	tags := stringsFromResourceData(d, TAGS)
 	isNumeric := optionalBoolFromResourceData(d, IS_NUMERIC, false)
 	urls := metricUrlsFromResourceData(d)
 	randomizationUnits := stringsFromResourceData(d, RANDOMIZATION_UNITS)
 	// Required depending on type
-	unit := trimmedStringAttr(d, UNIT)
-	selector := trimmedStringAttr(d, SELECTOR)
-	eventKey := trimmedStringAttr(d, EVENT_KEY)
-	unitAggregationType := trimmedStringAttr(d, UNIT_AGGREGATION_TYPE)
-	analysisType := trimmedStringAttr(d, ANALYSIS_TYPE)
+	unit := optionalStringAttr(d, UNIT)
+	selector := optionalStringAttr(d, SELECTOR)
+	eventKey := optionalStringAttr(d, EVENT_KEY)
+	unitAggregationType := optionalStringAttr(d, UNIT_AGGREGATION_TYPE)
+	analysisType := optionalStringAttr(d, ANALYSIS_TYPE)
 	includeUnitsWithoutEvents := optionalBoolFromResourceData(d, INCLUDE_UNITS_WITHOUT_EVENTS, false)
 	eventDefaultDisabled := !includeUnitsWithoutEvents
 
@@ -227,7 +227,7 @@ func resourceMetricCreate(ctx context.Context, d *schema.ResourceData, metaRaw i
 	// Only add successCriteria if it has a value - empty string causes API errors
 	_, ok := d.GetOk(SUCCESS_CRITERIA)
 	if ok {
-		successCriteria := trimmedStringAttr(d, SUCCESS_CRITERIA)
+		successCriteria := optionalStringAttr(d, SUCCESS_CRITERIA)
 		metric.SuccessCriteria = &successCriteria
 	} else {
 		if kind == "custom" {
@@ -296,17 +296,17 @@ func resourceMetricUpdate(ctx context.Context, d *schema.ResourceData, metaRaw i
 	key := d.Get(KEY).(string)
 	name := d.Get(NAME).(string)
 	kind := d.Get(KIND).(string)
-	description := trimmedStringAttr(d, DESCRIPTION)
+	description := optionalStringAttr(d, DESCRIPTION)
 	tags := stringsFromResourceData(d, TAGS)
 	isActive := optionalBoolFromResourceData(d, IS_ACTIVE, false)
 	isNumeric := optionalBoolFromResourceData(d, IS_NUMERIC, false)
 	urls := metricUrlsFromResourceData(d)
 	// Required depending on type
-	unit := trimmedStringAttr(d, UNIT)
-	selector := trimmedStringAttr(d, SELECTOR)
-	eventKey := trimmedStringAttr(d, EVENT_KEY)
-	unitAggregationType := trimmedStringAttr(d, UNIT_AGGREGATION_TYPE)
-	analysisType := trimmedStringAttr(d, ANALYSIS_TYPE)
+	unit := optionalStringAttr(d, UNIT)
+	selector := optionalStringAttr(d, SELECTOR)
+	eventKey := optionalStringAttr(d, EVENT_KEY)
+	unitAggregationType := optionalStringAttr(d, UNIT_AGGREGATION_TYPE)
+	analysisType := optionalStringAttr(d, ANALYSIS_TYPE)
 	includeUnitsWithoutEvents := optionalBoolFromResourceData(d, INCLUDE_UNITS_WITHOUT_EVENTS, false)
 
 	patch := []ldapi.PatchOperation{

--- a/launchdarkly/resource_launchdarkly_model_config.go
+++ b/launchdarkly/resource_launchdarkly_model_config.go
@@ -73,7 +73,7 @@ func resourceModelConfigCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if v, ok := d.GetOk(TAGS); ok {
-		post.Tags = interfaceSliceToStringSlice(v.(*schema.Set).List())
+		post.Tags = stringsFromSchemaSet(optionalSchemaSetFromInterface(v))
 	}
 
 	if v, ok := d.GetOk(COST_PER_INPUT_TOKEN); ok {

--- a/launchdarkly/resource_launchdarkly_project.go
+++ b/launchdarkly/resource_launchdarkly_project.go
@@ -282,13 +282,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, metaRaw 
 	}
 
 	environmentConfigs := interfaceSliceFromAny(newSchemaEnvList)
-	if environmentConfigs == nil {
-		environmentConfigs = []interface{}{}
-	}
 	oldEnvironmentConfigs := interfaceSliceFromAny(oldSchemaEnvList)
-	if oldEnvironmentConfigs == nil {
-		oldEnvironmentConfigs = []interface{}{}
-	}
 	oldEnvConfigsForCompare := make(map[string]map[string]interface{}, len(oldEnvironmentConfigs))
 	for _, env := range oldEnvironmentConfigs {
 		envConfig := env.(map[string]interface{})
@@ -337,9 +331,6 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, metaRaw 
 	// we also want to delete environments that were previously tracked in state and have been removed from the config
 	old, _ := d.GetChange(ENVIRONMENTS)
 	oldEnvs := interfaceSliceFromAny(old)
-	if oldEnvs == nil {
-		oldEnvs = []interface{}{}
-	}
 	for _, env := range oldEnvs {
 		envConfig := env.(map[string]interface{})
 		envKey := envConfig[KEY].(string)

--- a/launchdarkly/resource_launchdarkly_project.go
+++ b/launchdarkly/resource_launchdarkly_project.go
@@ -16,12 +16,21 @@ import (
 func customizeProjectDiff(ctx context.Context, diff *schema.ResourceDiff, v interface{}) error {
 	config := diff.GetRawConfig()
 
-	// Below values will exist due to the schema, we need to check if they are all null
-	snippetInConfig := config.GetAttr(INCLUDE_IN_SNIPPET)
-	csaInConfig := config.GetAttr(DEFAULT_CLIENT_SIDE_AVAILABILITY)
+	// Upjet may omit both deprecated IIS/CSA attributes from the embedded schema entirely; skip this
+	// CustomizeDiff workaround when neither appears on the raw config object type (avoids SetNew noise).
+	if ty := config.Type(); ty.IsObjectType() {
+		if !ty.HasAttribute(INCLUDE_IN_SNIPPET) && !ty.HasAttribute(DEFAULT_CLIENT_SIDE_AVAILABILITY) {
+			return nil
+		}
+	}
+
+	// Below values will exist due to the schema, we need to check if they are all null.
+	// Use safe cty access for embedded providers (Upjet) where raw config may omit attributes.
+	snippetInConfig := ctyObjectGetAttr(config, INCLUDE_IN_SNIPPET)
+	csaInConfig := ctyObjectGetAttr(config, DEFAULT_CLIENT_SIDE_AVAILABILITY)
 
 	// If we have no keys in the CSA block in the config (length is 0) we know the customer hasn't set any CSA values
-	csaKeys := csaInConfig.AsValueSlice()
+	csaKeys := ctyValueListElements(csaInConfig)
 	if len(csaKeys) == 0 {
 		// When we have no values for either clienSideAvailability or includeInSnippet
 		// Force an UPDATE call by setting a new value for INCLUDE_IN_SNIPPET in the diff according to project defaults
@@ -33,11 +42,11 @@ func customizeProjectDiff(ctx context.Context, diff *schema.ResourceDiff, v inte
 			// AND the customer removes the INCLUDE_IN_SNIPPET key from the config without replacing with defaultCSA
 			// The read would assume no changes are needed, HOWEVER we need to jump back to LD set defaults
 			// Hence the setting below
-			err := diff.SetNew(INCLUDE_IN_SNIPPET, false)
+			err := resourceDiffSetNewSkipMissingKey(diff, INCLUDE_IN_SNIPPET, false)
 			if err != nil {
 				return err
 			}
-			err = diff.SetNew(DEFAULT_CLIENT_SIDE_AVAILABILITY, []map[string]interface{}{{
+			err = resourceDiffSetNewSkipMissingKey(diff, DEFAULT_CLIENT_SIDE_AVAILABILITY, []map[string]interface{}{{
 				USING_ENVIRONMENT_ID: false,
 				USING_MOBILE_KEY:     true,
 			}})
@@ -184,12 +193,12 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, metaRaw in
 	return projectRead(ctx, d, metaRaw, false)
 }
 
-func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, metaRaw interface{}) diag.Diagnostics {
-	client := metaRaw.(*Client)
-	projectKey := d.Get(KEY).(string)
+// buildProjectUpdatePatches assembles the JSON Patch document for resourceProjectUpdate.
+// Extracted so the CSA/IIS fallback decision can be unit-tested without a live LD client.
+func buildProjectUpdatePatches(d *schema.ResourceData) []ldapi.PatchOperation {
 	projName := d.Get(NAME)
 	projTags := stringsFromResourceData(d, TAGS)
-	includeInSnippet := d.Get(INCLUDE_IN_SNIPPET).(bool)
+	includeInSnippet := optionalBoolFromResourceData(d, INCLUDE_IN_SNIPPET, false)
 
 	snippetHasChange := d.HasChange(INCLUDE_IN_SNIPPET)
 	clientSideHasChange := d.HasChange(DEFAULT_CLIENT_SIDE_AVAILABILITY)
@@ -199,8 +208,8 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, metaRaw 
 	_, includeInSnippetOk := d.GetOkExists(INCLUDE_IN_SNIPPET)
 	_, clientSideAvailabilityOk := d.GetOk(DEFAULT_CLIENT_SIDE_AVAILABILITY)
 	defaultClientSideAvailability := &ldapi.ClientSideAvailabilityPost{
-		UsingEnvironmentId: d.Get(fmt.Sprintf("%s.0.using_environment_id", DEFAULT_CLIENT_SIDE_AVAILABILITY)).(bool),
-		UsingMobileKey:     d.Get(fmt.Sprintf("%s.0.using_mobile_key", DEFAULT_CLIENT_SIDE_AVAILABILITY)).(bool),
+		UsingEnvironmentId: optionalBoolFromResourceData(d, fmt.Sprintf("%s.0.using_environment_id", DEFAULT_CLIENT_SIDE_AVAILABILITY), false),
+		UsingMobileKey:     optionalBoolFromResourceData(d, fmt.Sprintf("%s.0.using_mobile_key", DEFAULT_CLIENT_SIDE_AVAILABILITY), false),
 	}
 
 	patch := []ldapi.PatchOperation{
@@ -208,21 +217,39 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, metaRaw 
 		patchReplace("/tags", &projTags),
 	}
 
-	if clientSideAvailabilityOk && clientSideHasChange {
+	// Upjet/embedded schemas may strip the deprecated INCLUDE_IN_SNIPPET and the
+	// DEFAULT_CLIENT_SIDE_AVAILABILITY block. In that case neither attribute is in the user's
+	// config and we must not append a fallback /defaultClientSideAvailability patch — doing so
+	// would overwrite server-side defaults on every "tags only" update.
+	schemaExposesCSAOrIIS := rawConfigHasAnyAttr(d.GetRawConfig(), INCLUDE_IN_SNIPPET, DEFAULT_CLIENT_SIDE_AVAILABILITY)
+
+	switch {
+	case clientSideAvailabilityOk && clientSideHasChange:
 		patch = append(patch, patchReplace("/defaultClientSideAvailability", defaultClientSideAvailability))
-	} else if includeInSnippetOk && snippetHasChange {
+	case includeInSnippetOk && snippetHasChange:
 		// If includeInSnippet is set, still use clientSideAvailability behind the scenes in order to switch UsingMobileKey to false if needed
 		patch = append(patch, patchReplace("/defaultClientSideAvailability", &ldapi.ClientSideAvailabilityPost{
 			UsingEnvironmentId: includeInSnippet,
 			UsingMobileKey:     true,
 		}))
-	} else {
-		// If the user doesn't set either CSA or IIS in config, we set defaults to match API behaviour
+	case schemaExposesCSAOrIIS:
+		// If the user doesn't set either CSA or IIS in config, we set defaults to match API behaviour.
+		// Only do this when the schema actually exposes those attributes; otherwise we'd overwrite
+		// server-side state that the user never opted into managing via Terraform.
 		patch = append(patch, patchReplace("/defaultClientSideAvailability", &ldapi.ClientSideAvailabilityPost{
 			UsingEnvironmentId: false,
 			UsingMobileKey:     true,
 		}))
 	}
+
+	return patch
+}
+
+func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, metaRaw interface{}) diag.Diagnostics {
+	client := metaRaw.(*Client)
+	projectKey := d.Get(KEY).(string)
+
+	patch := buildProjectUpdatePatches(d)
 
 	var err error
 	err = client.withConcurrency(client.ctx, func() error {
@@ -238,8 +265,8 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, metaRaw 
 	flagsRequiredChanged := d.HasChange(REQUIRE_VIEW_ASSOCIATION_FOR_NEW_FLAGS)
 	segmentsRequiredChanged := d.HasChange(REQUIRE_VIEW_ASSOCIATION_FOR_NEW_SEGMENTS)
 	if flagsRequiredChanged || segmentsRequiredChanged {
-		flagsRequired := d.Get(REQUIRE_VIEW_ASSOCIATION_FOR_NEW_FLAGS).(bool)
-		segmentsRequired := d.Get(REQUIRE_VIEW_ASSOCIATION_FOR_NEW_SEGMENTS).(bool)
+		flagsRequired := optionalBoolFromResourceData(d, REQUIRE_VIEW_ASSOCIATION_FOR_NEW_FLAGS, false)
+		segmentsRequired := optionalBoolFromResourceData(d, REQUIRE_VIEW_ASSOCIATION_FOR_NEW_SEGMENTS, false)
 		err = patchProjectViewSettings(ctx, client, projectKey, flagsRequired, segmentsRequired, flagsRequiredChanged, segmentsRequiredChanged)
 		if err != nil {
 			return diag.Errorf("failed to update view association settings for project %q: %s", projectKey, err)
@@ -254,8 +281,14 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, metaRaw 
 		return diag.Errorf("failed to load project %q before updating environments: %s", projectKey, handleLdapiErr(err))
 	}
 
-	environmentConfigs := newSchemaEnvList.([]interface{})
-	oldEnvironmentConfigs := oldSchemaEnvList.([]interface{})
+	environmentConfigs := interfaceSliceFromAny(newSchemaEnvList)
+	if environmentConfigs == nil {
+		environmentConfigs = []interface{}{}
+	}
+	oldEnvironmentConfigs := interfaceSliceFromAny(oldSchemaEnvList)
+	if oldEnvironmentConfigs == nil {
+		oldEnvironmentConfigs = []interface{}{}
+	}
 	oldEnvConfigsForCompare := make(map[string]map[string]interface{}, len(oldEnvironmentConfigs))
 	for _, env := range oldEnvironmentConfigs {
 		envConfig := env.(map[string]interface{})
@@ -303,7 +336,10 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, metaRaw 
 	}
 	// we also want to delete environments that were previously tracked in state and have been removed from the config
 	old, _ := d.GetChange(ENVIRONMENTS)
-	oldEnvs := old.([]interface{})
+	oldEnvs := interfaceSliceFromAny(old)
+	if oldEnvs == nil {
+		oldEnvs = []interface{}{}
+	}
 	for _, env := range oldEnvs {
 		envConfig := env.(map[string]interface{})
 		envKey := envConfig[KEY].(string)

--- a/launchdarkly/resource_launchdarkly_relay_proxy_configuration.go
+++ b/launchdarkly/resource_launchdarkly_relay_proxy_configuration.go
@@ -56,7 +56,7 @@ func relayProxyConfigCreate(ctx context.Context, d *schema.ResourceData, m inter
 	client := m.(*Client)
 
 	name := d.Get(NAME).(string)
-	policy, err := policyStatementsFromResourceData(d.Get(POLICY).([]interface{}))
+	policy, err := policyStatementsFromResourceData(getOptionalInterfaceSlice(d, POLICY))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -138,7 +138,7 @@ func relayProxyConfigUpdate(ctx context.Context, d *schema.ResourceData, m inter
 
 	id := d.Id()
 	name := d.Get(NAME).(string)
-	policy, err := policyStatementsFromResourceData(d.Get(POLICY).([]interface{}))
+	policy, err := policyStatementsFromResourceData(getOptionalInterfaceSlice(d, POLICY))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/launchdarkly/resource_launchdarkly_segment.go
+++ b/launchdarkly/resource_launchdarkly_segment.go
@@ -114,11 +114,11 @@ func resourceSegmentCreate(ctx context.Context, d *schema.ResourceData, metaRaw 
 	}
 
 	key := d.Get(KEY).(string)
-	description := trimmedStringAttr(d, DESCRIPTION)
+	description := optionalStringAttr(d, DESCRIPTION)
 	segmentName := d.Get(NAME).(string)
 	tags := stringsFromResourceData(d, TAGS)
 	unbounded := optionalBoolFromResourceData(d, UNBOUNDED, false)
-	unboundedContextKind := trimmedStringAttr(d, UNBOUNDED_CONTEXT_KIND)
+	unboundedContextKind := optionalStringAttr(d, UNBOUNDED_CONTEXT_KIND)
 
 	// Check if view_keys is specified - if so, we need to use raw HTTP to include it in creation
 	var viewKeys []string
@@ -190,7 +190,7 @@ func resourceSegmentUpdate(ctx context.Context, d *schema.ResourceData, metaRaw 
 	if envKey == "" {
 		return diag.Errorf("%s is empty and resource id %q is not project_key/env_key/segment_key", ENV_KEY, d.Id())
 	}
-	description := trimmedStringAttr(d, DESCRIPTION)
+	description := optionalStringAttr(d, DESCRIPTION)
 	name := d.Get(NAME).(string)
 	tags := stringsFromResourceData(d, TAGS)
 	included := getOptionalInterfaceSlice(d, INCLUDED)

--- a/launchdarkly/resource_launchdarkly_segment.go
+++ b/launchdarkly/resource_launchdarkly_segment.go
@@ -114,11 +114,11 @@ func resourceSegmentCreate(ctx context.Context, d *schema.ResourceData, metaRaw 
 	}
 
 	key := d.Get(KEY).(string)
-	description := d.Get(DESCRIPTION).(string)
+	description := trimmedStringAttr(d, DESCRIPTION)
 	segmentName := d.Get(NAME).(string)
 	tags := stringsFromResourceData(d, TAGS)
-	unbounded := d.Get(UNBOUNDED).(bool)
-	unboundedContextKind := d.Get(UNBOUNDED_CONTEXT_KIND).(string)
+	unbounded := optionalBoolFromResourceData(d, UNBOUNDED, false)
+	unboundedContextKind := trimmedStringAttr(d, UNBOUNDED_CONTEXT_KIND)
 
 	// Check if view_keys is specified - if so, we need to use raw HTTP to include it in creation
 	var viewKeys []string
@@ -190,7 +190,7 @@ func resourceSegmentUpdate(ctx context.Context, d *schema.ResourceData, metaRaw 
 	if envKey == "" {
 		return diag.Errorf("%s is empty and resource id %q is not project_key/env_key/segment_key", ENV_KEY, d.Id())
 	}
-	description := d.Get(DESCRIPTION).(string)
+	description := trimmedStringAttr(d, DESCRIPTION)
 	name := d.Get(NAME).(string)
 	tags := stringsFromResourceData(d, TAGS)
 	included := getOptionalInterfaceSlice(d, INCLUDED)

--- a/launchdarkly/resource_launchdarkly_segment.go
+++ b/launchdarkly/resource_launchdarkly_segment.go
@@ -31,9 +31,8 @@ func customizeSegmentDiff(ctx context.Context, diff *schema.ResourceDiff, meta i
 	}
 
 	if viewSettings.RequireViewAssociationForNewSegments {
-		viewKeysRaw := diff.Get(VIEW_KEYS)
-		viewKeys, ok := viewKeysRaw.(*schema.Set)
-		if !ok || viewKeys == nil || viewKeys.Len() == 0 {
+		viewKeys := optionalSchemaSetFromInterface(diff.Get(VIEW_KEYS))
+		if viewKeys == nil || viewKeys.Len() == 0 {
 			return fmt.Errorf("project %q requires new segments to be associated with at least one view. Please set the 'view_keys' attribute", projectKey)
 		}
 	}
@@ -92,7 +91,27 @@ This resource allows you to create and manage segments within your LaunchDarkly 
 func resourceSegmentCreate(ctx context.Context, d *schema.ResourceData, metaRaw interface{}) diag.Diagnostics {
 	client := metaRaw.(*Client)
 	projectKey := d.Get(PROJECT_KEY).(string)
-	envKey := d.Get(ENV_KEY).(string)
+	envKey := effectiveEnvKeyFromIDOrAttr(d)
+	if envKey == "" {
+		return diag.Errorf(
+			"%s is required (LaunchDarkly environment key). If the embedded schema omits it, set resource id to project_key/env_key/segment_key before create.",
+			ENV_KEY)
+	}
+
+	if exists, err := projectExists(projectKey, client); !exists {
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		return diag.Errorf("cannot find project with key %q", projectKey)
+	}
+	if exists, err := environmentExists(projectKey, envKey, client); !exists {
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		return diag.Errorf(
+			"environment %q not found in project %q — env_key must match the LaunchDarkly environment **key**. Create nested `environments` or a `launchdarkly_environment` first.",
+			envKey, projectKey)
+	}
 
 	key := d.Get(KEY).(string)
 	description := d.Get(DESCRIPTION).(string)
@@ -104,9 +123,10 @@ func resourceSegmentCreate(ctx context.Context, d *schema.ResourceData, metaRaw 
 	// Check if view_keys is specified - if so, we need to use raw HTTP to include it in creation
 	var viewKeys []string
 	if viewKeysRaw, ok := d.GetOk(VIEW_KEYS); ok {
-		viewKeysSet := viewKeysRaw.(*schema.Set)
-		for _, v := range viewKeysSet.List() {
-			viewKeys = append(viewKeys, v.(string))
+		if viewKeysSet := optionalSchemaSetFromInterface(viewKeysRaw); viewKeysSet != nil {
+			for _, v := range viewKeysSet.List() {
+				viewKeys = append(viewKeys, v.(string))
+			}
 		}
 	}
 
@@ -166,12 +186,15 @@ func resourceSegmentUpdate(ctx context.Context, d *schema.ResourceData, metaRaw 
 	client := metaRaw.(*Client)
 	key := d.Get(KEY).(string)
 	projectKey := d.Get(PROJECT_KEY).(string)
-	envKey := d.Get(ENV_KEY).(string)
+	envKey := effectiveEnvKeyFromIDOrAttr(d)
+	if envKey == "" {
+		return diag.Errorf("%s is empty and resource id %q is not project_key/env_key/segment_key", ENV_KEY, d.Id())
+	}
 	description := d.Get(DESCRIPTION).(string)
 	name := d.Get(NAME).(string)
 	tags := stringsFromResourceData(d, TAGS)
-	included := d.Get(INCLUDED).([]interface{})
-	excluded := d.Get(EXCLUDED).([]interface{})
+	included := getOptionalInterfaceSlice(d, INCLUDED)
+	excluded := getOptionalInterfaceSlice(d, EXCLUDED)
 	includedContexts := segmentTargetsFromResourceData(d, segmentTargetOptions{Included: true})
 	excludedContexts := segmentTargetsFromResourceData(d, segmentTargetOptions{Excluded: true})
 	rules, err := segmentRulesFromResourceData(d, RULES)
@@ -214,7 +237,7 @@ func resourceSegmentUpdate(ctx context.Context, d *schema.ResourceData, metaRaw 
 				return diag.Errorf("failed to create beta client for view linking: %v", err)
 			}
 
-			desiredViewKeys := interfaceSliceToStringSlice(viewKeysRaw.(*schema.Set).List())
+			desiredViewKeys := stringListFromOptionalSetValue(viewKeysRaw)
 
 			// Get the environment ID
 			var env *ldapi.Environment
@@ -253,7 +276,7 @@ func resourceSegmentUpdate(ctx context.Context, d *schema.ResourceData, metaRaw 
 			if len(viewsToRemove) > 0 {
 				oldViewKeysRaw, _ := d.GetChange(VIEW_KEYS)
 				if oldViewKeysRaw != nil {
-					oldViewKeys := interfaceSliceToStringSlice(oldViewKeysRaw.(*schema.Set).List())
+					oldViewKeys := stringListFromOptionalSetValue(oldViewKeysRaw)
 					unexpectedViews := difference(viewsToRemove, oldViewKeys)
 					if len(unexpectedViews) > 0 {
 						log.Printf(
@@ -309,7 +332,7 @@ func resourceSegmentUpdate(ctx context.Context, d *schema.ResourceData, metaRaw 
 					return diag.Errorf("failed to get environment %q in project %q: %s", envKey, projectKey, handleLdapiErr(err))
 				}
 
-				oldViewKeys := interfaceSliceToStringSlice(oldViewKeysRaw.(*schema.Set).List())
+				oldViewKeys := stringListFromOptionalSetValue(oldViewKeysRaw)
 				for _, viewKey := range oldViewKeys {
 					segmentIdentifiers := []ViewSegmentIdentifier{{
 						EnvironmentId: env.Id,
@@ -332,7 +355,10 @@ func resourceSegmentDelete(ctx context.Context, d *schema.ResourceData, metaRaw 
 
 	client := metaRaw.(*Client)
 	projectKey := d.Get(PROJECT_KEY).(string)
-	envKey := d.Get(ENV_KEY).(string)
+	envKey := effectiveEnvKeyFromIDOrAttr(d)
+	if envKey == "" {
+		return diag.Errorf("%s is empty and resource id %q is not project_key/env_key/segment_key", ENV_KEY, d.Id())
+	}
 	key := d.Get(KEY).(string)
 
 	var err error
@@ -350,7 +376,10 @@ func resourceSegmentDelete(ctx context.Context, d *schema.ResourceData, metaRaw 
 func resourceSegmentExists(d *schema.ResourceData, metaRaw interface{}) (bool, error) {
 	client := metaRaw.(*Client)
 	projectKey := d.Get(PROJECT_KEY).(string)
-	envKey := d.Get(ENV_KEY).(string)
+	envKey := effectiveEnvKeyFromIDOrAttr(d)
+	if envKey == "" {
+		return false, fmt.Errorf("%s is required, or resource id must be project_key/env_key/segment_key", ENV_KEY)
+	}
 	key := d.Get(KEY).(string)
 
 	var res *http.Response
@@ -378,7 +407,9 @@ func resourceSegmentImport(d *schema.ResourceData, meta interface{}) ([]*schema.
 
 	parts := strings.SplitN(d.Id(), "/", 3)
 
-	projectKey, envKey, segmentKey := parts[0], parts[1], parts[2]
+	projectKey := strings.TrimSpace(parts[0])
+	envKey := strings.TrimSpace(parts[1])
+	segmentKey := strings.TrimSpace(parts[2])
 
 	_ = d.Set(PROJECT_KEY, projectKey)
 	_ = d.Set(ENV_KEY, envKey)

--- a/launchdarkly/resource_launchdarkly_team.go
+++ b/launchdarkly/resource_launchdarkly_team.go
@@ -122,7 +122,7 @@ func resourceTeamCreate(ctx context.Context, d *schema.ResourceData, metaRaw int
 	client := metaRaw.(*Client)
 	key := d.Get(KEY).(string)
 	name := d.Get(NAME).(string)
-	description := d.Get(DESCRIPTION).(string)
+	description := trimmedStringAttr(d, DESCRIPTION)
 	memberIDs := optionalSetList(d, MEMBER_IDS)
 	maintainers := optionalSetList(d, MAINTAINERS)
 	customRoleKeys := optionalSetList(d, CUSTOM_ROLE_KEYS)

--- a/launchdarkly/resource_launchdarkly_team.go
+++ b/launchdarkly/resource_launchdarkly_team.go
@@ -70,7 +70,11 @@ This resource allows you to create and manage a team within your LaunchDarkly or
 }
 
 func interfaceToArr(old interface{}) []string {
-	interfaceArr := old.(*schema.Set).List()
+	set := optionalSchemaSetFromInterface(old)
+	if set == nil {
+		return []string{}
+	}
+	interfaceArr := set.List()
 
 	stringArr := make([]string, len(interfaceArr))
 	for i, str := range interfaceArr {
@@ -119,10 +123,10 @@ func resourceTeamCreate(ctx context.Context, d *schema.ResourceData, metaRaw int
 	key := d.Get(KEY).(string)
 	name := d.Get(NAME).(string)
 	description := d.Get(DESCRIPTION).(string)
-	memberIDs := d.Get(MEMBER_IDS).(*schema.Set).List()
-	maintainers := d.Get(MAINTAINERS).(*schema.Set).List()
-	customRoleKeys := d.Get(CUSTOM_ROLE_KEYS).(*schema.Set).List()
-	roleAttributes := roleAttributesFromResourceData(d.Get(ROLE_ATTRIBUTES).(*schema.Set).List())
+	memberIDs := optionalSetList(d, MEMBER_IDS)
+	maintainers := optionalSetList(d, MAINTAINERS)
+	customRoleKeys := optionalSetList(d, CUSTOM_ROLE_KEYS)
+	roleAttributes := roleAttributesFromResourceData(optionalSetList(d, ROLE_ATTRIBUTES))
 
 	stringMemberIDs := make([]string, len(memberIDs))
 	for i := range memberIDs {
@@ -365,7 +369,7 @@ func resourceTeamUpdate(ctx context.Context, d *schema.ResourceData, metaRaw int
 	if d.HasChange(ROLE_ATTRIBUTES) {
 		replaceRoleAttributesInstruction := map[string]interface{}{
 			"kind":  "replaceRoleAttributes",
-			"value": roleAttributesFromResourceData(d.Get(ROLE_ATTRIBUTES).(*schema.Set).List()),
+			"value": roleAttributesFromResourceData(optionalSetList(d, ROLE_ATTRIBUTES)),
 		}
 		instructions = append(instructions, replaceRoleAttributesInstruction)
 	}

--- a/launchdarkly/resource_launchdarkly_team.go
+++ b/launchdarkly/resource_launchdarkly_team.go
@@ -122,7 +122,7 @@ func resourceTeamCreate(ctx context.Context, d *schema.ResourceData, metaRaw int
 	client := metaRaw.(*Client)
 	key := d.Get(KEY).(string)
 	name := d.Get(NAME).(string)
-	description := trimmedStringAttr(d, DESCRIPTION)
+	description := optionalStringAttr(d, DESCRIPTION)
 	memberIDs := optionalSetList(d, MEMBER_IDS)
 	maintainers := optionalSetList(d, MAINTAINERS)
 	customRoleKeys := optionalSetList(d, CUSTOM_ROLE_KEYS)

--- a/launchdarkly/resource_launchdarkly_team_member.go
+++ b/launchdarkly/resource_launchdarkly_team_member.go
@@ -77,9 +77,9 @@ This resource allows you to create and manage team members within your LaunchDar
 func resourceTeamMemberCreate(ctx context.Context, d *schema.ResourceData, metaRaw interface{}) diag.Diagnostics {
 	client := metaRaw.(*Client)
 	memberEmail := d.Get(EMAIL).(string)
-	firstName := trimmedStringAttr(d, FIRST_NAME)
-	lastName := trimmedStringAttr(d, LAST_NAME)
-	memberRole := trimmedStringAttr(d, ROLE)
+	firstName := optionalStringAttr(d, FIRST_NAME)
+	lastName := optionalStringAttr(d, LAST_NAME)
+	memberRole := optionalStringAttr(d, ROLE)
 	customRolesRaw := optionalSetList(d, CUSTOM_ROLES)
 	roleAttributes := roleAttributesFromResourceData(optionalSetList(d, ROLE_ATTRIBUTES))
 
@@ -162,7 +162,7 @@ func resourceTeamMemberRead(ctx context.Context, d *schema.ResourceData, metaRaw
 func resourceTeamMemberUpdate(ctx context.Context, d *schema.ResourceData, metaRaw interface{}) diag.Diagnostics {
 	client := metaRaw.(*Client)
 	memberID := d.Id()
-	memberRole := trimmedStringAttr(d, ROLE)
+	memberRole := optionalStringAttr(d, ROLE)
 	customRolesRaw := optionalSetList(d, CUSTOM_ROLES)
 
 	customRoleKeys := make([]string, len(customRolesRaw))

--- a/launchdarkly/resource_launchdarkly_team_member.go
+++ b/launchdarkly/resource_launchdarkly_team_member.go
@@ -80,8 +80,8 @@ func resourceTeamMemberCreate(ctx context.Context, d *schema.ResourceData, metaR
 	firstName := d.Get(FIRST_NAME).(string)
 	lastName := d.Get(LAST_NAME).(string)
 	memberRole := d.Get(ROLE).(string)
-	customRolesRaw := d.Get(CUSTOM_ROLES).(*schema.Set).List()
-	roleAttributes := roleAttributesFromResourceData(d.Get(ROLE_ATTRIBUTES).(*schema.Set).List())
+	customRolesRaw := optionalSetList(d, CUSTOM_ROLES)
+	roleAttributes := roleAttributesFromResourceData(optionalSetList(d, ROLE_ATTRIBUTES))
 
 	customRoles := make([]string, len(customRolesRaw))
 	for i, cr := range customRolesRaw {
@@ -163,7 +163,7 @@ func resourceTeamMemberUpdate(ctx context.Context, d *schema.ResourceData, metaR
 	client := metaRaw.(*Client)
 	memberID := d.Id()
 	memberRole := d.Get(ROLE).(string)
-	customRolesRaw := d.Get(CUSTOM_ROLES).(*schema.Set).List()
+	customRolesRaw := optionalSetList(d, CUSTOM_ROLES)
 
 	customRoleKeys := make([]string, len(customRolesRaw))
 	for i, cr := range customRolesRaw {

--- a/launchdarkly/resource_launchdarkly_team_member.go
+++ b/launchdarkly/resource_launchdarkly_team_member.go
@@ -77,9 +77,9 @@ This resource allows you to create and manage team members within your LaunchDar
 func resourceTeamMemberCreate(ctx context.Context, d *schema.ResourceData, metaRaw interface{}) diag.Diagnostics {
 	client := metaRaw.(*Client)
 	memberEmail := d.Get(EMAIL).(string)
-	firstName := d.Get(FIRST_NAME).(string)
-	lastName := d.Get(LAST_NAME).(string)
-	memberRole := d.Get(ROLE).(string)
+	firstName := trimmedStringAttr(d, FIRST_NAME)
+	lastName := trimmedStringAttr(d, LAST_NAME)
+	memberRole := trimmedStringAttr(d, ROLE)
 	customRolesRaw := optionalSetList(d, CUSTOM_ROLES)
 	roleAttributes := roleAttributesFromResourceData(optionalSetList(d, ROLE_ATTRIBUTES))
 
@@ -162,7 +162,7 @@ func resourceTeamMemberRead(ctx context.Context, d *schema.ResourceData, metaRaw
 func resourceTeamMemberUpdate(ctx context.Context, d *schema.ResourceData, metaRaw interface{}) diag.Diagnostics {
 	client := metaRaw.(*Client)
 	memberID := d.Id()
-	memberRole := d.Get(ROLE).(string)
+	memberRole := trimmedStringAttr(d, ROLE)
 	customRolesRaw := optionalSetList(d, CUSTOM_ROLES)
 
 	customRoleKeys := make([]string, len(customRolesRaw))

--- a/launchdarkly/resource_launchdarkly_view.go
+++ b/launchdarkly/resource_launchdarkly_view.go
@@ -104,7 +104,7 @@ func resourceViewCreate(ctx context.Context, d *schema.ResourceData, metaRaw int
 	}
 
 	if tags, ok := d.GetOk(TAGS); ok {
-		viewPost["tags"] = interfaceSliceToStringSlice(tags.(*schema.Set).List())
+		viewPost["tags"] = stringListFromOptionalSetValue(tags)
 	}
 
 	_, err = createView(betaClient, projectKey, viewPost)
@@ -158,7 +158,7 @@ func resourceViewUpdate(ctx context.Context, d *schema.ResourceData, metaRaw int
 	}
 
 	if d.HasChange(TAGS) {
-		patch["tags"] = interfaceSliceToStringSlice(d.Get(TAGS).(*schema.Set).List())
+		patch["tags"] = stringListFromOptionalSetValue(d.Get(TAGS))
 	}
 
 	if d.HasChange(ARCHIVED) {

--- a/launchdarkly/resource_launchdarkly_view.go
+++ b/launchdarkly/resource_launchdarkly_view.go
@@ -138,7 +138,7 @@ func resourceViewUpdate(ctx context.Context, d *schema.ResourceData, metaRaw int
 	}
 
 	if d.HasChange(DESCRIPTION) {
-		patch["description"] = trimmedStringAttr(d, DESCRIPTION)
+		patch["description"] = optionalStringAttr(d, DESCRIPTION)
 	}
 
 	if d.HasChange(MAINTAINER_ID) {

--- a/launchdarkly/resource_launchdarkly_view.go
+++ b/launchdarkly/resource_launchdarkly_view.go
@@ -138,7 +138,7 @@ func resourceViewUpdate(ctx context.Context, d *schema.ResourceData, metaRaw int
 	}
 
 	if d.HasChange(DESCRIPTION) {
-		patch["description"] = d.Get(DESCRIPTION).(string)
+		patch["description"] = trimmedStringAttr(d, DESCRIPTION)
 	}
 
 	if d.HasChange(MAINTAINER_ID) {
@@ -162,7 +162,7 @@ func resourceViewUpdate(ctx context.Context, d *schema.ResourceData, metaRaw int
 	}
 
 	if d.HasChange(ARCHIVED) {
-		patch["archived"] = d.Get(ARCHIVED).(bool)
+		patch["archived"] = optionalBoolFromResourceData(d, ARCHIVED, false)
 	}
 
 	if len(patch) > 0 {

--- a/launchdarkly/resource_launchdarkly_view_filter_links.go
+++ b/launchdarkly/resource_launchdarkly_view_filter_links.go
@@ -120,7 +120,7 @@ func resourceViewFilterLinksCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("cannot find view with key %q in project %q", viewKey, projectKey)
 	}
 
-	segmentFilterEnvId := trimmedStringAttr(d, SEGMENT_FILTER_ENVIRONMENT_ID)
+	segmentFilterEnvId := optionalStringAttr(d, SEGMENT_FILTER_ENVIRONMENT_ID)
 
 	// Link flags by filter if specified
 	if flagFilter, ok := d.GetOk(FLAG_FILTER); ok {
@@ -181,7 +181,7 @@ func resourceViewFilterLinksUpdate(ctx context.Context, d *schema.ResourceData, 
 	projectKey := d.Get(PROJECT_KEY).(string)
 	viewKey := d.Get(VIEW_KEY).(string)
 
-	segmentFilterEnvId := trimmedStringAttr(d, SEGMENT_FILTER_ENVIRONMENT_ID)
+	segmentFilterEnvId := optionalStringAttr(d, SEGMENT_FILTER_ENVIRONMENT_ID)
 	hasFlagFilterChange := d.HasChange(FLAG_FILTER)
 	hasSegmentFilterChange := d.HasChange(SEGMENT_FILTER) || d.HasChange(SEGMENT_FILTER_ENVIRONMENT_ID)
 	reconcileOnApply := optionalBoolFromResourceData(d, RECONCILE_ON_APPLY, false)
@@ -191,7 +191,7 @@ func resourceViewFilterLinksUpdate(ctx context.Context, d *schema.ResourceData, 
 
 	if shouldResyncFlags {
 		// Flags: full re-sync
-		flagFilter := trimmedStringAttr(d, FLAG_FILTER)
+		flagFilter := optionalStringAttr(d, FLAG_FILTER)
 		if flagFilter != "" {
 			// Unlink all currently linked flags (clean slate)
 			linkedFlags, err := getLinkedResources(betaClient, projectKey, viewKey, FLAGS)
@@ -237,7 +237,7 @@ func resourceViewFilterLinksUpdate(ctx context.Context, d *schema.ResourceData, 
 
 	if shouldResyncSegments {
 		// Segments: full re-sync
-		segmentFilter := trimmedStringAttr(d, SEGMENT_FILTER)
+		segmentFilter := optionalStringAttr(d, SEGMENT_FILTER)
 		if segmentFilter != "" {
 			// Unlink all currently linked segments (clean slate)
 			linkedSegments, err := getLinkedResources(betaClient, projectKey, viewKey, SEGMENTS)

--- a/launchdarkly/resource_launchdarkly_view_filter_links.go
+++ b/launchdarkly/resource_launchdarkly_view_filter_links.go
@@ -120,7 +120,7 @@ func resourceViewFilterLinksCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("cannot find view with key %q in project %q", viewKey, projectKey)
 	}
 
-	segmentFilterEnvId := d.Get(SEGMENT_FILTER_ENVIRONMENT_ID).(string)
+	segmentFilterEnvId := trimmedStringAttr(d, SEGMENT_FILTER_ENVIRONMENT_ID)
 
 	// Link flags by filter if specified
 	if flagFilter, ok := d.GetOk(FLAG_FILTER); ok {
@@ -181,17 +181,17 @@ func resourceViewFilterLinksUpdate(ctx context.Context, d *schema.ResourceData, 
 	projectKey := d.Get(PROJECT_KEY).(string)
 	viewKey := d.Get(VIEW_KEY).(string)
 
-	segmentFilterEnvId := d.Get(SEGMENT_FILTER_ENVIRONMENT_ID).(string)
+	segmentFilterEnvId := trimmedStringAttr(d, SEGMENT_FILTER_ENVIRONMENT_ID)
 	hasFlagFilterChange := d.HasChange(FLAG_FILTER)
 	hasSegmentFilterChange := d.HasChange(SEGMENT_FILTER) || d.HasChange(SEGMENT_FILTER_ENVIRONMENT_ID)
-	reconcileOnApply := d.Get(RECONCILE_ON_APPLY).(bool)
+	reconcileOnApply := optionalBoolFromResourceData(d, RECONCILE_ON_APPLY, false)
 	isPeriodicReconcile := reconcileOnApply && !hasFlagFilterChange && !hasSegmentFilterChange
 	shouldResyncFlags := hasFlagFilterChange || isPeriodicReconcile
 	shouldResyncSegments := hasSegmentFilterChange || isPeriodicReconcile
 
 	if shouldResyncFlags {
 		// Flags: full re-sync
-		flagFilter := d.Get(FLAG_FILTER).(string)
+		flagFilter := trimmedStringAttr(d, FLAG_FILTER)
 		if flagFilter != "" {
 			// Unlink all currently linked flags (clean slate)
 			linkedFlags, err := getLinkedResources(betaClient, projectKey, viewKey, FLAGS)
@@ -216,7 +216,7 @@ func resourceViewFilterLinksUpdate(ctx context.Context, d *schema.ResourceData, 
 		} else {
 			// Flag filter was removed — unlink all flags
 			oldVal, _ := d.GetChange(FLAG_FILTER)
-			if oldVal.(string) != "" {
+			if old, _ := oldVal.(string); old != "" {
 				linkedFlags, err := getLinkedResources(betaClient, projectKey, viewKey, FLAGS)
 				if err != nil {
 					return diag.Errorf("failed to get linked flags for view %q in project %q: %s", viewKey, projectKey, err)
@@ -237,7 +237,7 @@ func resourceViewFilterLinksUpdate(ctx context.Context, d *schema.ResourceData, 
 
 	if shouldResyncSegments {
 		// Segments: full re-sync
-		segmentFilter := d.Get(SEGMENT_FILTER).(string)
+		segmentFilter := trimmedStringAttr(d, SEGMENT_FILTER)
 		if segmentFilter != "" {
 			// Unlink all currently linked segments (clean slate)
 			linkedSegments, err := getLinkedResources(betaClient, projectKey, viewKey, SEGMENTS)
@@ -265,7 +265,7 @@ func resourceViewFilterLinksUpdate(ctx context.Context, d *schema.ResourceData, 
 		} else {
 			// Segment filter was removed — unlink all segments
 			oldVal, _ := d.GetChange(SEGMENT_FILTER)
-			if oldVal.(string) != "" {
+			if old, _ := oldVal.(string); old != "" {
 				linkedSegments, err := getLinkedResources(betaClient, projectKey, viewKey, SEGMENTS)
 				if err != nil {
 					return diag.Errorf("failed to get linked segments for view %q in project %q: %s", viewKey, projectKey, err)

--- a/launchdarkly/resource_launchdarkly_view_links.go
+++ b/launchdarkly/resource_launchdarkly_view_links.go
@@ -122,7 +122,7 @@ func resourceViewLinksCreate(ctx context.Context, d *schema.ResourceData, metaRa
 
 	// Link flags if specified
 	if flagsRaw, ok := d.GetOk(FLAGS); ok {
-		flags := interfaceSliceToStringSlice(flagsRaw.(*schema.Set).List())
+		flags := stringListFromOptionalSetValue(flagsRaw)
 		err = linkResourcesToView(betaClient, projectKey, viewKey, FLAGS, flags)
 		if err != nil {
 			return diag.Errorf("failed to link flags to view %q in project %q: %s", viewKey, projectKey, err)
@@ -131,7 +131,7 @@ func resourceViewLinksCreate(ctx context.Context, d *schema.ResourceData, metaRa
 
 	// Link segments if specified
 	if segmentsRaw, ok := d.GetOk(SEGMENTS); ok {
-		segments := segmentsRaw.(*schema.Set).List()
+		segments := optionalSetListFromAny(segmentsRaw)
 		segmentIdentifiers := make([]ViewSegmentIdentifier, len(segments))
 		for i, seg := range segments {
 			segMap := seg.(map[string]interface{})
@@ -221,8 +221,8 @@ func resourceViewLinksUpdate(ctx context.Context, d *schema.ResourceData, metaRa
 
 	if d.HasChange(FLAGS) {
 		oldFlagsRaw, newFlagsRaw := d.GetChange(FLAGS)
-		oldFlags := interfaceSliceToStringSlice(oldFlagsRaw.(*schema.Set).List())
-		newFlags := interfaceSliceToStringSlice(newFlagsRaw.(*schema.Set).List())
+		oldFlags := stringListFromOptionalSetValue(oldFlagsRaw)
+		newFlags := stringListFromOptionalSetValue(newFlagsRaw)
 
 		// Calculate flags to add and remove
 		flagsToAdd := difference(newFlags, oldFlags)
@@ -247,8 +247,8 @@ func resourceViewLinksUpdate(ctx context.Context, d *schema.ResourceData, metaRa
 
 	if d.HasChange(SEGMENTS) {
 		oldSegmentsRaw, newSegmentsRaw := d.GetChange(SEGMENTS)
-		oldSegments := oldSegmentsRaw.(*schema.Set).List()
-		newSegments := newSegmentsRaw.(*schema.Set).List()
+		oldSegments := optionalSetListFromAny(oldSegmentsRaw)
+		newSegments := optionalSetListFromAny(newSegmentsRaw)
 
 		// Convert to segment identifiers
 		oldSegmentIdentifiers := make([]ViewSegmentIdentifier, len(oldSegments))
@@ -306,7 +306,7 @@ func resourceViewLinksDelete(ctx context.Context, d *schema.ResourceData, metaRa
 
 	// Unlink all flags
 	if flagsRaw, ok := d.GetOk(FLAGS); ok {
-		flags := interfaceSliceToStringSlice(flagsRaw.(*schema.Set).List())
+		flags := stringListFromOptionalSetValue(flagsRaw)
 		if len(flags) > 0 {
 			err = unlinkResourcesFromView(betaClient, projectKey, viewKey, FLAGS, flags)
 			if err != nil {
@@ -317,7 +317,7 @@ func resourceViewLinksDelete(ctx context.Context, d *schema.ResourceData, metaRa
 
 	// Unlink all segments
 	if segmentsRaw, ok := d.GetOk(SEGMENTS); ok {
-		segments := segmentsRaw.(*schema.Set).List()
+		segments := optionalSetListFromAny(segmentsRaw)
 		if len(segments) > 0 {
 			segmentIdentifiers := make([]ViewSegmentIdentifier, len(segments))
 			for i, seg := range segments {

--- a/launchdarkly/resource_launchdarkly_webhook.go
+++ b/launchdarkly/resource_launchdarkly_webhook.go
@@ -45,8 +45,8 @@ This resource allows you to create and manage webhooks within your LaunchDarkly 
 func resourceWebhookCreate(ctx context.Context, d *schema.ResourceData, metaRaw interface{}) diag.Diagnostics {
 	client := metaRaw.(*Client)
 	webhookURL := d.Get(URL).(string)
-	webhookSecret := trimmedStringAttr(d, SECRET)
-	webhookName := trimmedStringAttr(d, NAME)
+	webhookSecret := optionalStringAttr(d, SECRET)
+	webhookName := optionalStringAttr(d, NAME)
 
 	webhookOn := optionalBoolFromResourceData(d, ON, false)
 
@@ -104,8 +104,8 @@ func resourceWebhookUpdate(ctx context.Context, d *schema.ResourceData, metaRaw 
 	client := metaRaw.(*Client)
 	webhookID := d.Id()
 	webhookURL := d.Get(URL).(string)
-	webhookSecret := trimmedStringAttr(d, SECRET)
-	webhookName := trimmedStringAttr(d, NAME)
+	webhookSecret := optionalStringAttr(d, SECRET)
+	webhookName := optionalStringAttr(d, NAME)
 	webhookTags := stringsFromResourceData(d, TAGS)
 	webhookOn := optionalBoolFromResourceData(d, ON, false)
 

--- a/launchdarkly/resource_launchdarkly_webhook.go
+++ b/launchdarkly/resource_launchdarkly_webhook.go
@@ -45,10 +45,10 @@ This resource allows you to create and manage webhooks within your LaunchDarkly 
 func resourceWebhookCreate(ctx context.Context, d *schema.ResourceData, metaRaw interface{}) diag.Diagnostics {
 	client := metaRaw.(*Client)
 	webhookURL := d.Get(URL).(string)
-	webhookSecret := d.Get(SECRET).(string)
-	webhookName := d.Get(NAME).(string)
+	webhookSecret := trimmedStringAttr(d, SECRET)
+	webhookName := trimmedStringAttr(d, NAME)
 
-	webhookOn := d.Get(ON).(bool)
+	webhookOn := optionalBoolFromResourceData(d, ON, false)
 
 	webhookBody := ldapi.WebhookPost{
 		Url:  webhookURL,
@@ -104,10 +104,10 @@ func resourceWebhookUpdate(ctx context.Context, d *schema.ResourceData, metaRaw 
 	client := metaRaw.(*Client)
 	webhookID := d.Id()
 	webhookURL := d.Get(URL).(string)
-	webhookSecret := d.Get(SECRET).(string)
-	webhookName := d.Get(NAME).(string)
+	webhookSecret := trimmedStringAttr(d, SECRET)
+	webhookName := trimmedStringAttr(d, NAME)
 	webhookTags := stringsFromResourceData(d, TAGS)
-	webhookOn := d.Get(ON).(bool)
+	webhookOn := optionalBoolFromResourceData(d, ON, false)
 
 	patch := []ldapi.PatchOperation{
 		patchReplace("/url", &webhookURL),

--- a/launchdarkly/resource_launchdarkly_webhook.go
+++ b/launchdarkly/resource_launchdarkly_webhook.go
@@ -57,7 +57,7 @@ func resourceWebhookCreate(ctx context.Context, d *schema.ResourceData, metaRaw 
 	}
 
 	if rawStatements, ok := d.GetOk(STATEMENTS); ok {
-		statements, err := policyStatementsFromResourceData(rawStatements.([]interface{}))
+		statements, err := policyStatementsFromResourceData(interfaceSliceFromAny(rawStatements))
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -117,7 +117,7 @@ func resourceWebhookUpdate(ctx context.Context, d *schema.ResourceData, metaRaw 
 		patchReplace("/tags", &webhookTags),
 	}
 
-	statements, err := policyStatementsFromResourceData(d.Get(STATEMENTS).([]interface{}))
+	statements, err := policyStatementsFromResourceData(getOptionalInterfaceSlice(d, STATEMENTS))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/launchdarkly/role_attributes_helper.go
+++ b/launchdarkly/role_attributes_helper.go
@@ -69,7 +69,7 @@ func roleAttributesToResourceData(roleAttributes *map[string][]string) *[]interf
 func getRoleAttributePatches(d *schema.ResourceData) []ldapi.PatchOperation {
 	var patch []ldapi.PatchOperation
 	if o, n := d.GetChange(ROLE_ATTRIBUTES); o != n {
-		new := roleAttributesFromResourceData(d.Get(ROLE_ATTRIBUTES).(*schema.Set).List())
+		new := roleAttributesFromResourceData(optionalSetList(d, ROLE_ATTRIBUTES))
 		if new != nil {
 			patch = append(patch, patchReplace("/roleAttributes", new))
 		} else {

--- a/launchdarkly/rule_helper.go
+++ b/launchdarkly/rule_helper.go
@@ -55,7 +55,7 @@ type rule struct {
 }
 
 func rulesFromResourceData(d *schema.ResourceData) ([]rule, error) {
-	schemaRules := d.Get(RULES).([]interface{})
+	schemaRules := getOptionalInterfaceSlice(d, RULES)
 	rules := make([]rule, 0, len(schemaRules))
 	for _, r := range schemaRules {
 		rule, err := ruleFromResourceData(r)

--- a/launchdarkly/schema_compat.go
+++ b/launchdarkly/schema_compat.go
@@ -1,0 +1,68 @@
+package launchdarkly
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// isOmittedEmbeddedSchemaAttrErr reports whether err is the specific Terraform plugin SDK error
+// emitted when a write target is not present in the runtime schema (e.g. Upjet has stripped a
+// deprecated attribute). The matchers are intentionally narrow so unrelated errors that merely
+// mention attr are never swallowed.
+//
+// Known SDK error shapes (terraform-plugin-sdk v2):
+//   - schema.ResourceData.Set / MapFieldWriter.WriteField:
+//     "Invalid address to set: []string{\"<attr>\"}"
+//   - schema.ResourceDiff.SetNew via mapFieldReader / readField:
+//     ": invalid key: <attr>"  (preceded by a colon and following a known SDK prefix)
+func isOmittedEmbeddedSchemaAttrErr(err error, attr string) bool {
+	if err == nil || attr == "" {
+		return false
+	}
+	addressPattern := fmt.Sprintf(`Invalid address to set: []string{%q}`, attr)
+	invalidKeyExact := fmt.Sprintf(": invalid key: %s", attr)
+	for cur := err; cur != nil; cur = errors.Unwrap(cur) {
+		s := cur.Error()
+		if strings.Contains(s, addressPattern) {
+			return true
+		}
+		if strings.Contains(s, invalidKeyExact) {
+			return true
+		}
+	}
+	return false
+}
+
+// resourceDiffSetNewSkipMissingKey runs diff.SetNew and treats a missing schema key as success.
+// Use when embedders remove deprecated attributes from the runtime schema while provider code
+// still references them for Terraform CLI compatibility. A suppressed error is logged at DEBUG
+// so the underlying mismatch remains observable.
+func resourceDiffSetNewSkipMissingKey(diff *schema.ResourceDiff, key string, value interface{}) error {
+	err := diff.SetNew(key, value)
+	if err == nil {
+		return nil
+	}
+	if isOmittedEmbeddedSchemaAttrErr(err, key) {
+		log.Printf("[DEBUG] schema_compat: suppressed SetNew(%q) on missing schema key: %v", key, err)
+		return nil
+	}
+	return err
+}
+
+// resourceDataSetSkipMissingKey runs d.Set and treats a missing schema key as success.
+// A suppressed error is logged at DEBUG.
+func resourceDataSetSkipMissingKey(d *schema.ResourceData, key string, value interface{}) error {
+	err := d.Set(key, value)
+	if err == nil {
+		return nil
+	}
+	if isOmittedEmbeddedSchemaAttrErr(err, key) {
+		log.Printf("[DEBUG] schema_compat: suppressed Set(%q) on missing schema key: %v", key, err)
+		return nil
+	}
+	return err
+}

--- a/launchdarkly/schema_compat_test.go
+++ b/launchdarkly/schema_compat_test.go
@@ -1,0 +1,115 @@
+package launchdarkly
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsOmittedEmbeddedSchemaAttrErr_wrapped(t *testing.T) {
+	inner := fmt.Errorf("SetNew: invalid key: include_in_snippet")
+	wrapped := fmt.Errorf("cannot compute the instance diff: %w", inner)
+	if !isOmittedEmbeddedSchemaAttrErr(wrapped, "include_in_snippet") {
+		t.Fatal("expected wrapped invalid key error to match")
+	}
+}
+
+func TestIsOmittedEmbeddedSchemaAttrErr(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		attr   string
+		wantOK bool
+	}{
+		{
+			name:   "SetNew invalid key",
+			err:    fmt.Errorf("SetNew: invalid key: include_in_snippet"),
+			attr:   "include_in_snippet",
+			wantOK: true,
+		},
+		{
+			name:   "Set invalid key prefix",
+			err:    fmt.Errorf("Set: invalid key: default_client_side_availability"),
+			attr:   "default_client_side_availability",
+			wantOK: true,
+		},
+		{
+			name:   "wrong attr",
+			err:    fmt.Errorf("SetNew: invalid key: other"),
+			attr:   "include_in_snippet",
+			wantOK: false,
+		},
+		{
+			name:   "Invalid address",
+			err:    errors.New(`Invalid address to set: []string{"include_in_snippet"}`),
+			attr:   "include_in_snippet",
+			wantOK: true,
+		},
+		{
+			name:   "nil",
+			err:    nil,
+			attr:   "include_in_snippet",
+			wantOK: false,
+		},
+		{
+			name:   "empty attr",
+			err:    fmt.Errorf("Set: invalid key: x"),
+			attr:   "",
+			wantOK: false,
+		},
+		{
+			name:   "false positive: validation message mentioning the attr",
+			err:    errors.New("validation failed: invalid value for include_in_snippet"),
+			attr:   "include_in_snippet",
+			wantOK: false,
+		},
+		{
+			name:   "false positive: bare 'invalid key' without colon prefix",
+			err:    errors.New("invalid key include_in_snippet"),
+			attr:   "include_in_snippet",
+			wantOK: false,
+		},
+		{
+			name:   "false positive: address-shape with different attr",
+			err:    errors.New(`Invalid address to set: []string{"other"}`),
+			attr:   "include_in_snippet",
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isOmittedEmbeddedSchemaAttrErr(tt.err, tt.attr); got != tt.wantOK {
+				t.Fatalf("isOmittedEmbeddedSchemaAttrErr(...) = %v, want %v", got, tt.wantOK)
+			}
+		})
+	}
+}
+
+// resourceDataSetSkipMissingKey must propagate non-suppression errors verbatim so callers do not
+// silently lose real type-mismatch / coercion failures.
+func TestResourceDataSetSkipMissingKey_propagatesUnrelatedErrors(t *testing.T) {
+	t.Parallel()
+
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"some_int": {Type: schema.TypeInt, Optional: true},
+	}, map[string]interface{}{})
+
+	err := resourceDataSetSkipMissingKey(d, "some_int", "not-an-int")
+	require.Error(t, err, "type-coercion errors must not be swallowed by the missing-key shim")
+}
+
+// resourceDataSetSkipMissingKey must swallow exactly the SDK 'Invalid address to set' error when
+// the attribute does not exist in the schema.
+func TestResourceDataSetSkipMissingKey_suppressesMissingKey(t *testing.T) {
+	t.Parallel()
+
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"present": {Type: schema.TypeString, Optional: true},
+	}, map[string]interface{}{})
+
+	err := resourceDataSetSkipMissingKey(d, "absent", "value")
+	require.NoError(t, err, "missing schema key must be suppressed")
+}

--- a/launchdarkly/segment_rule_helper.go
+++ b/launchdarkly/segment_rule_helper.go
@@ -42,7 +42,7 @@ func segmentRulesSchema(options segmentRulesSchemaOptions) *schema.Schema {
 }
 
 func segmentRulesFromResourceData(d *schema.ResourceData, metaRaw interface{}) ([]ldapi.UserSegmentRule, error) {
-	schemaRules := d.Get(RULES).([]interface{})
+	schemaRules := getOptionalInterfaceSlice(d, RULES)
 	rules := make([]ldapi.UserSegmentRule, len(schemaRules))
 	for i, rule := range schemaRules {
 		v, err := segmentRuleFromResourceData(rule)

--- a/launchdarkly/segments_helper.go
+++ b/launchdarkly/segments_helper.go
@@ -114,7 +114,10 @@ func segmentRead(ctx context.Context, d *schema.ResourceData, raw interface{}, i
 	var diags diag.Diagnostics
 	client := raw.(*Client)
 	projectKey := d.Get(PROJECT_KEY).(string)
-	envKey := d.Get(ENV_KEY).(string)
+	envKey := effectiveEnvKeyFromIDOrAttr(d)
+	if envKey == "" {
+		return diag.Errorf("%s is required, or resource id must be project_key/env_key/segment_key", ENV_KEY)
+	}
 	segmentKey := d.Get(KEY).(string)
 
 	var segment *ldapi.UserSegment
@@ -237,9 +240,9 @@ type segmentTargetOptions struct {
 func segmentTargetsFromResourceData(d *schema.ResourceData, options segmentTargetOptions) []ldapi.SegmentTarget {
 	var schemaTargets []interface{}
 	if options.Included {
-		schemaTargets = d.Get(INCLUDED_CONTEXTS).([]interface{})
+		schemaTargets = getOptionalInterfaceSlice(d, INCLUDED_CONTEXTS)
 	} else if options.Excluded {
-		schemaTargets = d.Get(EXCLUDED_CONTEXTS).([]interface{})
+		schemaTargets = getOptionalInterfaceSlice(d, EXCLUDED_CONTEXTS)
 	}
 	targets := make([]ldapi.SegmentTarget, len(schemaTargets))
 	for _, t := range schemaTargets {

--- a/launchdarkly/tags_helper.go
+++ b/launchdarkly/tags_helper.go
@@ -25,10 +25,13 @@ func tagsSchema(options tagsSchemaOptions) *schema.Schema {
 }
 
 func stringsFromResourceData(d *schema.ResourceData, key string) []string {
-	return stringsFromSchemaSet(d.Get(key).(*schema.Set))
+	return stringsFromSchemaSet(getOptionalSet(d, key))
 }
 
 func stringsFromSchemaSet(schemaSet *schema.Set) []string {
+	if schemaSet == nil {
+		return []string{}
+	}
 	strs := make([]string, schemaSet.Len())
 	for i, tag := range schemaSet.List() {
 		strs[i] = tag.(string)

--- a/launchdarkly/target_helper.go
+++ b/launchdarkly/target_helper.go
@@ -71,7 +71,11 @@ func targetsFromResourceData(d *schema.ResourceData, options targetOptions) []ld
 	if !ok {
 		return []ldapi.Target{}
 	}
-	schemaTargets := tgts.(*schema.Set).List()
+	set := optionalSchemaSetFromInterface(tgts)
+	if set == nil {
+		return []ldapi.Target{}
+	}
+	schemaTargets := set.List()
 	targets := make([]ldapi.Target, 0, len(schemaTargets))
 	for _, target := range schemaTargets {
 		targetMap := target.(map[string]interface{})
@@ -82,7 +86,10 @@ func targetsFromResourceData(d *schema.ResourceData, options targetOptions) []ld
 
 func targetFromResourceData(targetMap map[string]interface{}, options targetOptions) ldapi.Target {
 	contextKind := "user"
-	resourceValues := targetMap[VALUES].([]interface{})
+	resourceValues := interfaceSliceFromAny(targetMap[VALUES])
+	if resourceValues == nil {
+		resourceValues = []interface{}{}
+	}
 	values := make([]string, 0, len(resourceValues))
 	for _, v := range resourceValues {
 		values = append(values, v.(string))

--- a/launchdarkly/target_helper.go
+++ b/launchdarkly/target_helper.go
@@ -87,9 +87,6 @@ func targetsFromResourceData(d *schema.ResourceData, options targetOptions) []ld
 func targetFromResourceData(targetMap map[string]interface{}, options targetOptions) ldapi.Target {
 	contextKind := "user"
 	resourceValues := interfaceSliceFromAny(targetMap[VALUES])
-	if resourceValues == nil {
-		resourceValues = []interface{}{}
-	}
 	values := make([]string, 0, len(resourceValues))
 	for _, v := range resourceValues {
 		values = append(values, v.(string))

--- a/launchdarkly/variations_helper.go
+++ b/launchdarkly/variations_helper.go
@@ -93,7 +93,7 @@ func variationPatchesFromResourceData(d *schema.ResourceData) ([]ldapi.PatchOper
 	variationType := d.Get(VARIATION_TYPE).(string)
 	old, new := d.GetChange(VARIATIONS)
 
-	if len(old.([]interface{})) == 0 {
+	if len(interfaceSliceFromAny(old)) == 0 {
 		// This can only happen when the resource is first created. Since this is handled in the creation POST,
 		// variation patches are not necessary.
 		return patches, nil
@@ -127,7 +127,10 @@ func variationPatchesFromResourceData(d *schema.ResourceData) ([]ldapi.PatchOper
 }
 
 func variationsFromSchemaData(schemaVariations interface{}, variationType string) ([]ldapi.Variation, error) {
-	list := schemaVariations.([]interface{})
+	list := interfaceSliceFromAny(schemaVariations)
+	if list == nil {
+		list = []interface{}{}
+	}
 	variations := make([]ldapi.Variation, len(list))
 	if variationType != BOOL_VARIATION && len(list) < 2 {
 		return variations, fmt.Errorf("multivariate flags must have at least two variations defined")

--- a/launchdarkly/variations_helper.go
+++ b/launchdarkly/variations_helper.go
@@ -128,9 +128,6 @@ func variationPatchesFromResourceData(d *schema.ResourceData) ([]ldapi.PatchOper
 
 func variationsFromSchemaData(schemaVariations interface{}, variationType string) ([]ldapi.Variation, error) {
 	list := interfaceSliceFromAny(schemaVariations)
-	if list == nil {
-		list = []interface{}{}
-	}
 	variations := make([]ldapi.Variation, len(list))
 	if variationType != BOOL_VARIATION && len(list) < 2 {
 		return variations, fmt.Errorf("multivariate flags must have at least two variations defined")


### PR DESCRIPTION
## Summary

Closes #387.

Several optional schema attributes (`policy_statements`, `custom_roles`, `tags`,
`include_in_snippet`, `default_client_side_availability`, `policy`, etc.) were
read with naked type assertions like `d.Get(KEY).(*schema.Set)` /
`.([]interface{})`. When the runtime schema is _embedded_ — most notably under
Crossplane / Upjet, which strips deprecated attributes and may pass nil values
for unset blocks — those assertions panicked or silently coerced to wrong
defaults. The affected resources include `launchdarkly_custom_role`,
`launchdarkly_access_token`, `launchdarkly_project`,
`launchdarkly_feature_flag_environment`, and `launchdarkly_segment`.

This PR replaces the unsafe call sites with nil-safe helpers, adds an
embedded-schema compatibility shim, and tightens diagnostics so a misconfigured
or stripped schema is observable rather than fatal.

## What changed

- **New nil-safe helpers** in `launchdarkly/resource_data_helpers.go`:
  `getOptionalSet`, `optionalSetList`, `getOptionalInterfaceSlice`,
  `optionalSchemaSetFromInterface`, `interfaceSliceFromAny`,
  `optionalSetListFromAny`, `stringListFromOptionalSetValue`,
  `optionalBoolFromResourceData`, `trimmedStringAttr`. List-shaped helpers
  return an empty (non-nil) slice; bool / string helpers log at WARN on type
  mismatch so a schema regression is never silently coerced.
- **ID-derived fallbacks with explicit-error variants**: `effectiveEnvKey`
  (for `feature_flag_environment` / `segment`) and
  `effectiveCustomRoleKeyOrError`. These resolve the resource id when the
  associated attribute is absent (Upjet / Crossplane external-name flow) and
  return an error for malformed ids instead of a silent empty string.
- **Embedded-schema compatibility shim** in `launchdarkly/schema_compat.go`:
  `resourceDataSetSkipMissingKey` and `resourceDiffSetNewSkipMissingKey`
  swallow only the SDK's exact "missing schema key" errors
  (`Invalid address to set: []string{"<attr>"}` and `: invalid key: <attr>`).
  All other errors propagate. Each suppression is logged at DEBUG.
- **`launchdarkly_project` update guard**: `buildProjectUpdatePatches` no
  longer appends a fallback `replace /defaultClientSideAvailability` op when
  the runtime schema has stripped both `INCLUDE_IN_SNIPPET` and
  `DEFAULT_CLIENT_SIDE_AVAILABILITY`. Previously a "tags only" update under
  Upjet would overwrite server-side CSA defaults on every apply.
- **`customizeProjectDiff`** uses safe `cty` access (`ctyObjectGetAttr`,
  `ctyValueListElements`, `ctyBoolTrue`, `rawConfigHasAnyAttr`) so a stripped
  schema or null raw config does not panic during plan.
- **`launchdarkly_custom_role`** Read normalizes `d.SetId(customRole.Key)` so
  the Terraform id is always the canonical LD key (fixes Crossplane Observe
  matching). Create / Update accept the id as a fallback when the embedded
  schema omits `key`.
- **`launchdarkly_feature_flag_environment` / `launchdarkly_segment`** call
  `effectiveEnvKey` everywhere `env_key` is needed (Create, Read, Update,
  Delete, Exists, patch path builders). Failure messages explicitly state
  that `env_key` must be the LaunchDarkly environment **key**, not its
  display name.

## Why it fixes #387 safely

- The unsafe `.(type)` patterns are now replaced exhaustively across the
  affected resources; every removed assertion has a corresponding helper that
  tolerates `nil` and wrong types.
- `schema_compat` only swallows the two specific SDK error strings emitted
  when the runtime schema is missing the attribute. Unrelated errors (type
  coercion, validation, etc.) still surface — covered by negative tests.
- The CSA-fallback guard is gated on the schema actually exposing IIS / CSA;
  full-schema users keep the previous behavior. A regression test asserts
  both directions.

## New tests

All non-acc, no `TF_ACC` / token required.

- `launchdarkly/resource_data_helpers_test.go`
  - `TestOptionalSchemaSetFromInterface`, `TestInterfaceSliceFromAny`,
    `TestOptionalSetListAndGetOptionalInterfaceSlice_unsetOptionalBlocks`,
    `TestOptionalBoolFromResourceData`,
    `TestPoliciesFromResourceData_nilPolicyNoPanic`,
    `TestEffectiveEnvKeyFromIDOrAttr`, `TestEffectiveCustomRoleKey`.
- `launchdarkly/cty_helpers_test.go`
  - `TestCtyObjectGetAttr_*`, `TestCtyValueListElements_nullOrEmpty`,
    `TestCtyBoolTrue`, `TestRawConfigHasAnyAttr`.
- `launchdarkly/schema_compat_test.go`
  - `TestIsOmittedEmbeddedSchemaAttrErr` (true positives, false positives,
    wrapped errors), `TestIsOmittedEmbeddedSchemaAttrErr_wrapped`,
    `TestResourceDataSetSkipMissingKey_propagatesUnrelatedErrors`,
    `TestResourceDataSetSkipMissingKey_suppressesMissingKey`.
- `launchdarkly/embedded_schema_compat_test.go` (resource-level regressions)
  - `TestBuildProjectUpdatePatches_embeddedSchemaOmitsCSAFallback`,
    `TestBuildProjectUpdatePatches_fullSchemaKeepsCSAFallback`,
    `TestPolicyStatementsFromResourceData_emptyDoesNotPanic`,
    `TestAccessTokenValidate_emptyOptionalBlocksNoPanic`,
    `TestEffectiveEnvKey_*`, `TestEffectiveCustomRoleKeyOrError_errorWhenEmpty`.

## Known non-goals / unchanged behavior

- No new resources, attributes, or data sources.
- No changes to the JSON Patch payloads emitted under the full
  Terraform-CLI schema; existing acceptance tests should remain green.
- No changes to docs (no user-facing surface added).
- Team / references plumbing, `launchdarkly_environment` standalone resource
  semantics, and any Crossplane / Upjet generator code remain untouched —
  they were verified to consume the same LD identifiers and require no
  provider-side change for this fix.
- `make generate` is a no-op against this branch.

---

**Wait!**

- [x] Have you added comprehensive tests?
- [x] Have you updated relevant data sources as well as resources? _(N/A — no
  data-source surface changed.)_
- [x] Have you updated the docs? _(N/A — no user-facing surface changed.)_