### PR TITLE
feat(feature_flag)!: remove deprecated include_in_snippet attribute

### DIFF
--- a/docs/data-sources/feature_flag.md
+++ b/docs/data-sources/feature_flag.md
@@ -88,7 +88,6 @@ output "team_notifications" {
 - `deprecated` (Boolean) Whether the flag is deprecated.
 - `description` (String) Feature flag description.
 - `id` (String) Composite ID `project_key/key`.
-- `include_in_snippet` (Boolean, Deprecated) Deprecated: use client_side_availability.using_environment_id.
 - `name` (String) Human-readable name.
 - `tags` (Set of String) Tags.
 - `temporary` (Boolean) Whether the flag is temporary.

--- a/docs/resources/feature_flag.md
+++ b/docs/resources/feature_flag.md
@@ -146,7 +146,6 @@ resource "launchdarkly_feature_flag" "mobile_app_feature" {
 - `defaults` (Attributes List) The indices of the variations to be used as the default on and off variations in all new environments. Flag configurations in existing environments will not be changed nor updated if removed. (see [below for nested schema](#nestedatt--defaults))
 - `deprecated` (Boolean) Specifies whether the flag is deprecated or not. Note that you cannot create a new flag that is deprecated, but can update a flag to be deprecated.
 - `description` (String) The feature flag's description.
-- `include_in_snippet` (Boolean, Deprecated) Specifies whether this flag should be made available to the client-side JavaScript SDK using the client-side Id. This value gets its default from your project configuration if not set. `include_in_snippet` is now deprecated. Please migrate to `client_side_availability.using_environment_id` to maintain future compatibility.
 - `maintainer_id` (String) The feature flag maintainer's 24 character alphanumeric team member ID. `maintainer_team_key` cannot be set if `maintainer_id` is set. If neither is set, it will automatically be or stay set to the member ID associated with the API key used by your LaunchDarkly Terraform provider or the most recently-set maintainer.
 - `maintainer_team_key` (String) The key of the associated team that maintains this feature flag. `maintainer_id` cannot be set if `maintainer_team_key` is set
 - `tags` (Set of String) Tags associated with your resource.

--- a/launchdarkly/data_source_feature_flag_framework.go
+++ b/launchdarkly/data_source_feature_flag_framework.go
@@ -30,7 +30,6 @@ type FeatureFlagDataSourceModel struct {
 	VariationType          types.String `tfsdk:"variation_type"`
 	Variations             types.List   `tfsdk:"variations"`
 	Temporary              types.Bool   `tfsdk:"temporary"`
-	IncludeInSnippet       types.Bool   `tfsdk:"include_in_snippet"`
 	ClientSideAvailability types.List   `tfsdk:"client_side_availability"`
 	CustomProperties       types.Set    `tfsdk:"custom_properties"`
 	Defaults               types.List   `tfsdk:"defaults"`
@@ -87,13 +86,8 @@ func (d *FeatureFlagDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 			TAGS:           schema.SetAttribute{Computed: true, ElementType: types.StringType, Description: "Tags."},
 			VARIATION_TYPE: schema.StringAttribute{Computed: true, Description: fmt.Sprintf("Variation type: %q, %q, %q, or %q.", BOOL_VARIATION, STRING_VARIATION, NUMBER_VARIATION, JSON_VARIATION)},
 			TEMPORARY:      schema.BoolAttribute{Computed: true, Description: "Whether the flag is temporary."},
-			INCLUDE_IN_SNIPPET: schema.BoolAttribute{
-				Computed:           true,
-				Description:        "Deprecated: use client_side_availability.using_environment_id.",
-				DeprecationMessage: "'include_in_snippet' is now deprecated. Please migrate to 'client_side_availability' to maintain future compatability.",
-			},
-			ARCHIVED:   schema.BoolAttribute{Computed: true, Description: "Whether the flag is archived."},
-			DEPRECATED: schema.BoolAttribute{Computed: true, Description: "Whether the flag is deprecated."},
+			ARCHIVED:       schema.BoolAttribute{Computed: true, Description: "Whether the flag is archived."},
+			DEPRECATED:     schema.BoolAttribute{Computed: true, Description: "Whether the flag is deprecated."},
 			VIEW_KEYS: schema.SetAttribute{
 				Computed:    true,
 				ElementType: types.StringType,
@@ -211,7 +205,6 @@ func (d *FeatureFlagDataSource) Read(ctx context.Context, req datasource.ReadReq
 	resp.Diagnostics.Append(diags...)
 	data.Tags = tagsSet
 
-	// client_side_availability + include_in_snippet
 	csaType := types.ObjectType{AttrTypes: map[string]attr.Type{
 		USING_ENVIRONMENT_ID: types.BoolType,
 		USING_MOBILE_KEY:     types.BoolType,
@@ -238,7 +231,6 @@ func (d *FeatureFlagDataSource) Read(ctx context.Context, req datasource.ReadReq
 	csaList, diags := types.ListValue(csaType, []attr.Value{csaObj})
 	resp.Diagnostics.Append(diags...)
 	data.ClientSideAvailability = csaList
-	data.IncludeInSnippet = types.BoolValue(usingEnvID)
 
 	// variations
 	variationType, err := variationsToVariationType(flag.Variations)

--- a/launchdarkly/feature_flag_helpers.go
+++ b/launchdarkly/feature_flag_helpers.go
@@ -41,9 +41,9 @@ func flagIdToKeys(id string) (projectKey, flagKey string, err error) {
 	return parts[0], parts[1], nil
 }
 
-// getProjectDefaultCSAandIncludeInSnippet returns the project's default
-// CSA + IncludeInSnippet for use when a feature_flag config omits both.
-func getProjectDefaultCSAandIncludeInSnippet(client *Client, projectKey string) (ldapi.ClientSideAvailability, bool, error) {
+// getProjectDefaultCSA returns the project's default client-side
+// availability for use when a feature_flag config omits CSA.
+func getProjectDefaultCSA(client *Client, projectKey string) (ldapi.ClientSideAvailability, error) {
 	var project *ldapi.Project
 	var err error
 	err = client.withConcurrency(client.ctx, func() error {
@@ -51,9 +51,9 @@ func getProjectDefaultCSAandIncludeInSnippet(client *Client, projectKey string) 
 		return err
 	})
 	if err != nil {
-		return ldapi.ClientSideAvailability{}, false, err
+		return ldapi.ClientSideAvailability{}, err
 	}
-	return *project.DefaultClientSideAvailability, project.IncludeInSnippetByDefault, nil
+	return *project.DefaultClientSideAvailability, nil
 }
 
 // FeatureFlagBodyWithViewKeys represents the feature flag creation

--- a/launchdarkly/framework_schema_compat_test.go
+++ b/launchdarkly/framework_schema_compat_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestIsOmittedFrameworkAttrDiag_PositiveMatch(t *testing.T) {
-	attrPath := path.Root("include_in_snippet")
+	attrPath := path.Root("deprecated_attr")
 	d := diag.NewAttributeErrorDiagnostic(
 		attrPath,
 		"State Write Error",
@@ -26,13 +26,13 @@ func TestIsOmittedFrameworkAttrDiag_WrongPath(t *testing.T) {
 		"State Write Error",
 		"An unexpected error was encountered trying to retrieve type information at a given path.",
 	)
-	if isOmittedFrameworkAttrDiag(d, path.Root("include_in_snippet")) {
+	if isOmittedFrameworkAttrDiag(d, path.Root("deprecated_attr")) {
 		t.Fatalf("matcher must scope on attribute path; mismatched path should not match")
 	}
 }
 
 func TestIsOmittedFrameworkAttrDiag_WrongSummary(t *testing.T) {
-	attrPath := path.Root("include_in_snippet")
+	attrPath := path.Root("deprecated_attr")
 	d := diag.NewAttributeErrorDiagnostic(
 		attrPath,
 		"Some Other Error",
@@ -44,7 +44,7 @@ func TestIsOmittedFrameworkAttrDiag_WrongSummary(t *testing.T) {
 }
 
 func TestIsOmittedFrameworkAttrDiag_WrongDetail(t *testing.T) {
-	attrPath := path.Root("include_in_snippet")
+	attrPath := path.Root("deprecated_attr")
 	d := diag.NewAttributeErrorDiagnostic(
 		attrPath,
 		"State Write Error",
@@ -56,7 +56,7 @@ func TestIsOmittedFrameworkAttrDiag_WrongDetail(t *testing.T) {
 }
 
 func TestFilterOmittedAttrDiags_PassThroughUnrelated(t *testing.T) {
-	attrPath := path.Root("include_in_snippet")
+	attrPath := path.Root("deprecated_attr")
 
 	matching := diag.NewAttributeErrorDiagnostic(
 		attrPath,
@@ -83,7 +83,7 @@ func TestIsOmittedFrameworkAttrDiag_NonAttributePathDoesNotMatch(t *testing.T) {
 		"State Write Error",
 		"An unexpected error was encountered trying to retrieve type information at a given path.",
 	)
-	if isOmittedFrameworkAttrDiag(d, path.Root("include_in_snippet")) {
+	if isOmittedFrameworkAttrDiag(d, path.Root("deprecated_attr")) {
 		t.Fatalf("plain error diagnostics must not match path-scoped matcher")
 	}
 }

--- a/launchdarkly/resource_feature_flag_framework.go
+++ b/launchdarkly/resource_feature_flag_framework.go
@@ -533,7 +533,7 @@ func (r *FeatureFlagResource) Create(ctx context.Context, req resource.CreateReq
 		}
 		finalCSA = csa
 	} else {
-		defaultCSA, _, err := getProjectDefaultCSAandIncludeInSnippet(r.client, projectKey)
+		defaultCSA, err := getProjectDefaultCSA(r.client, projectKey)
 		if err != nil {
 			resp.Diagnostics.AddError(fmt.Sprintf("failed to get project level client side availability defaults. %s", err.Error()), "")
 			return

--- a/launchdarkly/resource_feature_flag_framework.go
+++ b/launchdarkly/resource_feature_flag_framework.go
@@ -54,7 +54,6 @@ type FeatureFlagResourceModel struct {
 	VariationType          types.String `tfsdk:"variation_type"`
 	Variations             types.List   `tfsdk:"variations"`
 	Temporary              types.Bool   `tfsdk:"temporary"`
-	IncludeInSnippet       types.Bool   `tfsdk:"include_in_snippet"`
 	ClientSideAvailability types.List   `tfsdk:"client_side_availability"`
 	CustomProperties       types.Set    `tfsdk:"custom_properties"`
 	Defaults               types.List   `tfsdk:"defaults"`
@@ -147,17 +146,6 @@ func featureFlagSchemaAttributes() map[string]schema.Attribute {
 			Computed:    true,
 			Default:     booldefault.StaticBool(false),
 			Description: "Specifies whether the flag is a temporary flag.",
-		},
-		INCLUDE_IN_SNIPPET: schema.BoolAttribute{
-			Optional:           true,
-			Computed:           true,
-			Description:        "Specifies whether this flag should be made available to the client-side JavaScript SDK using the client-side Id. This value gets its default from your project configuration if not set. `include_in_snippet` is now deprecated. Please migrate to `client_side_availability.using_environment_id` to maintain future compatibility.",
-			DeprecationMessage: "'include_in_snippet' is now deprecated. Please migrate to 'client_side_availability' to maintain future compatability.",
-			// Intentionally no UseStateForUnknown: include_in_snippet
-			// and client_side_availability are mutually exclusive
-			// (ConfigValidators.Conflicting). When the user switches
-			// between them, plan must recompute rather than preserve
-			// the previous state's value.
 		},
 		TAGS: schema.SetAttribute{
 			Optional:    true,
@@ -323,24 +311,57 @@ func featureFlagCSAMatchesAPIShape(ctx context.Context, csa types.List) bool {
 }
 
 func (r *FeatureFlagResource) UpgradeState(_ context.Context) map[int64]resource.StateUpgrader {
-	priorSchema := schema.Schema{Attributes: featureFlagSchemaAttributes()}
+	priorSchema := schema.Schema{Attributes: featureFlagSchemaAttributesV0()}
 	return map[int64]resource.StateUpgrader{
 		0: {
 			PriorSchema: &priorSchema,
 			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				var data FeatureFlagResourceModel
-				resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+				var prior FeatureFlagResourceModelV0
+				resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
 				if resp.Diagnostics.HasError() {
 					return
 				}
-				data.Tags = nullIfEmptySet(ctx, data.Tags)
-				data.CustomProperties = nullIfEmptySet(ctx, data.CustomProperties)
-				data.ViewKeys = nullIfEmptySet(ctx, data.ViewKeys)
-				data.Description = nullIfEmptyString(data.Description)
+				data := FeatureFlagResourceModel{
+					ID:                     prior.ID,
+					ProjectKey:             prior.ProjectKey,
+					Key:                    prior.Key,
+					Name:                   prior.Name,
+					Description:            nullIfEmptyString(prior.Description),
+					MaintainerID:           prior.MaintainerID,
+					MaintainerTeamKey:      prior.MaintainerTeamKey,
+					Tags:                   nullIfEmptySet(ctx, prior.Tags),
+					VariationType:          prior.VariationType,
+					Variations:             prior.Variations,
+					Temporary:              prior.Temporary,
+					ClientSideAvailability: prior.ClientSideAvailability,
+					CustomProperties:       nullIfEmptySet(ctx, prior.CustomProperties),
+					Defaults:               prior.Defaults,
+					Archived:               prior.Archived,
+					Deprecated:             prior.Deprecated,
+					ViewKeys:               nullIfEmptySet(ctx, prior.ViewKeys),
+				}
 				if featureFlagDefaultsMatchesAPIShape(ctx, data.Defaults, data.Variations) {
 					data.Defaults = types.ListNull(data.Defaults.ElementType(ctx))
 				}
-				if featureFlagCSAMatchesAPIShape(ctx, data.ClientSideAvailability) {
+				// IIS->CSA migration: when prior state set include_in_snippet
+				// and left client_side_availability empty, materialize the
+				// CSA list so the resource still controls SDK availability.
+				// using_mobile_key was never expressible via IIS — match the
+				// Create-path projection (false). When both were populated,
+				// the v2 Conflicting validator should have prevented it, so
+				// drop IIS and keep CSA.
+				csaEmpty := data.ClientSideAvailability.IsNull() || data.ClientSideAvailability.IsUnknown() || len(data.ClientSideAvailability.Elements()) == 0
+				iisSet := !prior.IncludeInSnippet.IsNull() && !prior.IncludeInSnippet.IsUnknown()
+				if csaEmpty && iisSet {
+					obj, d := types.ObjectValue(featureFlagCSAAttrTypes, map[string]attr.Value{
+						USING_ENVIRONMENT_ID: types.BoolValue(prior.IncludeInSnippet.ValueBool()),
+						USING_MOBILE_KEY:     types.BoolValue(false),
+					})
+					resp.Diagnostics.Append(d...)
+					list, d := types.ListValue(types.ObjectType{AttrTypes: featureFlagCSAAttrTypes}, []attr.Value{obj})
+					resp.Diagnostics.Append(d...)
+					data.ClientSideAvailability = list
+				} else if featureFlagCSAMatchesAPIShape(ctx, data.ClientSideAvailability) {
 					data.ClientSideAvailability = types.ListNull(data.ClientSideAvailability.ElementType(ctx))
 				}
 				resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -351,10 +372,6 @@ func (r *FeatureFlagResource) UpgradeState(_ context.Context) map[int64]resource
 
 func (r *FeatureFlagResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
 	return []resource.ConfigValidator{
-		resourcevalidator.Conflicting(
-			path.MatchRoot(INCLUDE_IN_SNIPPET),
-			path.MatchRoot(CLIENT_SIDE_AVAILABILITY),
-		),
 		resourcevalidator.Conflicting(
 			path.MatchRoot(MAINTAINER_ID),
 			path.MatchRoot(MAINTAINER_TEAM_KEY),
@@ -506,23 +523,16 @@ func (r *FeatureFlagResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	csaPlanned := !plan.ClientSideAvailability.IsNull() && !plan.ClientSideAvailability.IsUnknown() && len(plan.ClientSideAvailability.Elements()) > 0
-	iisPlanned := !plan.IncludeInSnippet.IsNull() && !plan.IncludeInSnippet.IsUnknown()
 
 	var finalCSA *ldapi.ClientSideAvailabilityPost
-	switch {
-	case csaPlanned:
+	if csaPlanned {
 		csa, d := csaPostFromList(ctx, plan.ClientSideAvailability)
 		resp.Diagnostics.Append(d...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
 		finalCSA = csa
-	case iisPlanned:
-		finalCSA = &ldapi.ClientSideAvailabilityPost{
-			UsingEnvironmentId: plan.IncludeInSnippet.ValueBool(),
-			UsingMobileKey:     false,
-		}
-	default:
+	} else {
 		defaultCSA, _, err := getProjectDefaultCSAandIncludeInSnippet(r.client, projectKey)
 		if err != nil {
 			resp.Diagnostics.AddError(fmt.Sprintf("failed to get project level client side availability defaults. %s", err.Error()), "")
@@ -700,9 +710,7 @@ func (r *FeatureFlagResource) applyFlagUpdate(ctx context.Context, plan, state F
 	}
 
 	csaChanged := isCreate || !plan.ClientSideAvailability.Equal(state.ClientSideAvailability)
-	iisChanged := isCreate || !plan.IncludeInSnippet.Equal(state.IncludeInSnippet)
 	csaPlanned := !plan.ClientSideAvailability.IsNull() && !plan.ClientSideAvailability.IsUnknown() && len(plan.ClientSideAvailability.Elements()) > 0
-	iisPlanned := !plan.IncludeInSnippet.IsNull() && !plan.IncludeInSnippet.IsUnknown()
 
 	if csaPlanned && csaChanged && !isCreate {
 		csa, d := csaPostFromList(ctx, plan.ClientSideAvailability)
@@ -711,11 +719,6 @@ func (r *FeatureFlagResource) applyFlagUpdate(ctx context.Context, plan, state F
 			return diags
 		}
 		patch.Patch = append(patch.Patch, patchReplace("/clientSideAvailability", csa))
-	} else if iisPlanned && iisChanged && !isCreate {
-		patch.Patch = append(patch.Patch, patchReplace("/clientSideAvailability", &ldapi.ClientSideAvailabilityPost{
-			UsingEnvironmentId: plan.IncludeInSnippet.ValueBool(),
-			UsingMobileKey:     false,
-		}))
 	}
 
 	if !isCreate {
@@ -861,15 +864,9 @@ func (r *FeatureFlagResource) readIntoModel(ctx context.Context, data *FeatureFl
 	diags.Append(d...)
 	data.Tags = tagsSet
 
-	// CSA + IIS — emit both so plan/state remains stable.
 	csaList, d := featureFlagCSAListFromAPI(ctx, flag.ClientSideAvailability, data.ClientSideAvailability)
 	diags.Append(d...)
 	data.ClientSideAvailability = csaList
-	usingEnvID := false
-	if flag.ClientSideAvailability != nil && flag.ClientSideAvailability.UsingEnvironmentId != nil {
-		usingEnvID = *flag.ClientSideAvailability.UsingEnvironmentId
-	}
-	data.IncludeInSnippet = types.BoolValue(usingEnvID)
 
 	// Maintainer fields — Optional+Computed. Only write these to state
 	// when the user declares either maintainer_id or maintainer_team_key:

--- a/launchdarkly/resource_feature_flag_upgrade.go
+++ b/launchdarkly/resource_feature_flag_upgrade.go
@@ -1,0 +1,50 @@
+package launchdarkly
+
+// Frozen pre-v3 feature_flag schema + model used as PriorSchema for
+// the v0->v1 state upgrader. The v0 shape (v2.x SDKv2 provider)
+// carried the deprecated `include_in_snippet` attribute; v3 drops it.
+// The upgrader decodes prior state into FeatureFlagResourceModelV0
+// and projects to the current FeatureFlagResourceModel, materializing
+// `client_side_availability` from `include_in_snippet` when CSA was
+// absent in prior state.
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type FeatureFlagResourceModelV0 struct {
+	ID                     types.String `tfsdk:"id"`
+	ProjectKey             types.String `tfsdk:"project_key"`
+	Key                    types.String `tfsdk:"key"`
+	Name                   types.String `tfsdk:"name"`
+	Description            types.String `tfsdk:"description"`
+	MaintainerID           types.String `tfsdk:"maintainer_id"`
+	MaintainerTeamKey      types.String `tfsdk:"maintainer_team_key"`
+	Tags                   types.Set    `tfsdk:"tags"`
+	VariationType          types.String `tfsdk:"variation_type"`
+	Variations             types.List   `tfsdk:"variations"`
+	Temporary              types.Bool   `tfsdk:"temporary"`
+	IncludeInSnippet       types.Bool   `tfsdk:"include_in_snippet"`
+	ClientSideAvailability types.List   `tfsdk:"client_side_availability"`
+	CustomProperties       types.Set    `tfsdk:"custom_properties"`
+	Defaults               types.List   `tfsdk:"defaults"`
+	Archived               types.Bool   `tfsdk:"archived"`
+	Deprecated             types.Bool   `tfsdk:"deprecated"`
+	ViewKeys               types.Set    `tfsdk:"view_keys"`
+}
+
+// featureFlagSchemaAttributesV0 returns the current attribute map
+// plus the removed include_in_snippet attribute, so the v0->v1
+// upgrader can decode prior state shapes captured under the v2.x
+// SDKv2 provider.
+func featureFlagSchemaAttributesV0() map[string]schema.Attribute {
+	attrs := featureFlagSchemaAttributes()
+	attrs[INCLUDE_IN_SNIPPET] = schema.BoolAttribute{
+		Optional:           true,
+		Computed:           true,
+		Description:        "Specifies whether this flag should be made available to the client-side JavaScript SDK using the client-side Id. This value gets its default from your project configuration if not set. `include_in_snippet` is now deprecated. Please migrate to `client_side_availability.using_environment_id` to maintain future compatibility.",
+		DeprecationMessage: "'include_in_snippet' is now deprecated. Please migrate to 'client_side_availability' to maintain future compatability.",
+	}
+	return attrs
+}

--- a/launchdarkly/resource_launchdarkly_feature_flag_test.go
+++ b/launchdarkly/resource_launchdarkly_feature_flag_test.go
@@ -100,7 +100,6 @@ resource "launchdarkly_feature_flag" "basic" {
 	]
 	description = "this is a boolean flag by default because the variations field is omitted"
 	tags = ["update", "terraform"]
-	include_in_snippet = true
 	temporary = true
 	defaults = [{
 		on_variation = 1
@@ -498,44 +497,6 @@ resource "launchdarkly_feature_flag" "empty_string_variation" {
 	}]
 }
 `
-	testAccFeatureFlagIncludeInSnippet = `
-resource "launchdarkly_feature_flag" "sdk_settings" {
-	project_key = launchdarkly_project.test.key
-	key = "basic-flag-sdk-settings"
-	name = "Basic feature flag"
-	variation_type = "boolean"
-	variations = [
-		{ value = "true" },
-		{ value = "false" },
-	]
-	include_in_snippet = true
-}
-`
-	testAccFeatureFlagIncludeInSnippetUpdate = `
-resource "launchdarkly_feature_flag" "sdk_settings" {
-	project_key = launchdarkly_project.test.key
-	key = "basic-flag-sdk-settings"
-	name = "Basic feature flag"
-	variation_type = "boolean"
-	variations = [
-		{ value = "true" },
-		{ value = "false" },
-	]
-	include_in_snippet = false
-}
-`
-	testAccFeatureFlagIncludeInSnippetEmpty = `
-resource "launchdarkly_feature_flag" "sdk_settings" {
-	project_key = launchdarkly_project.test.key
-	key = "basic-flag-sdk-settings"
-	name = "Basic feature flag"
-	variation_type = "boolean"
-	variations = [
-		{ value = "true" },
-		{ value = "false" },
-	]
-}
-`
 	testAccFeatureFlagClientSideAvailability = `
 resource "launchdarkly_feature_flag" "sdk_settings" {
 	project_key = launchdarkly_project.test.key
@@ -688,7 +649,6 @@ func TestAccFeatureFlag_BasicCreateAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "terraform"),
 					resource.TestCheckResourceAttr(resourceName, "tags.1", "update"),
-					resource.TestCheckResourceAttr(resourceName, INCLUDE_IN_SNIPPET, "true"),
 					resource.TestCheckResourceAttr(resourceName, TEMPORARY, "true"),
 					resource.TestCheckResourceAttr(resourceName, "defaults.0.on_variation", "1"),
 					resource.TestCheckResourceAttr(resourceName, "defaults.0.off_variation", "1"),
@@ -1416,214 +1376,6 @@ func TestAccFeatureFlag_ClientSideAvailabilityUpdate(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceName, MAINTAINER_ID),
 					resource.TestCheckResourceAttr(resourceName, "client_side_availability.0.using_environment_id", "false"),
 					resource.TestCheckResourceAttr(resourceName, "client_side_availability.0.using_mobile_key", "false"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: importIgnoreOptionalComputedKeys,
-			},
-		},
-	})
-}
-
-func TestAccFeatureFlag_IncludeInSnippetToClientSide(t *testing.T) {
-	projectKey := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	resourceName := "launchdarkly_feature_flag.sdk_settings"
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: withRandomProject(projectKey, testAccFeatureFlagIncludeInSnippet),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckProjectExists("launchdarkly_project.test"),
-					testAccCheckFeatureFlagExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, NAME, "Basic feature flag"),
-					resource.TestCheckResourceAttr(resourceName, KEY, "basic-flag-sdk-settings"),
-					resource.TestCheckResourceAttr(resourceName, PROJECT_KEY, projectKey),
-					resource.TestCheckResourceAttr(resourceName, VARIATION_TYPE, "boolean"),
-					resource.TestCheckResourceAttr(resourceName, "variations.#", "2"),
-					resource.TestCheckNoResourceAttr(resourceName, "client_side_availability.#"),
-					resource.TestCheckNoResourceAttr(resourceName, MAINTAINER_ID),
-					resource.TestCheckResourceAttr(resourceName, INCLUDE_IN_SNIPPET, "true"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: importIgnoreOptionalComputedKeys,
-			},
-			{
-				Config: withRandomProject(projectKey, testAccFeatureFlagClientSideAvailability),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckProjectExists("launchdarkly_project.test"),
-					testAccCheckFeatureFlagExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, NAME, "Basic feature flag"),
-					resource.TestCheckResourceAttr(resourceName, KEY, "basic-flag-sdk-settings"),
-					resource.TestCheckResourceAttr(resourceName, PROJECT_KEY, projectKey),
-					resource.TestCheckResourceAttr(resourceName, VARIATION_TYPE, "boolean"),
-					resource.TestCheckResourceAttr(resourceName, "variations.#", "2"),
-					resource.TestCheckNoResourceAttr(resourceName, MAINTAINER_ID),
-					resource.TestCheckResourceAttr(resourceName, "client_side_availability.0.using_environment_id", "true"),
-					resource.TestCheckResourceAttr(resourceName, "client_side_availability.0.using_mobile_key", "true"),
-					resource.TestCheckResourceAttr(resourceName, INCLUDE_IN_SNIPPET, "true"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: importIgnoreOptionalComputedKeys,
-			},
-			{
-				Config: withRandomProject(projectKey, testAccFeatureFlagClientSideAvailabilityUpdate),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckProjectExists("launchdarkly_project.test"),
-					testAccCheckFeatureFlagExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, NAME, "Basic feature flag"),
-					resource.TestCheckResourceAttr(resourceName, KEY, "basic-flag-sdk-settings"),
-					resource.TestCheckResourceAttr(resourceName, PROJECT_KEY, projectKey),
-					resource.TestCheckResourceAttr(resourceName, VARIATION_TYPE, "boolean"),
-					resource.TestCheckResourceAttr(resourceName, "variations.#", "2"),
-					resource.TestCheckNoResourceAttr(resourceName, MAINTAINER_ID),
-					resource.TestCheckResourceAttr(resourceName, "client_side_availability.0.using_environment_id", "false"),
-					resource.TestCheckResourceAttr(resourceName, "client_side_availability.0.using_mobile_key", "false"),
-					resource.TestCheckResourceAttr(resourceName, INCLUDE_IN_SNIPPET, "false"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: importIgnoreOptionalComputedKeys,
-			},
-		},
-	})
-}
-
-func TestAccFeatureFlag_ClientSideToIncludeInSnippet(t *testing.T) {
-	projectKey := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	resourceName := "launchdarkly_feature_flag.sdk_settings"
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: withRandomProject(projectKey, testAccFeatureFlagClientSideAvailability),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckProjectExists("launchdarkly_project.test"),
-					testAccCheckFeatureFlagExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, NAME, "Basic feature flag"),
-					resource.TestCheckResourceAttr(resourceName, KEY, "basic-flag-sdk-settings"),
-					resource.TestCheckResourceAttr(resourceName, PROJECT_KEY, projectKey),
-					resource.TestCheckResourceAttr(resourceName, VARIATION_TYPE, "boolean"),
-					resource.TestCheckResourceAttr(resourceName, "variations.#", "2"),
-					resource.TestCheckNoResourceAttr(resourceName, MAINTAINER_ID),
-					resource.TestCheckResourceAttr(resourceName, "client_side_availability.0.using_environment_id", "true"),
-					resource.TestCheckResourceAttr(resourceName, "client_side_availability.0.using_mobile_key", "true"),
-					resource.TestCheckResourceAttr(resourceName, INCLUDE_IN_SNIPPET, "true"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: importIgnoreOptionalComputedKeys,
-			},
-			{
-				Config: withRandomProject(projectKey, testAccFeatureFlagIncludeInSnippetUpdate),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckProjectExists("launchdarkly_project.test"),
-					testAccCheckFeatureFlagExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, NAME, "Basic feature flag"),
-					resource.TestCheckResourceAttr(resourceName, KEY, "basic-flag-sdk-settings"),
-					resource.TestCheckResourceAttr(resourceName, PROJECT_KEY, projectKey),
-					resource.TestCheckResourceAttr(resourceName, VARIATION_TYPE, "boolean"),
-					resource.TestCheckResourceAttr(resourceName, "variations.#", "2"),
-					resource.TestCheckNoResourceAttr(resourceName, MAINTAINER_ID),
-					// Removing client_side_availability drops it from state
-					// rather than retaining the previously-set values.
-					resource.TestCheckNoResourceAttr(resourceName, "client_side_availability.#"),
-					resource.TestCheckResourceAttr(resourceName, INCLUDE_IN_SNIPPET, "false"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: importIgnoreOptionalComputedKeys,
-			},
-		},
-	})
-}
-
-func TestAccFeatureFlag_IncludeInSnippet(t *testing.T) {
-	projectKey := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	resourceName := "launchdarkly_feature_flag.sdk_settings"
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Create without value set and check for default value
-			{
-				Config: withRandomProjectIncludeInSnippetTrue(projectKey, testAccFeatureFlagIncludeInSnippetEmpty),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckProjectExists("launchdarkly_project.test"),
-					testAccCheckFeatureFlagExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, NAME, "Basic feature flag"),
-					resource.TestCheckResourceAttr(resourceName, KEY, "basic-flag-sdk-settings"),
-					resource.TestCheckResourceAttr(resourceName, PROJECT_KEY, projectKey),
-					resource.TestCheckResourceAttr(resourceName, INCLUDE_IN_SNIPPET, "true"),
-					// Omitted client_side_availability stays null in state;
-					// project defaults are not inflated onto the flag.
-					resource.TestCheckNoResourceAttr(resourceName, "client_side_availability.#"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: importIgnoreOptionalComputedKeys,
-			},
-			// Replace default value with specific value
-			{
-				Config: withRandomProjectIncludeInSnippetTrue(projectKey, testAccFeatureFlagIncludeInSnippetUpdate),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckProjectExists("launchdarkly_project.test"),
-					testAccCheckFeatureFlagExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, NAME, "Basic feature flag"),
-					resource.TestCheckResourceAttr(resourceName, KEY, "basic-flag-sdk-settings"),
-					resource.TestCheckResourceAttr(resourceName, PROJECT_KEY, projectKey),
-					resource.TestCheckResourceAttr(resourceName, INCLUDE_IN_SNIPPET, "false"),
-					resource.TestCheckNoResourceAttr(resourceName, "client_side_availability.#"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: importIgnoreOptionalComputedKeys,
-			},
-			// Clear specific value, should not revert to default
-			{
-				Config: withRandomProjectIncludeInSnippetTrue(projectKey, testAccFeatureFlagIncludeInSnippetEmpty),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckProjectExists("launchdarkly_project.test"),
-					testAccCheckFeatureFlagExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, NAME, "Basic feature flag"),
-					resource.TestCheckResourceAttr(resourceName, KEY, "basic-flag-sdk-settings"),
-					resource.TestCheckResourceAttr(resourceName, PROJECT_KEY, projectKey),
-					resource.TestCheckResourceAttr(resourceName, INCLUDE_IN_SNIPPET, "false"),
-					resource.TestCheckNoResourceAttr(resourceName, "client_side_availability.#"),
 				),
 			},
 			{

--- a/scripts/migrate-tf-syntax/main.go
+++ b/scripts/migrate-tf-syntax/main.go
@@ -240,11 +240,66 @@ func applyDeprecations(body *hclwrite.Body, deps []*DeprecationSpec) bool {
 				body.RemoveAttribute(d.Name)
 				changed = true
 			}
+		case "iis_to_csa":
+			if dropOrConvertIISToCSA(body, d.Name, d.To) {
+				changed = true
+			}
 		default:
 			fmt.Fprintf(os.Stderr, "warning: unknown deprecation action %q for attribute %q (skipping)\n", d.Action, d.Name)
 		}
 	}
 	return changed
+}
+
+// dropOrConvertIISToCSA implements the iis_to_csa deprecation action. If the body already declares
+// `to` (the replacement nested attribute, e.g. client_side_availability or
+// default_client_side_availability), it just removes `name` — config wins. Otherwise it materializes
+// `to = [{ using_environment_id = <iis-value>, using_mobile_key = false }]` and removes `name`.
+//
+// The IIS expression is preserved verbatim (true/false/var refs/etc.), so the result still type-
+// checks under the v3 schema. Comments attached to the IIS attribute are lost — emit a one-line note
+// on stderr so users notice.
+func dropOrConvertIISToCSA(body *hclwrite.Body, name, to string) bool {
+	if to == "" {
+		fmt.Fprintf(os.Stderr, "warning: iis_to_csa action on %q requires \"to\" target (skipping)\n", name)
+		return false
+	}
+	iisAttr := body.GetAttribute(name)
+	if iisAttr == nil {
+		return false
+	}
+	if body.GetAttribute(to) != nil {
+		// Replacement already declared — config wins. Drop the deprecated attr.
+		body.RemoveAttribute(name)
+		return true
+	}
+	// Read the IIS expression tokens (right-hand side only) and trim surrounding whitespace.
+	exprTokens := iisAttr.Expr().BuildTokens(nil)
+	exprTokens = trimLeadingNewlines(exprTokens)
+	// Build the replacement attribute tokens: to = [{
+	//   using_environment_id = <iis-expr>
+	//   using_mobile_key     = false
+	// }]
+	tokens := hclwrite.Tokens{
+		{Type: hclsyntax.TokenOBrack, Bytes: []byte("[")},
+		{Type: hclsyntax.TokenOBrace, Bytes: []byte("{")},
+		{Type: hclsyntax.TokenNewline, Bytes: []byte("\n")},
+		{Type: hclsyntax.TokenIdent, Bytes: []byte("using_environment_id")},
+		{Type: hclsyntax.TokenEqual, Bytes: []byte(" = ")},
+	}
+	tokens = append(tokens, exprTokens...)
+	tokens = append(tokens,
+		&hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: []byte("\n")},
+		&hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte("using_mobile_key")},
+		&hclwrite.Token{Type: hclsyntax.TokenEqual, Bytes: []byte(" = ")},
+		&hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte("false")},
+		&hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: []byte("\n")},
+		&hclwrite.Token{Type: hclsyntax.TokenCBrace, Bytes: []byte("}")},
+		&hclwrite.Token{Type: hclsyntax.TokenCBrack, Bytes: []byte("]")},
+	)
+	body.RemoveAttribute(name)
+	body.SetAttributeRaw(to, tokens)
+	return true
 }
 
 // extractTupleElements walks token stream `[ {...}, {...}, ... ]` and returns the inner body

--- a/scripts/migrate-tf-syntax/mappings.json
+++ b/scripts/migrate-tf-syntax/mappings.json
@@ -72,6 +72,9 @@
       {"name": "client_side_availability"},
       {"name": "variations"},
       {"name": "defaults"}
+    ],
+    "deprecations": [
+      {"name": "include_in_snippet", "action": "iis_to_csa", "to": "client_side_availability"}
     ]
   }
 }


### PR DESCRIPTION
include_in_snippet was deprecated in v2.2.0 (Dec 2021) in favor of the
client_side_availability nested attribute. Drop it from the
launchdarkly_feature_flag resource and data source schemas and from
the Create/Update/Read paths and ConfigValidators.

State-upgrade path: the existing v0->v1 upgrader now decodes prior
state into a frozen FeatureFlagResourceModelV0 (which still carries
include_in_snippet) and projects to the current model. When prior
state had include_in_snippet set and client_side_availability empty,
the upgrader materializes client_side_availability = [{
using_environment_id = <iis-value>, using_mobile_key = false }] —
matching the Create-path projection. When both were populated, IIS is
dropped (the v2 Conflicting validator should have prevented this).

HCL migration: scripts/migrate-tf-syntax gains a new iis_to_csa action.
Running v2-to-v3 on existing configs either drops include_in_snippet
(when client_side_availability is already declared) or rewrites it to
client_side_availability = [{ using_environment_id = <iis-expr>,
using_mobile_key = false }] preserving the IIS expression verbatim.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>