### PR TITLE
feat(metric)!: remove deprecated is_active attribute

### DIFF
--- a/docs/data-sources/metric.md
+++ b/docs/data-sources/metric.md
@@ -30,10 +30,6 @@ data "launchdarkly_metric" "example" {
 - `key` (String) The unique key that references the metric.
 - `project_key` (String) The metric's project key.
 
-### Optional
-
-- `is_active` (Boolean, Deprecated) Ignored. All metrics are considered active.
-
 ### Read-Only
 
 - `analysis_type` (String) The method for analyzing metric events.

--- a/docs/resources/metric.md
+++ b/docs/resources/metric.md
@@ -49,7 +49,6 @@ resource "launchdarkly_metric" "example" {
 - `description` (String) The description of the metric's purpose.
 - `event_key` (String) The event key for your metric (if custom metric)
 - `include_units_without_events` (Boolean) Include units that did not send any events and set their value to 0.
-- `is_active` (Boolean, Deprecated) Ignored. All metrics are considered active.
 - `is_numeric` (Boolean) Whether a `custom` metric is a numeric metric or not.
 - `maintainer_id` (String) The LaunchDarkly member ID of the member who will maintain the metric. If not set, the API will automatically apply the member associated with your Terraform API key or the most recently-set maintainer
 - `percentile_value` (Number) The percentile for the analysis method. An integer denoting the target percentile between 0 and 100. Required when analysis_type is percentile.

--- a/launchdarkly/data_source_metric_framework.go
+++ b/launchdarkly/data_source_metric_framework.go
@@ -25,7 +25,6 @@ type MetricDataSourceModel struct {
 	MaintainerID              types.String `tfsdk:"maintainer_id"`
 	Description               types.String `tfsdk:"description"`
 	Tags                      types.Set    `tfsdk:"tags"`
-	IsActive                  types.Bool   `tfsdk:"is_active"`
 	IsNumeric                 types.Bool   `tfsdk:"is_numeric"`
 	Unit                      types.String `tfsdk:"unit"`
 	Selector                  types.String `tfsdk:"selector"`
@@ -91,12 +90,6 @@ func (d *MetricDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 				Computed:    true,
 				ElementType: types.StringType,
 				Description: "Tags associated with the metric.",
-			},
-			IS_ACTIVE: schema.BoolAttribute{
-				Optional:           true,
-				Computed:           true,
-				Description:        "Ignored. All metrics are considered active.",
-				DeprecationMessage: "No longer in use. This field will be removed in a future major release of the LaunchDarkly provider.",
 			},
 			IS_NUMERIC: schema.BoolAttribute{
 				Computed:    true,
@@ -203,11 +196,6 @@ func (d *MetricDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		data.Description = types.StringValue(*metric.Description)
 	} else {
 		data.Description = types.StringValue("")
-	}
-	if metric.IsActive != nil {
-		data.IsActive = types.BoolValue(*metric.IsActive)
-	} else {
-		data.IsActive = types.BoolValue(true)
 	}
 	if metric.IsNumeric != nil {
 		data.IsNumeric = types.BoolValue(*metric.IsNumeric)

--- a/launchdarkly/framework_state_upgrade.go
+++ b/launchdarkly/framework_state_upgrade.go
@@ -53,14 +53,3 @@ func nullIfEmptySet(ctx context.Context, s types.Set) types.Set {
 	}
 	return s
 }
-
-// nullIfEmptyMap is nullIfEmptyList for types.Map.
-func nullIfEmptyMap(ctx context.Context, m types.Map) types.Map {
-	if m.IsNull() || m.IsUnknown() {
-		return m
-	}
-	if len(m.Elements()) == 0 {
-		return types.MapNull(m.ElementType(ctx))
-	}
-	return m
-}

--- a/launchdarkly/resource_metric_framework.go
+++ b/launchdarkly/resource_metric_framework.go
@@ -43,7 +43,6 @@ type MetricResourceModel struct {
 	MaintainerID              types.String `tfsdk:"maintainer_id"`
 	Description               types.String `tfsdk:"description"`
 	Tags                      types.Set    `tfsdk:"tags"`
-	IsActive                  types.Bool   `tfsdk:"is_active"`
 	IsNumeric                 types.Bool   `tfsdk:"is_numeric"`
 	Unit                      types.String `tfsdk:"unit"`
 	Selector                  types.String `tfsdk:"selector"`
@@ -123,12 +122,6 @@ func metricSchemaAttributes() map[string]schema.Attribute {
 			Computed:    true,
 			ElementType: types.StringType,
 			Description: "Tags associated with this resource.",
-		},
-		IS_ACTIVE: schema.BoolAttribute{
-			Optional:           true,
-			Computed:           true,
-			Description:        "Ignored. All metrics are considered active.",
-			DeprecationMessage: "No longer in use. This field will be removed in a future major release of the LaunchDarkly provider.",
 		},
 		IS_NUMERIC: schema.BoolAttribute{
 			Optional:    true,
@@ -224,22 +217,38 @@ func metricSchemaAttributes() map[string]schema.Attribute {
 }
 
 func (r *MetricResource) UpgradeState(_ context.Context) map[int64]resource.StateUpgrader {
-	priorSchema := schema.Schema{Attributes: metricSchemaAttributes()}
+	priorSchema := schema.Schema{Attributes: metricSchemaAttributesV0()}
 	return map[int64]resource.StateUpgrader{
 		0: {
 			PriorSchema: &priorSchema,
 			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				var data MetricResourceModel
-				resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+				var prior MetricResourceModelV0
+				resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
 				if resp.Diagnostics.HasError() {
 					return
 				}
-				data.Description = nullIfEmptyString(data.Description)
-				data.EventKey = nullIfEmptyString(data.EventKey)
-				data.Selector = nullIfEmptyString(data.Selector)
-				data.SuccessCriteria = nullIfEmptyString(data.SuccessCriteria)
-				data.Unit = nullIfEmptyString(data.Unit)
-				data.URLs = nullIfEmptyList(ctx, data.URLs)
+				data := MetricResourceModel{
+					ID:                        prior.ID,
+					ProjectKey:                prior.ProjectKey,
+					Key:                       prior.Key,
+					Name:                      prior.Name,
+					Kind:                      prior.Kind,
+					MaintainerID:              prior.MaintainerID,
+					Description:               nullIfEmptyString(prior.Description),
+					Tags:                      prior.Tags,
+					IsNumeric:                 prior.IsNumeric,
+					Unit:                      nullIfEmptyString(prior.Unit),
+					Selector:                  nullIfEmptyString(prior.Selector),
+					EventKey:                  nullIfEmptyString(prior.EventKey),
+					SuccessCriteria:           nullIfEmptyString(prior.SuccessCriteria),
+					URLs:                      nullIfEmptyList(ctx, prior.URLs),
+					RandomizationUnits:        prior.RandomizationUnits,
+					IncludeUnitsWithoutEvents: prior.IncludeUnitsWithoutEvents,
+					UnitAggregationType:       prior.UnitAggregationType,
+					AnalysisType:              prior.AnalysisType,
+					PercentileValue:           prior.PercentileValue,
+					Version:                   prior.Version,
+				}
 				resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 			},
 		},
@@ -606,7 +615,6 @@ func (r *MetricResource) applyMetricUpdate(ctx context.Context, plan *MetricReso
 	name := plan.Name.ValueString()
 	description := plan.Description.ValueString()
 	kind := plan.Kind.ValueString()
-	isActive := plan.IsActive.ValueBool()
 	isNumeric := plan.IsNumeric.ValueBool()
 	unit := plan.Unit.ValueString()
 	selector := plan.Selector.ValueString()
@@ -620,7 +628,6 @@ func (r *MetricResource) applyMetricUpdate(ctx context.Context, plan *MetricReso
 		patchReplace("/description", description),
 		patchReplace("/tags", tags),
 		patchReplace("/kind", kind),
-		patchReplace("/isActive", isActive),
 		patchReplace("/isNumeric", isNumeric),
 		patchReplace("/urls", urlPosts),
 		patchReplace("/unit", unit),
@@ -688,11 +695,6 @@ func (r *MetricResource) readIntoModel(
 	data.Name = types.StringValue(metric.Name)
 	data.Description = stringValueFromPointer(metric.Description)
 	data.Kind = types.StringValue(metric.Kind)
-	if metric.IsActive != nil {
-		data.IsActive = types.BoolValue(*metric.IsActive)
-	} else {
-		data.IsActive = types.BoolValue(false)
-	}
 	if metric.IsNumeric != nil {
 		data.IsNumeric = types.BoolValue(*metric.IsNumeric)
 	} else {

--- a/launchdarkly/resource_metric_upgrade.go
+++ b/launchdarkly/resource_metric_upgrade.go
@@ -1,0 +1,50 @@
+package launchdarkly
+
+// Frozen pre-v3 metric schema + model used as PriorSchema for the
+// v0->v1 state upgrader. The v0 shape (v2.x SDKv2 provider) carried
+// the deprecated `is_active` attribute; v3 drops it. The upgrader
+// decodes prior state into MetricResourceModelV0 and projects to the
+// current MetricResourceModel, discarding IsActive.
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type MetricResourceModelV0 struct {
+	ID                        types.String `tfsdk:"id"`
+	ProjectKey                types.String `tfsdk:"project_key"`
+	Key                       types.String `tfsdk:"key"`
+	Name                      types.String `tfsdk:"name"`
+	Kind                      types.String `tfsdk:"kind"`
+	MaintainerID              types.String `tfsdk:"maintainer_id"`
+	Description               types.String `tfsdk:"description"`
+	Tags                      types.Set    `tfsdk:"tags"`
+	IsActive                  types.Bool   `tfsdk:"is_active"`
+	IsNumeric                 types.Bool   `tfsdk:"is_numeric"`
+	Unit                      types.String `tfsdk:"unit"`
+	Selector                  types.String `tfsdk:"selector"`
+	EventKey                  types.String `tfsdk:"event_key"`
+	SuccessCriteria           types.String `tfsdk:"success_criteria"`
+	URLs                      types.List   `tfsdk:"urls"`
+	RandomizationUnits        types.Set    `tfsdk:"randomization_units"`
+	IncludeUnitsWithoutEvents types.Bool   `tfsdk:"include_units_without_events"`
+	UnitAggregationType       types.String `tfsdk:"unit_aggregation_type"`
+	AnalysisType              types.String `tfsdk:"analysis_type"`
+	PercentileValue           types.Int64  `tfsdk:"percentile_value"`
+	Version                   types.Int64  `tfsdk:"version"`
+}
+
+// metricSchemaAttributesV0 returns the current attribute map plus the
+// removed is_active attribute, so the v0->v1 upgrader can decode prior
+// state shapes captured under the v2.x SDKv2 provider.
+func metricSchemaAttributesV0() map[string]schema.Attribute {
+	attrs := metricSchemaAttributes()
+	attrs[IS_ACTIVE] = schema.BoolAttribute{
+		Optional:           true,
+		Computed:           true,
+		Description:        "Ignored. All metrics are considered active.",
+		DeprecationMessage: "No longer in use. This field will be removed in a future major release of the LaunchDarkly provider.",
+	}
+	return attrs
+}

--- a/scripts/migrate-tf-syntax/README.md
+++ b/scripts/migrate-tf-syntax/README.md
@@ -26,16 +26,28 @@ go build -o ../../bin/migrate-tf-syntax .
 
 ## Mapping file format
 
-`mappings.json` (embedded as default) maps resource type → list of attributes that switched from block to list-of-objects. Nested entries describe attributes inside an element that themselves migrated (e.g. `rules` contains `clauses`).
+`mappings.json` (embedded as default) maps resource type → object containing two optional sections:
+
+- `blocks` — attributes that switched from block to list-of-objects nested attribute. Nested entries describe attributes inside an element that themselves migrated (e.g. `rules` contains `clauses`).
+- `deprecations` — attributes removed from the v3 schema. Each entry has `name`, `action`, and (for some actions) `to`. Supported actions:
+  - `drop` — remove the attribute outright (no replacement).
 
 ```json
 {
-  "launchdarkly_segment": [
-    { "name": "included_contexts" },
-    { "name": "rules", "nested": [{ "name": "clauses" }] }
-  ]
+  "launchdarkly_segment": {
+    "blocks": [
+      { "name": "included_contexts" },
+      { "name": "rules", "nested": [{ "name": "clauses" }] }
+    ]
+  },
+  "launchdarkly_metric": {
+    "blocks": [{ "name": "urls" }],
+    "deprecations": [{ "name": "is_active", "action": "drop" }]
+  }
 }
 ```
+
+Deprecation operations are one-way (v2→v3 only). The reverse direction reinstates block syntax but cannot re-create attributes the v3 schema no longer accepts.
 
 The embedded default ships every attribute touched by LD provider v3.0.0. Pass `-mappings path.json` to override.
 

--- a/scripts/migrate-tf-syntax/main.go
+++ b/scripts/migrate-tf-syntax/main.go
@@ -34,7 +34,22 @@ type AttrSpec struct {
 	Nested []*AttrSpec `json:"nested,omitempty"`
 }
 
-type Spec map[string][]*AttrSpec
+// DeprecationSpec describes an attribute that was removed from the provider schema between v2 and v3.
+// Supported actions:
+//   - "drop": remove the attribute from the resource body (no replacement).
+type DeprecationSpec struct {
+	Name   string `json:"name"`
+	Action string `json:"action"`
+	To     string `json:"to,omitempty"`
+}
+
+// ResourceSpec bundles all rewrite operations that apply to one resource type.
+type ResourceSpec struct {
+	Blocks       []*AttrSpec        `json:"blocks,omitempty"`
+	Deprecations []*DeprecationSpec `json:"deprecations,omitempty"`
+}
+
+type Spec map[string]*ResourceSpec
 
 func main() {
 	var (
@@ -100,15 +115,20 @@ func process(path, direction string, spec Spec, dryRun bool) error {
 		if len(labels) < 1 {
 			continue
 		}
-		specs, ok := spec[labels[0]]
-		if !ok {
+		rspec, ok := spec[labels[0]]
+		if !ok || rspec == nil {
 			continue
 		}
 		var did bool
 		if direction == "v2-to-v3" {
-			did = forward(blk.Body(), specs)
+			if forward(blk.Body(), rspec.Blocks) {
+				did = true
+			}
+			if applyDeprecations(blk.Body(), rspec.Deprecations) {
+				did = true
+			}
 		} else {
-			did = reverse(blk.Body(), specs)
+			did = reverse(blk.Body(), rspec.Blocks)
 		}
 		if did {
 			changed = true
@@ -203,6 +223,25 @@ func reverse(body *hclwrite.Body, specs []*AttrSpec) bool {
 				newBlock.Body().AppendUnstructuredTokens(elem)
 			}
 			changed = true
+		}
+	}
+	return changed
+}
+
+// applyDeprecations runs each deprecation rule against the resource body. Returns true if any
+// rewrite happened. v2-to-v3 only; reverse direction is unsupported (deprecation removals are
+// strictly one-way — the attribute no longer exists in the v3 schema).
+func applyDeprecations(body *hclwrite.Body, deps []*DeprecationSpec) bool {
+	changed := false
+	for _, d := range deps {
+		switch d.Action {
+		case "drop":
+			if body.GetAttribute(d.Name) != nil {
+				body.RemoveAttribute(d.Name)
+				changed = true
+			}
+		default:
+			fmt.Fprintf(os.Stderr, "warning: unknown deprecation action %q for attribute %q (skipping)\n", d.Action, d.Name)
 		}
 	}
 	return changed

--- a/scripts/migrate-tf-syntax/mappings.json
+++ b/scripts/migrate-tf-syntax/mappings.json
@@ -1,64 +1,77 @@
 {
-  "launchdarkly_access_token": [
-    {"name": "inline_roles"},
-    {"name": "policy_statements"}
-  ],
-  "launchdarkly_audit_log_subscription": [
-    {"name": "statements"}
-  ],
-  "launchdarkly_webhook": [
-    {"name": "statements"}
-  ],
-  "launchdarkly_custom_role": [
-    {"name": "policy"},
-    {"name": "policy_statements"}
-  ],
-  "launchdarkly_relay_proxy_configuration": [
-    {"name": "policy"}
-  ],
-  "launchdarkly_project": [
-    {"name": "default_client_side_availability"},
-    {"name": "environments", "nested": [{"name": "approval_settings"}]}
-  ],
-  "launchdarkly_environment": [
-    {"name": "approval_settings"}
-  ],
-  "launchdarkly_segment": [
-    {"name": "included_contexts"},
-    {"name": "excluded_contexts"},
-    {"name": "rules", "nested": [{"name": "clauses"}]}
-  ],
-  "launchdarkly_flag_trigger": [
-    {"name": "instructions"}
-  ],
-  "launchdarkly_view_links": [
-    {"name": "segments"}
-  ],
-  "launchdarkly_metric": [
-    {"name": "urls"}
-  ],
-  "launchdarkly_team": [
-    {"name": "role_attributes"}
-  ],
-  "launchdarkly_team_member": [
-    {"name": "role_attributes"}
-  ],
-  "launchdarkly_ai_config_variation": [
-    {"name": "messages"}
-  ],
-  "launchdarkly_flag_templates": [
-    {"name": "boolean_defaults"}
-  ],
-  "launchdarkly_feature_flag_environment": [
-    {"name": "prerequisites"},
-    {"name": "targets"},
-    {"name": "context_targets"},
-    {"name": "rules", "nested": [{"name": "clauses"}]},
-    {"name": "fallthrough"}
-  ],
-  "launchdarkly_feature_flag": [
-    {"name": "client_side_availability"},
-    {"name": "variations"},
-    {"name": "defaults"}
-  ]
+  "launchdarkly_access_token": {
+    "blocks": [
+      {"name": "inline_roles"},
+      {"name": "policy_statements"}
+    ]
+  },
+  "launchdarkly_audit_log_subscription": {
+    "blocks": [{"name": "statements"}]
+  },
+  "launchdarkly_webhook": {
+    "blocks": [{"name": "statements"}]
+  },
+  "launchdarkly_custom_role": {
+    "blocks": [
+      {"name": "policy"},
+      {"name": "policy_statements"}
+    ]
+  },
+  "launchdarkly_relay_proxy_configuration": {
+    "blocks": [{"name": "policy"}]
+  },
+  "launchdarkly_project": {
+    "blocks": [
+      {"name": "default_client_side_availability"},
+      {"name": "environments", "nested": [{"name": "approval_settings"}]}
+    ]
+  },
+  "launchdarkly_environment": {
+    "blocks": [{"name": "approval_settings"}]
+  },
+  "launchdarkly_segment": {
+    "blocks": [
+      {"name": "included_contexts"},
+      {"name": "excluded_contexts"},
+      {"name": "rules", "nested": [{"name": "clauses"}]}
+    ]
+  },
+  "launchdarkly_flag_trigger": {
+    "blocks": [{"name": "instructions"}]
+  },
+  "launchdarkly_view_links": {
+    "blocks": [{"name": "segments"}]
+  },
+  "launchdarkly_metric": {
+    "blocks": [{"name": "urls"}],
+    "deprecations": [{"name": "is_active", "action": "drop"}]
+  },
+  "launchdarkly_team": {
+    "blocks": [{"name": "role_attributes"}]
+  },
+  "launchdarkly_team_member": {
+    "blocks": [{"name": "role_attributes"}]
+  },
+  "launchdarkly_ai_config_variation": {
+    "blocks": [{"name": "messages"}]
+  },
+  "launchdarkly_flag_templates": {
+    "blocks": [{"name": "boolean_defaults"}]
+  },
+  "launchdarkly_feature_flag_environment": {
+    "blocks": [
+      {"name": "prerequisites"},
+      {"name": "targets"},
+      {"name": "context_targets"},
+      {"name": "rules", "nested": [{"name": "clauses"}]},
+      {"name": "fallthrough"}
+    ]
+  },
+  "launchdarkly_feature_flag": {
+    "blocks": [
+      {"name": "client_side_availability"},
+      {"name": "variations"},
+      {"name": "defaults"}
+    ]
+  }
 }


### PR DESCRIPTION
is_active was deprecated in v2.21.0 (Oct 2024) and is no longer used by
the LaunchDarkly API — all metrics are considered active. Drop it from
the launchdarkly_metric resource and data source schemas and from the
update PATCH payload.

State-upgrade path: the existing v0->v1 upgrader now decodes prior
state into a frozen MetricResourceModelV0 (which still carries
is_active) and projects to the current MetricResourceModel without it.
Users on v2.x will migrate cleanly on next apply — no manual state
edits required.

HCL migration: scripts/migrate-tf-syntax gains a "deprecations" section
in mappings.json with a "drop" action handler. Running v2-to-v3 on
existing configs strips is_active from launchdarkly_metric resource
blocks. README updated.

The mappings.json shape changed from `map[string][]AttrSpec` to a
per-resource object with `blocks` and `deprecations` arrays — v3
preview only, no backwards-compat needed.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>