### PR TITLE
fix: disable Go cache in fork PR workflow to prevent cache poisoning

### DIFF
--- a/.github/workflows/test-fork-pr.yml
+++ b/.github/workflows/test-fork-pr.yml
@@ -6,6 +6,11 @@
 # Security: Only the "labeled" event triggers this workflow. New pushes to the fork do NOT
 # re-trigger tests — see remove-safe-to-test-label.yml which strips the label on new commits,
 # forcing a maintainer to re-review and re-label.
+#
+# Cache safety: Go module/build caching is explicitly disabled (cache: false) in this workflow.
+# pull_request_target runs share the base repo's cache scope — a fork's code could poison cache
+# entries that subsequent pushes to main would restore. See:
+# https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/
 name: "Test (Fork PRs)"
 
 on:
@@ -43,7 +48,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: "go.mod"
-          cache: true
+          cache: false
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_wrapper: false
@@ -114,6 +119,7 @@ jobs:
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: "go.mod"
+          cache: false
       - run: go mod download
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:


### PR DESCRIPTION
## Summary

- Disables `actions/setup-go` caching (`cache: false`) in the `test-fork-pr.yml` workflow
- Adds documentation comment explaining why caching is disabled

## Context

The [TanStack/router supply-chain compromise](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem) (2026-05-11) demonstrated how `pull_request_target` workflows can be exploited via GitHub Actions cache poisoning:

1. `pull_request_target` runs in the **base repo's cache scope** (not the fork's)
2. Fork code can poison cache entries (Go module/build cache) during its run
3. Subsequent pushes to `main` restore the poisoned cache, executing attacker-controlled code

Our `test-fork-pr.yml` was vulnerable to this pattern — `actions/setup-go` defaults to `cache: true` in v5.x, meaning fork PR runs could write to the shared cache that `test.yml` on main restores.

The label gate (`safe-to-test`) significantly raises the bar (human review required), but defense-in-depth says we should eliminate the cache vector entirely. Fork PR runs are infrequent enough that the performance cost is negligible.

## References

- [TanStack postmortem](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem)
- [Adnan Khan: "The Monsters in Your Build Cache"](https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/)
- [GitHub Security Lab: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

## Test plan

- [ ] Verify fork PR workflow still runs successfully without cache (next time `safe-to-test` is applied)
- [ ] Confirm `test.yml` on main still uses its own cache independently

Made with [Cursor](https://cursor.com)