### PR TITLE
feat(project)!: remove deprecated include_in_snippet and DS client_side_availability

### DIFF
--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -33,22 +33,12 @@ data "launchdarkly_project" "example" {
 
 ### Read-Only
 
-- `client_side_availability` (Attributes List, Deprecated) Deprecated. Use `default_client_side_availability`. (see [below for nested schema](#nestedatt--client_side_availability))
 - `default_client_side_availability` (Attributes List) Which client-side SDKs can use new flags by default. (see [below for nested schema](#nestedatt--default_client_side_availability))
 - `id` (String) The project's ID.
 - `name` (String) The project's name.
 - `require_view_association_for_new_flags` (Boolean) Whether new flags created in this project must be associated with at least one view.
 - `require_view_association_for_new_segments` (Boolean) Whether new segments created in this project must be associated with at least one view.
 - `tags` (Set of String) Tags.
-
-<a id="nestedatt--client_side_availability"></a>
-### Nested Schema for `client_side_availability`
-
-Read-Only:
-
-- `using_environment_id` (Boolean)
-- `using_mobile_key` (Boolean)
-
 
 <a id="nestedatt--default_client_side_availability"></a>
 ### Nested Schema for `default_client_side_availability`

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -64,7 +64,6 @@ resource "launchdarkly_project" "example" {
 ### Optional
 
 - `default_client_side_availability` (Attributes List) Which client-side SDKs can use new flags by default. (see [below for nested schema](#nestedatt--default_client_side_availability))
-- `include_in_snippet` (Boolean, Deprecated) Whether feature flags created under the project should be available to client-side SDKs by default. Please migrate to `default_client_side_availability` to maintain future compatibility.
 - `require_view_association_for_new_flags` (Boolean) Whether new flags created in this project must be associated with at least one view.
 - `require_view_association_for_new_segments` (Boolean) Whether new segments created in this project must be associated with at least one view.
 - `tags` (Set of String) Tags associated with your resource.

--- a/launchdarkly/data_source_launchdarkly_project_test.go
+++ b/launchdarkly/data_source_launchdarkly_project_test.go
@@ -106,9 +106,6 @@ func TestAccDataSourceProject_exists(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, NAME, project.Name),
 					resource.TestCheckResourceAttr(resourceName, ID, project.Id),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
-					// TODO: remove deprecated client_side_availability attribute tests pending next major release
-					resource.TestCheckResourceAttr(resourceName, "client_side_availability.0.using_environment_id", "false"),
-					resource.TestCheckResourceAttr(resourceName, "client_side_availability.0.using_mobile_key", "false"),
 					resource.TestCheckResourceAttr(resourceName, "default_client_side_availability.0.using_environment_id", "false"),
 					resource.TestCheckResourceAttr(resourceName, "default_client_side_availability.0.using_mobile_key", "false"),
 				),

--- a/launchdarkly/data_source_project_framework.go
+++ b/launchdarkly/data_source_project_framework.go
@@ -20,7 +20,6 @@ type ProjectDataSourceModel struct {
 	ID                                   types.String `tfsdk:"id"`
 	Key                                  types.String `tfsdk:"key"`
 	Name                                 types.String `tfsdk:"name"`
-	ClientSideAvailability               types.List   `tfsdk:"client_side_availability"`
 	DefaultClientSideAvailability        types.List   `tfsdk:"default_client_side_availability"`
 	Tags                                 types.Set    `tfsdk:"tags"`
 	RequireViewAssociationForNewFlags    types.Bool   `tfsdk:"require_view_association_for_new_flags"`
@@ -50,17 +49,6 @@ func (d *ProjectDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 			TAGS:                                   schema.SetAttribute{Computed: true, ElementType: types.StringType, Description: "Tags."},
 			REQUIRE_VIEW_ASSOCIATION_FOR_NEW_FLAGS: schema.BoolAttribute{Computed: true, Description: "Whether new flags created in this project must be associated with at least one view."},
 			REQUIRE_VIEW_ASSOCIATION_FOR_NEW_SEGMENTS: schema.BoolAttribute{Computed: true, Description: "Whether new segments created in this project must be associated with at least one view."},
-			CLIENT_SIDE_AVAILABILITY: schema.ListNestedAttribute{
-				Computed:           true,
-				DeprecationMessage: "'client_side_availability' is now deprecated. Please migrate to 'default_client_side_availability' to maintain future compatibility.",
-				Description:        "Deprecated. Use `default_client_side_availability`.",
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						USING_ENVIRONMENT_ID: schema.BoolAttribute{Computed: true},
-						USING_MOBILE_KEY:     schema.BoolAttribute{Computed: true},
-					},
-				},
-			},
 			DEFAULT_CLIENT_SIDE_AVAILABILITY: schema.ListNestedAttribute{
 				Computed:    true,
 				Description: "Which client-side SDKs can use new flags by default.",
@@ -131,7 +119,6 @@ func (d *ProjectDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		csaList, diags = types.ListValue(objectType, []attr.Value{})
 		resp.Diagnostics.Append(diags...)
 	}
-	data.ClientSideAvailability = csaList
 	data.DefaultClientSideAvailability = csaList
 
 	viewSettings, viewSettingsErr := getProjectViewSettings(ctx, d.client, projectKey)

--- a/launchdarkly/resource_feature_flag_environment_framework.go
+++ b/launchdarkly/resource_feature_flag_environment_framework.go
@@ -165,7 +165,6 @@ func featureFlagEnvironmentSchemaAttributes() map[string]schema.Attribute {
 					DESCRIPTION: schema.StringAttribute{
 						Optional:    true,
 						Computed:    true,
-						Default:     stringdefault.StaticString(""),
 						Description: "A human-readable description of the targeting rule.",
 					},
 					VARIATION: schema.Int64Attribute{

--- a/launchdarkly/resource_feature_flag_framework.go
+++ b/launchdarkly/resource_feature_flag_framework.go
@@ -23,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -181,13 +180,11 @@ func featureFlagSchemaAttributes() map[string]schema.Attribute {
 					NAME: schema.StringAttribute{
 						Optional:    true,
 						Computed:    true,
-						Default:     stringdefault.StaticString(""),
 						Description: "The name of the variation.",
 					},
 					DESCRIPTION: schema.StringAttribute{
 						Optional:    true,
 						Computed:    true,
-						Default:     stringdefault.StaticString(""),
 						Description: "The variation's description.",
 					},
 					VALUE: schema.StringAttribute{

--- a/launchdarkly/resource_launchdarkly_feature_flag_test.go
+++ b/launchdarkly/resource_launchdarkly_feature_flag_test.go
@@ -589,25 +589,6 @@ func withRandomProjectAndEnv(randomProject, randomEnvironment, resource string) 
 	%s`, randomProject, randomEnvironment, resource)
 }
 
-func withRandomProjectIncludeInSnippetTrue(randomProject, resource string) string {
-	return fmt.Sprintf(`
-	resource "launchdarkly_project" "test" {
-		lifecycle {
-			ignore_changes = [environments]
-		}
-		include_in_snippet = true
-		name = "testProject"
-		key = "%s"
-		environments = [{
-			name  = "testEnvironment"
-			key   = "test"
-			color = "000000"
-		}]
-	}
-	
-	%s`, randomProject, resource)
-}
-
 func TestAccFeatureFlag_BasicCreateAndUpdate(t *testing.T) {
 	projectKey := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	resourceName := "launchdarkly_feature_flag.basic"

--- a/launchdarkly/resource_launchdarkly_project_test.go
+++ b/launchdarkly/resource_launchdarkly_project_test.go
@@ -16,7 +16,6 @@ const (
 resource "launchdarkly_project" "test" {
 	key = "%s"
 	name = "test project"
-	include_in_snippet = false
 	tags = [ "terraform", "test" ]
 	environments = [{
 	  name  = "Test Environment"
@@ -29,7 +28,6 @@ resource "launchdarkly_project" "test" {
 resource "launchdarkly_project" "test" {
 	key = "%s"
 	name = "awesome test project"
-	include_in_snippet = true
 	tags = [ "terraform" ]
 	environments = [{
 	  name  = "Test Environment 2.0"
@@ -271,7 +269,6 @@ func TestAccProject_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, KEY, projectKey),
 					resource.TestCheckResourceAttr(resourceName, NAME, "test project"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, INCLUDE_IN_SNIPPET, "false"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "terraform"),
 					resource.TestCheckResourceAttr(resourceName, "tags.1", "test"),
 					resource.TestCheckResourceAttr(resourceName, "environments.#", "1"),
@@ -286,7 +283,6 @@ func TestAccProject_Update(t *testing.T) {
 					testAccCheckProjectExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, KEY, projectKey),
 					resource.TestCheckResourceAttr(resourceName, NAME, "awesome test project"),
-					resource.TestCheckResourceAttr(resourceName, INCLUDE_IN_SNIPPET, "true"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "terraform"),
 					resource.TestCheckResourceAttr(resourceName, "environments.#", "1"),
@@ -302,7 +298,6 @@ func TestAccProject_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, KEY, projectKey),
 					resource.TestCheckResourceAttr(resourceName, NAME, "awesome test project"),
 					resource.TestCheckNoResourceAttr(resourceName, "tags.#"),
-					resource.TestCheckResourceAttr(resourceName, INCLUDE_IN_SNIPPET, "false"),
 				),
 			},
 			{
@@ -330,7 +325,6 @@ func TestAccProject_CSA_Update_And_Revert(t *testing.T) {
 					testAccCheckProjectExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, KEY, projectKey),
 					resource.TestCheckResourceAttr(resourceName, NAME, "test project"),
-					resource.TestCheckResourceAttr(resourceName, INCLUDE_IN_SNIPPET, "false"),
 					// default_client_side_availability is Optional-only; when
 					// the user omits it, state stays null and the LD-API
 					// defaults are not surfaced.
@@ -343,7 +337,6 @@ func TestAccProject_CSA_Update_And_Revert(t *testing.T) {
 					testAccCheckProjectExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, KEY, projectKey),
 					resource.TestCheckResourceAttr(resourceName, NAME, "test project"),
-					resource.TestCheckResourceAttr(resourceName, INCLUDE_IN_SNIPPET, "true"),
 					resource.TestCheckResourceAttr(resourceName, "default_client_side_availability.0.using_environment_id", "true"),
 					resource.TestCheckResourceAttr(resourceName, "default_client_side_availability.0.using_mobile_key", "true"),
 				),
@@ -354,7 +347,6 @@ func TestAccProject_CSA_Update_And_Revert(t *testing.T) {
 					testAccCheckProjectExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, KEY, projectKey),
 					resource.TestCheckResourceAttr(resourceName, NAME, "awesome test project"),
-					resource.TestCheckResourceAttr(resourceName, INCLUDE_IN_SNIPPET, "false"),
 					// Removing default_client_side_availability from config
 					// drops it from state.
 					resource.TestCheckNoResourceAttr(resourceName, "default_client_side_availability.#"),

--- a/launchdarkly/resource_project_framework.go
+++ b/launchdarkly/resource_project_framework.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -22,11 +21,10 @@ import (
 )
 
 var (
-	_ resource.Resource                     = &ProjectResource{}
-	_ resource.ResourceWithImportState      = &ProjectResource{}
-	_ resource.ResourceWithConfigValidators = &ProjectResource{}
-	_ resource.ResourceWithModifyPlan       = &ProjectResource{}
-	_ resource.ResourceWithUpgradeState     = &ProjectResource{}
+	_ resource.Resource                 = &ProjectResource{}
+	_ resource.ResourceWithImportState  = &ProjectResource{}
+	_ resource.ResourceWithModifyPlan   = &ProjectResource{}
+	_ resource.ResourceWithUpgradeState = &ProjectResource{}
 )
 
 type ProjectResource struct {
@@ -37,7 +35,6 @@ type ProjectResourceModel struct {
 	ID                                   types.String `tfsdk:"id"`
 	Key                                  types.String `tfsdk:"key"`
 	Name                                 types.String `tfsdk:"name"`
-	IncludeInSnippet                     types.Bool   `tfsdk:"include_in_snippet"`
 	DefaultClientSideAvailability        types.List   `tfsdk:"default_client_side_availability"`
 	Tags                                 types.Set    `tfsdk:"tags"`
 	Environments                         types.List   `tfsdk:"environments"`
@@ -85,12 +82,6 @@ func projectSchemaAttributes() map[string]schema.Attribute {
 		NAME: schema.StringAttribute{
 			Required:    true,
 			Description: "The project's name.",
-		},
-		INCLUDE_IN_SNIPPET: schema.BoolAttribute{
-			Optional:           true,
-			Computed:           true,
-			Description:        "Whether feature flags created under the project should be available to client-side SDKs by default. Please migrate to `default_client_side_availability` to maintain future compatibility.",
-			DeprecationMessage: "'include_in_snippet' is now deprecated. Please migrate to 'default_client_side_availability' to maintain future compatibility.",
 		},
 		TAGS: schema.SetAttribute{
 			Optional:    true,
@@ -160,25 +151,51 @@ func approvalSettingsMatchesAPIDefaults(item approvalSettingsModel) bool {
 }
 
 func (r *ProjectResource) UpgradeState(_ context.Context) map[int64]resource.StateUpgrader {
-	priorSchema := schema.Schema{Attributes: projectSchemaAttributes()}
+	priorSchema := schema.Schema{Attributes: projectSchemaAttributesV0()}
 	return map[int64]resource.StateUpgrader{
 		0: {
 			PriorSchema: &priorSchema,
 			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				var data ProjectResourceModel
-				resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+				var prior ProjectResourceModelV0
+				resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
 				if resp.Diagnostics.HasError() {
 					return
 				}
-				// Cat 3 #1: default_client_side_availability that matches
-				// LD account defaults → null. Reuse the feature_flag
-				// helper since the inner shape is identical.
-				if featureFlagCSAMatchesAPIShape(ctx, data.DefaultClientSideAvailability) {
+				data := ProjectResourceModel{
+					ID:                                   prior.ID,
+					Key:                                  prior.Key,
+					Name:                                 prior.Name,
+					DefaultClientSideAvailability:        prior.DefaultClientSideAvailability,
+					Tags:                                 prior.Tags,
+					Environments:                         prior.Environments,
+					RequireViewAssociationForNewFlags:    prior.RequireViewAssociationForNewFlags,
+					RequireViewAssociationForNewSegments: prior.RequireViewAssociationForNewSegments,
+				}
+				// IIS->DCSA migration: when prior state set include_in_snippet
+				// and left default_client_side_availability empty, materialize
+				// DCSA so the resource still controls the project default.
+				// using_mobile_key was always implicitly true in v2 (see the
+				// pre-removal Update patch that hardcoded UsingMobileKey: true).
+				// When both were populated, drop IIS in favor of DCSA.
+				dcsaEmpty := data.DefaultClientSideAvailability.IsNull() || data.DefaultClientSideAvailability.IsUnknown() || len(data.DefaultClientSideAvailability.Elements()) == 0
+				iisSet := !prior.IncludeInSnippet.IsNull() && !prior.IncludeInSnippet.IsUnknown()
+				if dcsaEmpty && iisSet {
+					obj, d := types.ObjectValue(projectCSAAttrTypes, map[string]attr.Value{
+						USING_ENVIRONMENT_ID: types.BoolValue(prior.IncludeInSnippet.ValueBool()),
+						USING_MOBILE_KEY:     types.BoolValue(true),
+					})
+					resp.Diagnostics.Append(d...)
+					list, d := types.ListValue(types.ObjectType{AttrTypes: projectCSAAttrTypes}, []attr.Value{obj})
+					resp.Diagnostics.Append(d...)
+					data.DefaultClientSideAvailability = list
+				} else if featureFlagCSAMatchesAPIShape(ctx, data.DefaultClientSideAvailability) {
+					// default_client_side_availability that matches LD account
+					// defaults → null. Reuse the feature_flag helper since the
+					// inner shape is identical.
 					data.DefaultClientSideAvailability = types.ListNull(data.DefaultClientSideAvailability.ElementType(ctx))
 				}
-				// Cat 3 #2: each environments[].approval_settings whose
-				// 1-element matches API defaults → null. Decode envs,
-				// modify each, re-encode.
+				// each environments[].approval_settings whose 1-element matches
+				// API defaults → null. Decode envs, modify each, re-encode.
 				if !data.Environments.IsNull() && !data.Environments.IsUnknown() && len(data.Environments.Elements()) > 0 {
 					var envs []environmentModel
 					resp.Diagnostics.Append(data.Environments.ElementsAs(ctx, &envs, false)...)
@@ -217,35 +234,19 @@ func (r *ProjectResource) UpgradeState(_ context.Context) map[int64]resource.Sta
 	}
 }
 
-func (r *ProjectResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
-	return []resource.ConfigValidator{
-		resourcevalidator.Conflicting(
-			path.MatchRoot(INCLUDE_IN_SNIPPET),
-			path.MatchRoot(DEFAULT_CLIENT_SIDE_AVAILABILITY),
-		),
-	}
-}
-
 func (r *ProjectResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	r.client = configureResourceClient(req, resp)
 }
 
-// ModifyPlan handles two plan-time concerns:
-//
-//  1. include_in_snippet default: when neither IIS nor CSA is declared
-//     in config, set include_in_snippet = false so terraform sees a
-//     stable Computed value matching LD's backend default. (Port of the
-//     IIS-side half of the legacy customizeProjectDiff.)
-//
-//  2. Environments-level sensitive Unknowns: nested-attribute schemas
-//     synthesize zero values for inner Computed fields once the user
-//     supplies the required ones (key/name/color). For api_key,
-//     mobile_key, client_side_id — secrets only LD can mint — this
-//     produces a "" plan value that Apply replaces with the real
-//     secret, tripping the framework's plan-vs-apply consistency
-//     check (see [[feedback-nested-attr-computed-sensitive]]). Mark
-//     these fields Unknown whenever there's no prior state entry for
-//     the same env key.
+// ModifyPlan addresses environments-level sensitive Unknowns: nested-
+// attribute schemas synthesize zero values for inner Computed fields
+// once the user supplies the required ones (key/name/color). For
+// api_key, mobile_key, client_side_id — secrets only LD can mint —
+// this produces a "" plan value that Apply replaces with the real
+// secret, tripping the framework's plan-vs-apply consistency check
+// (see [[feedback-nested-attr-computed-sensitive]]). Mark these
+// fields Unknown whenever there's no prior state entry for the same
+// env key.
 func (r *ProjectResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	if req.Plan.Raw.IsNull() {
 		return
@@ -253,23 +254,10 @@ func (r *ProjectResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 	if r.client == nil {
 		return
 	}
-	var config ProjectResourceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 	var plan ProjectResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
-	}
-
-	iisNotSet := config.IncludeInSnippet.IsNull() || config.IncludeInSnippet.IsUnknown()
-	csaEmpty := config.DefaultClientSideAvailability.IsNull() ||
-		config.DefaultClientSideAvailability.IsUnknown() ||
-		len(config.DefaultClientSideAvailability.Elements()) == 0
-	if iisNotSet && csaEmpty {
-		plan.IncludeInSnippet = types.BoolValue(false)
 	}
 
 	var state ProjectResourceModel
@@ -516,21 +504,14 @@ func (r *ProjectResource) applyProjectUpdates(ctx context.Context, projectKey st
 
 	csaPlanned := !plan.DefaultClientSideAvailability.IsNull() && !plan.DefaultClientSideAvailability.IsUnknown() && len(plan.DefaultClientSideAvailability.Elements()) > 0
 	csaChanged := isCreate || !plan.DefaultClientSideAvailability.Equal(state.DefaultClientSideAvailability)
-	iisChanged := isCreate || !plan.IncludeInSnippet.Equal(state.IncludeInSnippet)
 
-	switch {
-	case csaPlanned && csaChanged:
+	if csaPlanned && csaChanged {
 		csa, d := csaPostFromList(ctx, plan.DefaultClientSideAvailability)
 		diags.Append(d...)
 		if diags.HasError() {
 			return diags
 		}
 		patches = append(patches, patchReplace("/defaultClientSideAvailability", csa))
-	case !plan.IncludeInSnippet.IsNull() && !plan.IncludeInSnippet.IsUnknown() && iisChanged:
-		patches = append(patches, patchReplace("/defaultClientSideAvailability", &ldapi.ClientSideAvailabilityPost{
-			UsingEnvironmentId: plan.IncludeInSnippet.ValueBool(),
-			UsingMobileKey:     true,
-		}))
 	}
 
 	err := r.client.withConcurrency(r.client.ctx, func() error {
@@ -652,10 +633,6 @@ func (r *ProjectResource) readIntoModel(ctx context.Context, projectKey string, 
 	csaList, d := projectCSAValueFromAPI(ctx, project.DefaultClientSideAvailability, data.DefaultClientSideAvailability)
 	diags.Append(d...)
 	data.DefaultClientSideAvailability = csaList
-
-	// include_in_snippet mirrors the deprecated API field; LD's
-	// IncludeInSnippetByDefault is the canonical source.
-	data.IncludeInSnippet = types.BoolValue(project.IncludeInSnippetByDefault)
 
 	// Environments — preserve config order, then append unmanaged ones.
 	envItems := []ldapi.Environment{}

--- a/launchdarkly/resource_project_upgrade.go
+++ b/launchdarkly/resource_project_upgrade.go
@@ -1,0 +1,37 @@
+package launchdarkly
+
+// Frozen pre-v3 project schema + model used as PriorSchema for the
+// v0->v1 state upgrader. The v0 shape (v2.x SDKv2 provider) carried
+// the deprecated `include_in_snippet` attribute; v3 drops it. The
+// upgrader decodes prior state into ProjectResourceModelV0 and
+// projects to the current ProjectResourceModel, materializing
+// `default_client_side_availability` from `include_in_snippet` when
+// DCSA was absent in prior state.
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type ProjectResourceModelV0 struct {
+	ID                                   types.String `tfsdk:"id"`
+	Key                                  types.String `tfsdk:"key"`
+	Name                                 types.String `tfsdk:"name"`
+	IncludeInSnippet                     types.Bool   `tfsdk:"include_in_snippet"`
+	DefaultClientSideAvailability        types.List   `tfsdk:"default_client_side_availability"`
+	Tags                                 types.Set    `tfsdk:"tags"`
+	Environments                         types.List   `tfsdk:"environments"`
+	RequireViewAssociationForNewFlags    types.Bool   `tfsdk:"require_view_association_for_new_flags"`
+	RequireViewAssociationForNewSegments types.Bool   `tfsdk:"require_view_association_for_new_segments"`
+}
+
+func projectSchemaAttributesV0() map[string]schema.Attribute {
+	attrs := projectSchemaAttributes()
+	attrs[INCLUDE_IN_SNIPPET] = schema.BoolAttribute{
+		Optional:           true,
+		Computed:           true,
+		Description:        "Whether feature flags created under the project should be available to client-side SDKs by default. Please migrate to `default_client_side_availability` to maintain future compatibility.",
+		DeprecationMessage: "'include_in_snippet' is now deprecated. Please migrate to 'default_client_side_availability' to maintain future compatibility.",
+	}
+	return attrs
+}

--- a/scripts/migrate-tf-syntax/main.go
+++ b/scripts/migrate-tf-syntax/main.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -37,16 +38,38 @@ type AttrSpec struct {
 // DeprecationSpec describes an attribute that was removed from the provider schema between v2 and v3.
 // Supported actions:
 //   - "drop": remove the attribute from the resource body (no replacement).
+//   - "iis_to_csa": rewrite include_in_snippet into a client_side_availability nested-attribute list.
+//     "to" names the replacement attribute (e.g. client_side_availability or
+//     default_client_side_availability). "using_mobile_key" overrides the synthesized mobile-key
+//     value (default false) — set to "true" for the project resource which historically wrote
+//     using_mobile_key=true when migrating include_in_snippet.
 type DeprecationSpec struct {
-	Name   string `json:"name"`
-	Action string `json:"action"`
-	To     string `json:"to,omitempty"`
+	Name           string `json:"name"`
+	Action         string `json:"action"`
+	To             string `json:"to,omitempty"`
+	UsingMobileKey string `json:"using_mobile_key,omitempty"`
 }
 
-// ResourceSpec bundles all rewrite operations that apply to one resource type.
+// DSAttrRewrite describes a data-source attribute that was removed/renamed in v3. The script does
+// a cross-file expression rewrite of every `data.<resource_label>.<name>.<from>` reference, where
+// <resource_label> is the spec key holding this entry.
+//
+//   - To set: rename the terminal attr (`data.X.Y.from` → `data.X.Y.to`). Anything after is
+//     preserved (e.g. `[0].using_environment_id`).
+//   - ToExpr set: replace the whole prefix (`data.X.Y.from` → `data.X.Y.<to-expr>`). Use when the
+//     v3 access path is structurally different.
+type DSAttrRewrite struct {
+	From   string `json:"from"`
+	To     string `json:"to,omitempty"`
+	ToExpr string `json:"to_expr,omitempty"`
+}
+
+// ResourceSpec bundles all rewrite operations that apply to one resource type. DSAttrRewrites apply
+// to the data source of the same name.
 type ResourceSpec struct {
-	Blocks       []*AttrSpec        `json:"blocks,omitempty"`
-	Deprecations []*DeprecationSpec `json:"deprecations,omitempty"`
+	Blocks         []*AttrSpec        `json:"blocks,omitempty"`
+	Deprecations   []*DeprecationSpec `json:"deprecations,omitempty"`
+	DSAttrRewrites []*DSAttrRewrite   `json:"ds_attr_rewrites,omitempty"`
 }
 
 type Spec map[string]*ResourceSpec
@@ -134,10 +157,18 @@ func process(path, direction string, spec Spec, dryRun bool) error {
 			changed = true
 		}
 	}
+	out := hclwrite.Format(f.Bytes())
+	// Cross-file DS-reader rewrites apply only in v2-to-v3.
+	if direction == "v2-to-v3" {
+		var rewritten bool
+		out, rewritten = applyDSAttrRewrites(out, spec)
+		if rewritten {
+			changed = true
+		}
+	}
 	if !changed {
 		return nil
 	}
-	out := hclwrite.Format(f.Bytes())
 	if dryRun {
 		fmt.Println("// ---", path, "---")
 		_, err := os.Stdout.Write(out)
@@ -145,6 +176,46 @@ func process(path, direction string, spec Spec, dryRun bool) error {
 	}
 	fmt.Fprintf(os.Stderr, "wrote %s\n", path)
 	return os.WriteFile(path, out, 0o644)
+}
+
+// applyDSAttrRewrites runs every ds_attr_rewrite entry across the file contents. Each rewrite
+// targets `data.<resource_label>.<name>.<from>` and either renames the terminal segment (`To`) or
+// replaces the entire prefix with a new expression rooted at the same name (`ToExpr`).
+//
+// Implementation: regex over the formatted file bytes. The pattern uses a word boundary on `<from>`
+// so it matches both the bare reference (`...client_side_availability`) and chained access
+// (`...client_side_availability[0]`, `...client_side_availability.foo`). False positives inside
+// HCL strings/comments are vanishingly unlikely for these very specific deprecated attr names.
+func applyDSAttrRewrites(src []byte, spec Spec) ([]byte, bool) {
+	out := src
+	changed := false
+	for label, rspec := range spec {
+		if rspec == nil {
+			continue
+		}
+		for _, rw := range rspec.DSAttrRewrites {
+			if rw.From == "" {
+				continue
+			}
+			re := regexp.MustCompile(`\bdata\.` + regexp.QuoteMeta(label) + `\.([A-Za-z_][A-Za-z0-9_]*)\.` + regexp.QuoteMeta(rw.From) + `\b`)
+			var repl string
+			switch {
+			case rw.ToExpr != "":
+				repl = "data." + label + ".${1}." + rw.ToExpr
+			case rw.To != "":
+				repl = "data." + label + ".${1}." + rw.To
+			default:
+				fmt.Fprintf(os.Stderr, "warning: ds_attr_rewrite on %q/%q missing \"to\" and \"to_expr\" (skipping)\n", label, rw.From)
+				continue
+			}
+			newOut := re.ReplaceAll(out, []byte(repl))
+			if !bytes.Equal(newOut, out) {
+				out = newOut
+				changed = true
+			}
+		}
+	}
+	return out, changed
 }
 
 // forward converts repeated `name { ... }` blocks into a single `name = [{...}, ...]` attribute.
@@ -241,7 +312,11 @@ func applyDeprecations(body *hclwrite.Body, deps []*DeprecationSpec) bool {
 				changed = true
 			}
 		case "iis_to_csa":
-			if dropOrConvertIISToCSA(body, d.Name, d.To) {
+			mobile := "false"
+			if d.UsingMobileKey != "" {
+				mobile = d.UsingMobileKey
+			}
+			if dropOrConvertIISToCSA(body, d.Name, d.To, mobile) {
 				changed = true
 			}
 		default:
@@ -259,7 +334,7 @@ func applyDeprecations(body *hclwrite.Body, deps []*DeprecationSpec) bool {
 // The IIS expression is preserved verbatim (true/false/var refs/etc.), so the result still type-
 // checks under the v3 schema. Comments attached to the IIS attribute are lost — emit a one-line note
 // on stderr so users notice.
-func dropOrConvertIISToCSA(body *hclwrite.Body, name, to string) bool {
+func dropOrConvertIISToCSA(body *hclwrite.Body, name, to, mobile string) bool {
 	if to == "" {
 		fmt.Fprintf(os.Stderr, "warning: iis_to_csa action on %q requires \"to\" target (skipping)\n", name)
 		return false
@@ -292,7 +367,7 @@ func dropOrConvertIISToCSA(body *hclwrite.Body, name, to string) bool {
 		&hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: []byte("\n")},
 		&hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte("using_mobile_key")},
 		&hclwrite.Token{Type: hclsyntax.TokenEqual, Bytes: []byte(" = ")},
-		&hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte("false")},
+		&hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte(mobile)},
 		&hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: []byte("\n")},
 		&hclwrite.Token{Type: hclsyntax.TokenCBrace, Bytes: []byte("}")},
 		&hclwrite.Token{Type: hclsyntax.TokenCBrack, Bytes: []byte("]")},

--- a/scripts/migrate-tf-syntax/mappings.json
+++ b/scripts/migrate-tf-syntax/mappings.json
@@ -24,6 +24,12 @@
     "blocks": [
       {"name": "default_client_side_availability"},
       {"name": "environments", "nested": [{"name": "approval_settings"}]}
+    ],
+    "deprecations": [
+      {"name": "include_in_snippet", "action": "iis_to_csa", "to": "default_client_side_availability", "using_mobile_key": "true"}
+    ],
+    "ds_attr_rewrites": [
+      {"from": "client_side_availability", "to": "default_client_side_availability"}
     ]
   },
   "launchdarkly_environment": {
@@ -75,6 +81,9 @@
     ],
     "deprecations": [
       {"name": "include_in_snippet", "action": "iis_to_csa", "to": "client_side_availability"}
+    ],
+    "ds_attr_rewrites": [
+      {"from": "include_in_snippet", "to_expr": "client_side_availability[0].using_environment_id"}
     ]
   }
 }


### PR DESCRIPTION
project.include_in_snippet was deprecated in v2.3.0 (Jan 2022) in
favor of default_client_side_availability. The DS attribute
client_side_availability was renamed in the same release. Both go
away in v3 along with the resource ConfigValidator that paired them.

State-upgrade path: the existing v0->v1 upgrader now decodes prior
state into ProjectResourceModelV0 (with include_in_snippet) and
projects to the current model. When prior state set include_in_snippet
and left default_client_side_availability empty, the upgrader
materializes DCSA = [{ using_environment_id = <iis-value>,
using_mobile_key = true }] — matching the v2 PATCH that hardcoded
using_mobile_key=true on IIS-driven updates. When both were
populated, IIS is dropped in favor of DCSA.

HCL migration: scripts/migrate-tf-syntax reuses the iis_to_csa action
for the project resource (with using_mobile_key=true override). A new
ds_attr_rewrites pass rewrites cross-file data-source references:
`data.launchdarkly_project.X.client_side_availability` becomes
`data.launchdarkly_project.X.default_client_side_availability`, and
`data.launchdarkly_feature_flag.X.include_in_snippet` becomes
`data.launchdarkly_feature_flag.X.client_side_availability[0].using_environment_id`.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>