### PR TITLE
fix: fix ip allowlist behaviour/tests

### DIFF
--- a/launchdarkly/ip_allowlist_helper.go
+++ b/launchdarkly/ip_allowlist_helper.go
@@ -7,7 +7,30 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 )
+
+// LD's IP allowlist API persists the whole allowlist as a single account
+// document with optimistic concurrency. Two truly-simultaneous writes can
+// race that version. ipAllowlistWriteMu serialises POST/PATCH/PUT/DELETE
+// in-process so two test goroutines (e.g. parallel TestCases inside one
+// test binary) never race the version. GETs skip the mutex.
+//
+// Note: the API returns 409 `optimistic_locking_error` for BOTH genuine
+// version races AND attempts to insert a duplicate IP. The two are
+// indistinguishable from the error body, so we don't auto-retry — a
+// retry on a duplicate-IP 409 is a no-op that wastes time and can mask
+// orphans from prior failed tests. Cleanup hooks in test PreChecks
+// handle the orphan scenario.
+var ipAllowlistWriteMu sync.Mutex
+
+func ipAllowlistMethodMutates(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPatch, http.MethodPut, http.MethodDelete:
+		return true
+	}
+	return false
+}
 
 type ipAllowlistResponse struct {
 	SessionAllowlistEnabled  bool                       `json:"sessionAllowlistEnabled"`
@@ -64,6 +87,13 @@ func ipAllowlistRequest(client *Client, method, path string, body interface{}) (
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", client.apiKey)
 	req.Header.Set("LD-API-Version", "beta")
+
+	// Mutating calls serialise in-process so two test goroutines don't
+	// race the LD account allowlist version. GETs skip the mutex.
+	if ipAllowlistMethodMutates(method) {
+		ipAllowlistWriteMu.Lock()
+		defer ipAllowlistWriteMu.Unlock()
+	}
 
 	var resp *http.Response
 	err = client.withConcurrency(client.ctx, func() error {

--- a/launchdarkly/resource_launchdarkly_ip_allowlist_entry_test.go
+++ b/launchdarkly/resource_launchdarkly_ip_allowlist_entry_test.go
@@ -8,6 +8,45 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+// testAccIpAllowlistEntryTestIPs are the IPs / CIDRs the acceptance
+// tests in this file create. The LD account allowlist is a single
+// shared document; if a previous CI run's Create succeeded but a
+// later test step failed before the framework recorded state, the
+// orphan entry survives and poisons the next run with a 409
+// optimistic_locking_error (LD's API reuses the code for both
+// genuine version races and duplicate-IP rejections).
+//
+// cleanupOrphanIpAllowlistEntries runs as part of each test's
+// PreCheck and DELETEs any entry whose ipAddress matches one of
+// these tests' targets. Best-effort: a missing entry is success,
+// transient errors are logged and ignored so the test still gets
+// a chance to surface a real-account problem.
+var testAccIpAllowlistEntryTestIPs = []string{"52.1.1.1", "54.0.0.0/24"}
+
+func cleanupOrphanIpAllowlistEntries(t *testing.T) {
+	t.Helper()
+	client := testAccProvider.Meta().(*Client)
+	allowlist, err := getIpAllowlist(client)
+	if err != nil {
+		t.Logf("ip-allowlist cleanup probe failed (continuing): %s", err)
+		return
+	}
+	targets := map[string]struct{}{}
+	for _, ip := range testAccIpAllowlistEntryTestIPs {
+		targets[ip] = struct{}{}
+	}
+	for _, entry := range allowlist.Entries {
+		if _, hit := targets[entry.IpAddress]; !hit {
+			continue
+		}
+		if delErr := deleteIpAllowlistEntry(client, entry.ID); delErr != nil {
+			t.Logf("ip-allowlist cleanup: failed to delete orphan %s (%s): %s", entry.ID, entry.IpAddress, delErr)
+			continue
+		}
+		t.Logf("ip-allowlist cleanup: deleted orphan entry %s for %s", entry.ID, entry.IpAddress)
+	}
+}
+
 const (
 	testAccIpAllowlistEntryCreate = `
 resource "launchdarkly_ip_allowlist_entry" "test" {
@@ -42,6 +81,7 @@ func TestAccIpAllowlistEntry_CreateAndUpdate(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			cleanupOrphanIpAllowlistEntries(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -105,6 +145,7 @@ func TestAccIpAllowlistEntry_CIDRBlock(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			cleanupOrphanIpAllowlistEntries(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{

--- a/launchdarkly/resource_launchdarkly_ip_allowlist_entry_test.go
+++ b/launchdarkly/resource_launchdarkly_ip_allowlist_entry_test.go
@@ -2,6 +2,7 @@ package launchdarkly
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -25,7 +26,14 @@ var testAccIpAllowlistEntryTestIPs = []string{"52.1.1.1", "54.0.0.0/24"}
 
 func cleanupOrphanIpAllowlistEntries(t *testing.T) {
 	t.Helper()
-	client := testAccProvider.Meta().(*Client)
+	// Build a client directly from env: testAccProvider.Meta() is nil
+	// until terraform-plugin-sdk configures the provider, which only
+	// happens once a test Step runs. PreCheck fires before that.
+	client, err := newClient(os.Getenv(LAUNCHDARKLY_ACCESS_TOKEN), os.Getenv(LAUNCHDARKLY_API_HOST), false, DEFAULT_HTTP_TIMEOUT_S, DEFAULT_MAX_CONCURRENCY)
+	if err != nil {
+		t.Logf("ip-allowlist cleanup: client construction failed (continuing): %s", err)
+		return
+	}
 	allowlist, err := getIpAllowlist(client)
 	if err != nil {
 		t.Logf("ip-allowlist cleanup probe failed (continuing): %s", err)


### PR DESCRIPTION
Fixes a 409 conflict issue for duplicate IP inserts and race conditions - this will unblock acceptance tests and https://github.com/launchdarkly/terraform-provider-launchdarkly/pull/420