### PR TITLE
feat(access_token)!: remove deprecated expire and policy_statements

### DIFF
--- a/docs/resources/access_token.md
+++ b/docs/resources/access_token.md
@@ -6,7 +6,7 @@ description: |-
   Provides a LaunchDarkly access token resource.
   This resource allows you to create and manage access tokens within your LaunchDarkly organization.
   -> Note: This resource stores the full plaintext secret for your access token in Terraform state. Be sure your state is configured securely before using this resource. To learn more, read Sensitive data in state https://www.terraform.io/docs/state/sensitive-data.html.
-  The resource must contain either a "role", "custom_role" or an "inline_roles" (previously "policy_statements") block. As of v1.7.0, "policy_statements" has been deprecated in favor of "inline_roles".
+  The resource must contain either a "role", "custom_role" or an "inline_roles" block.
 ---
 
 # launchdarkly_access_token (Resource)
@@ -17,7 +17,7 @@ This resource allows you to create and manage access tokens within your LaunchDa
 
 -> **Note:** This resource stores the full plaintext secret for your access token in Terraform state. Be sure your state is configured securely before using this resource. To learn more, read [Sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 
-The resource must contain either a "role", "custom_role" or an "inline_roles" (previously "policy_statements") block. As of v1.7.0, "policy_statements" has been deprecated in favor of "inline_roles".
+The resource must contain either a "role", "custom_role" or an "inline_roles" block.
 
 ## Example Usage
 
@@ -52,10 +52,8 @@ resource "launchdarkly_access_token" "token_with_policy_statements" {
 
 - `custom_roles` (Set of String) A list of custom role IDs to use as access limits for the access token.
 - `default_api_version` (Number) The default API version for this token. Defaults to the latest API version. A change in this field will force the destruction of the existing resource and the creation of a new one.
-- `expire` (Number, Deprecated) An expiration time for the current token secret, expressed as a Unix epoch time. Replace the computed token secret with a new value. The expired secret will no longer be able to authorize usage of the LaunchDarkly API. This field argument is **deprecated**. Please update your config to remove `expire` to maintain compatibility with future versions
 - `inline_roles` (Attributes List) Define inline custom roles. An array of statements with three attributes: effect, resources, actions. May be used in place of a built-in or custom role. [Using polices](https://docs.launchdarkly.com/home/members/role-policies). (see [below for nested schema](#nestedatt--inline_roles))
 - `name` (String) A human-friendly name for the access token.
-- `policy_statements` (Attributes List, Deprecated) Define inline custom roles. An array of statements with three attributes: effect, resources, actions. May be used in place of a built-in or custom role. This field argument is **deprecated**. Update your config to use `inline_role` to maintain compatibility with future versions. (see [below for nested schema](#nestedatt--policy_statements))
 - `role` (String) A built-in LaunchDarkly role. Can be `reader`, `writer`, or `admin`
 - `service_token` (Boolean) Whether the token will be a [service token](https://docs.launchdarkly.com/home/account-security/api-access-tokens#service-tokens). A change in this field will force the destruction of the existing resource and the creation of a new one.
 
@@ -66,22 +64,6 @@ resource "launchdarkly_access_token" "token_with_policy_statements" {
 
 <a id="nestedatt--inline_roles"></a>
 ### Nested Schema for `inline_roles`
-
-Required:
-
-- `effect` (String) Either `allow` or `deny`. This argument defines whether the statement allows or denies access to the named resources and actions.
-
-Optional:
-
-- `actions` (List of String) The list of action specifiers defining the actions to which the statement applies.
-Either `actions` or `not_actions` must be specified. For a list of available actions read [Actions reference](https://docs.launchdarkly.com/home/account-security/custom-roles/actions#actions-reference).
-- `not_actions` (List of String) The list of action specifiers defining the actions to which the statement does not apply.
-- `not_resources` (List of String) The list of resource specifiers defining the resources to which the statement does not apply.
-- `resources` (List of String) The list of resource specifiers defining the resources to which the statement applies.
-
-
-<a id="nestedatt--policy_statements"></a>
-### Nested Schema for `policy_statements`
 
 Required:
 

--- a/launchdarkly/resource_access_token_framework.go
+++ b/launchdarkly/resource_access_token_framework.go
@@ -1,13 +1,9 @@
 package launchdarkly
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -41,12 +37,10 @@ type AccessTokenResourceModel struct {
 	Name              types.String `tfsdk:"name"`
 	Role              types.String `tfsdk:"role"`
 	CustomRoles       types.Set    `tfsdk:"custom_roles"`
-	PolicyStatements  types.List   `tfsdk:"policy_statements"`
 	InlineRoles       types.List   `tfsdk:"inline_roles"`
 	ServiceToken      types.Bool   `tfsdk:"service_token"`
 	DefaultAPIVersion types.Int64  `tfsdk:"default_api_version"`
 	Token             types.String `tfsdk:"token"`
-	Expire            types.Int64  `tfsdk:"expire"`
 }
 
 func NewAccessTokenResource() resource.Resource {
@@ -66,7 +60,7 @@ This resource allows you to create and manage access tokens within your LaunchDa
 
 -> **Note:** This resource stores the full plaintext secret for your access token in Terraform state. Be sure your state is configured securely before using this resource. To learn more, read [Sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 
-The resource must contain either a "role", "custom_role" or an "inline_roles" (previously "policy_statements") block. As of v1.7.0, "policy_statements" has been deprecated in favor of "inline_roles".`,
+The resource must contain either a "role", "custom_role" or an "inline_roles" block.`,
 		Attributes: accessTokenSchemaAttributes(),
 	}
 }
@@ -127,19 +121,6 @@ func accessTokenSchemaAttributes() map[string]schema.Attribute {
 			Description:   "The access token used to authorize usage of the LaunchDarkly API.",
 			PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 		},
-		EXPIRE: schema.Int64Attribute{
-			Optional:           true,
-			Description:        "An expiration time for the current token secret, expressed as a Unix epoch time. Replace the computed token secret with a new value. The expired secret will no longer be able to authorize usage of the LaunchDarkly API. This field argument is **deprecated**. Please update your config to remove `expire` to maintain compatibility with future versions",
-			DeprecationMessage: "'expire' is deprecated and will be removed in the next major release of the LaunchDarkly provider",
-			Validators: []validator.Int64{
-				noZeroValuesInt64Validator{},
-			},
-		},
-		POLICY_STATEMENTS: frameworkPolicyStatementsResourceAttribute(
-			false,
-			"Define inline custom roles. An array of statements with three attributes: effect, resources, actions. May be used in place of a built-in or custom role. This field argument is **deprecated**. Update your config to use `inline_role` to maintain compatibility with future versions.",
-			"'policy_statements' is deprecated in favor of 'inline_roles'. This field will be removed in the next major release of the LaunchDarkly provider",
-		),
 		INLINE_ROLES: frameworkPolicyStatementsResourceAttribute(
 			false,
 			"Define inline custom roles. An array of statements with three attributes: effect, resources, actions. May be used in place of a built-in or custom role. [Using polices](https://docs.launchdarkly.com/home/members/role-policies).",
@@ -149,18 +130,43 @@ func accessTokenSchemaAttributes() map[string]schema.Attribute {
 }
 
 func (r *AccessTokenResource) UpgradeState(_ context.Context) map[int64]resource.StateUpgrader {
-	priorSchema := schema.Schema{Attributes: accessTokenSchemaAttributes()}
+	priorSchema := schema.Schema{Attributes: accessTokenSchemaAttributesV0()}
 	return map[int64]resource.StateUpgrader{
 		0: {
 			PriorSchema: &priorSchema,
 			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				var data AccessTokenResourceModel
-				resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+				var prior AccessTokenResourceModelV0
+				resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
 				if resp.Diagnostics.HasError() {
 					return
 				}
-				data.InlineRoles = nullIfEmptyList(ctx, data.InlineRoles)
-				data.PolicyStatements = nullIfEmptyList(ctx, data.PolicyStatements)
+				priorPS := nullIfEmptyList(ctx, prior.PolicyStatements)
+				priorIR := nullIfEmptyList(ctx, prior.InlineRoles)
+				psSet := !priorPS.IsNull() && !priorPS.IsUnknown() && len(priorPS.Elements()) > 0
+				irSet := !priorIR.IsNull() && !priorIR.IsUnknown() && len(priorIR.Elements()) > 0
+				if psSet && irSet {
+					resp.Diagnostics.AddError(
+						"Cannot upgrade access_token state: both policy_statements and inline_roles set",
+						"v2 ConfigValidator should have prevented this. Resolve by manually editing state to drop one of the two attributes, then re-apply.",
+					)
+					return
+				}
+				data := AccessTokenResourceModel{
+					ID:                prior.ID,
+					Name:              prior.Name,
+					Role:              prior.Role,
+					CustomRoles:       prior.CustomRoles,
+					InlineRoles:       priorIR,
+					ServiceToken:      prior.ServiceToken,
+					DefaultAPIVersion: prior.DefaultAPIVersion,
+					Token:             prior.Token,
+				}
+				// policy_statements -> inline_roles: identical shape (both
+				// built from frameworkPolicyStatementsResourceAttribute), so
+				// just move the list onto inline_roles when only PS was set.
+				if psSet {
+					data.InlineRoles = priorPS
+				}
 				resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 			},
 		},
@@ -172,7 +178,6 @@ func (r *AccessTokenResource) ConfigValidators(_ context.Context) []resource.Con
 		resourcevalidator.Conflicting(
 			path.MatchRoot(ROLE),
 			path.MatchRoot(CUSTOM_ROLES),
-			path.MatchRoot(POLICY_STATEMENTS),
 			path.MatchRoot(INLINE_ROLES),
 		),
 	}
@@ -184,12 +189,11 @@ func (r *AccessTokenResource) Configure(_ context.Context, req resource.Configur
 
 // ModifyPlan preserves default_api_version across upgrades from v2.x
 // state where the attribute was implicit. Per-attribute
-// UseStateForUnknown on default_api_version trips the .token
-// inconsistent-sensitive-attr check in TestAccAccessToken_Reset, so
-// this resource-level plan modifier replicates UseStateForUnknown's
-// behaviour selectively — skipped when expire is changing (the path
-// that triggers a token reset and needs the framework's default
-// Computed-coupling intact).
+// UseStateForUnknown on default_api_version was historically avoided
+// to keep the framework's Computed-coupling intact for the
+// expire-driven reset path; expire has been removed in v3 but the
+// state-preservation logic is still useful when upgrading from
+// states where default_api_version was unset.
 func (r *AccessTokenResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
 		return
@@ -199,9 +203,6 @@ func (r *AccessTokenResource) ModifyPlan(ctx context.Context, req resource.Modif
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
-		return
-	}
-	if !plan.Expire.Equal(state.Expire) {
 		return
 	}
 	if !config.DefaultAPIVersion.IsNull() {
@@ -235,13 +236,9 @@ func (r *AccessTokenResource) Create(ctx context.Context, req resource.CreateReq
 		body.DefaultApiVersion = &v
 	}
 
-	// Precedence: policy_statements > inline_roles > custom_roles > role.
-	inline, diags := frameworkPolicyStatementsFromList(ctx, plan.PolicyStatements)
+	// Precedence: inline_roles > custom_roles > role.
+	inline, diags := frameworkPolicyStatementsFromList(ctx, plan.InlineRoles)
 	resp.Diagnostics.Append(diags...)
-	if len(inline) == 0 {
-		inline, diags = frameworkPolicyStatementsFromList(ctx, plan.InlineRoles)
-		resp.Diagnostics.Append(diags...)
-	}
 	customRoles, diags := stringSliceFromSet(ctx, plan.CustomRoles)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -259,7 +256,7 @@ func (r *AccessTokenResource) Create(ctx context.Context, req resource.CreateReq
 	default:
 		resp.Diagnostics.AddError(
 			"Missing role configuration",
-			"access_token must contain either 'role', 'custom_roles', 'policy_statements', or 'inline_roles'.",
+			"access_token must contain either 'role', 'custom_roles', or 'inline_roles'.",
 		)
 		return
 	}
@@ -320,12 +317,8 @@ func (r *AccessTokenResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	inline, diags := frameworkPolicyStatementsFromList(ctx, plan.PolicyStatements)
+	inline, diags := frameworkPolicyStatementsFromList(ctx, plan.InlineRoles)
 	resp.Diagnostics.Append(diags...)
-	if len(inline) == 0 {
-		inline, diags = frameworkPolicyStatementsFromList(ctx, plan.InlineRoles)
-		resp.Diagnostics.Append(diags...)
-	}
 
 	patch := []ldapi.PatchOperation{patchReplace("/name", &name)}
 
@@ -350,10 +343,9 @@ func (r *AccessTokenResource) Update(ctx context.Context, req resource.UpdateReq
 	emptyList := func(l types.List) bool {
 		return l.IsNull() || l.IsUnknown() || len(l.Elements()) == 0
 	}
-	hadInline := !emptyList(state.PolicyStatements) || !emptyList(state.InlineRoles)
-	wantInline := !emptyList(plan.PolicyStatements) || !emptyList(plan.InlineRoles)
-	if hadInline != wantInline ||
-		(wantInline && (!plan.PolicyStatements.Equal(state.PolicyStatements) || !plan.InlineRoles.Equal(state.InlineRoles))) {
+	hadInline := !emptyList(state.InlineRoles)
+	wantInline := !emptyList(plan.InlineRoles)
+	if hadInline != wantInline || (wantInline && !plan.InlineRoles.Equal(state.InlineRoles)) {
 		if len(inline) == 0 {
 			if hadInline {
 				patch = append(patch, patchRemove("/inlineRole"))
@@ -376,21 +368,6 @@ func (r *AccessTokenResource) Update(ctx context.Context, req resource.UpdateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	// expire reset — must come AFTER readIntoModel so that plan.Token set
-	// here is not overwritten by the GET response (which omits the secret).
-	if !plan.Expire.Equal(state.Expire) {
-		newExpire := plan.Expire.ValueInt64()
-		if newExpire != 0 {
-			token, err := resetAccessTokenFramework(r.client, id, int(newExpire))
-			if err != nil {
-				addLdapiError(&resp.Diagnostics, "Failed to reset access token", err)
-				return
-			}
-			plan.Token = stringValueFromPointer(token.Token)
-		}
-	}
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -458,12 +435,7 @@ func (r *AccessTokenResource) readIntoModel(
 
 	if len(accessToken.InlineRole) > 0 {
 		stmts, _ := frameworkPolicyStatementsValue(ctx, accessToken.InlineRole)
-		// Preserve which of the two blocks was set in the existing state.
-		if !data.PolicyStatements.IsNull() && len(data.PolicyStatements.Elements()) > 0 {
-			data.PolicyStatements = stmts
-		} else {
-			data.InlineRoles = stmts
-		}
+		data.InlineRoles = stmts
 	}
 }
 
@@ -514,46 +486,4 @@ func (noZeroValuesInt64Validator) ValidateInt64(_ context.Context, req validator
 			fmt.Errorf("expected %q to not be an empty value, got %v", EXPIRE, v).Error(),
 		)
 	}
-}
-
-// resetAccessTokenFramework issues a raw HTTP POST to the token Reset
-// endpoint. The ldapi v22 client omits Content-Type, so we fall back
-// to fallbackClient.
-func resetAccessTokenFramework(client *Client, accessTokenID string, expiry int) (ldapi.Token, error) {
-	var token ldapi.Token
-	endpoint := fmt.Sprintf("%s/api/v2/tokens/%s/reset", client.apiHost, accessTokenID)
-	if !strings.HasPrefix(endpoint, "http") {
-		endpoint = "https://" + endpoint
-	}
-	var body io.Reader
-	if expiry > 0 {
-		raw, err := json.Marshal(map[string]int{"expiry": expiry})
-		if err != nil {
-			return token, err
-		}
-		body = bytes.NewBuffer(raw)
-	}
-	req, err := http.NewRequest("POST", endpoint, body)
-	if err != nil {
-		return token, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", client.apiKey)
-
-	var resp *http.Response
-	err = client.withConcurrency(client.ctx, func() error {
-		resp, err = client.fallbackClient.Do(req)
-		return err
-	})
-	if err != nil {
-		return token, err
-	}
-	rawBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return token, err
-	}
-	if err := json.Unmarshal(rawBody, &token); err != nil {
-		return token, err
-	}
-	return token, nil
 }

--- a/launchdarkly/resource_access_token_upgrade.go
+++ b/launchdarkly/resource_access_token_upgrade.go
@@ -1,0 +1,48 @@
+package launchdarkly
+
+// Frozen pre-v3 access_token schema + model used as PriorSchema for
+// the v0->v1 state upgrader. The v0 shape (v2.x SDKv2 provider)
+// carried the deprecated `expire` and `policy_statements`
+// attributes; v3 drops both. The upgrader decodes prior state into
+// AccessTokenResourceModelV0 and projects to the current
+// AccessTokenResourceModel: expire is discarded (LD's public API
+// never supported it), and policy_statements migrates verbatim into
+// inline_roles (identical shape — both built from
+// frameworkPolicyStatementsResourceAttribute).
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type AccessTokenResourceModelV0 struct {
+	ID                types.String `tfsdk:"id"`
+	Name              types.String `tfsdk:"name"`
+	Role              types.String `tfsdk:"role"`
+	CustomRoles       types.Set    `tfsdk:"custom_roles"`
+	PolicyStatements  types.List   `tfsdk:"policy_statements"`
+	InlineRoles       types.List   `tfsdk:"inline_roles"`
+	ServiceToken      types.Bool   `tfsdk:"service_token"`
+	DefaultAPIVersion types.Int64  `tfsdk:"default_api_version"`
+	Token             types.String `tfsdk:"token"`
+	Expire            types.Int64  `tfsdk:"expire"`
+}
+
+func accessTokenSchemaAttributesV0() map[string]schema.Attribute {
+	attrs := accessTokenSchemaAttributes()
+	attrs[EXPIRE] = schema.Int64Attribute{
+		Optional:           true,
+		Description:        "An expiration time for the current token secret, expressed as a Unix epoch time. Replace the computed token secret with a new value. The expired secret will no longer be able to authorize usage of the LaunchDarkly API. This field argument is **deprecated**. Please update your config to remove `expire` to maintain compatibility with future versions",
+		DeprecationMessage: "'expire' is deprecated and will be removed in the next major release of the LaunchDarkly provider",
+		Validators: []validator.Int64{
+			noZeroValuesInt64Validator{},
+		},
+	}
+	attrs[POLICY_STATEMENTS] = frameworkPolicyStatementsResourceAttribute(
+		false,
+		"Define inline custom roles. An array of statements with three attributes: effect, resources, actions. May be used in place of a built-in or custom role. This field argument is **deprecated**. Update your config to use `inline_role` to maintain compatibility with future versions.",
+		"'policy_statements' is deprecated in favor of 'inline_roles'. This field will be removed in the next major release of the LaunchDarkly provider",
+	)
+	return attrs
+}

--- a/launchdarkly/resource_launchdarkly_access_token_test.go
+++ b/launchdarkly/resource_launchdarkly_access_token_test.go
@@ -2,9 +2,7 @@ package launchdarkly
 
 import (
 	"fmt"
-	"strconv"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -89,23 +87,6 @@ resource "launchdarkly_access_token" "test" {
 		effect = "allow"
 		resources = ["proj/*:env/staging"]
 	}]
-}
-`
-	testAccAccessTokenCreateWithPolicyStatements = `
-resource "launchdarkly_access_token" "test" {
-	name = "Access token - %s"
-	policy_statements = [{
-		actions = ["*"]
-		effect = "allow"
-		resources = ["proj/*:env/staging"]
-	}]
-}
-`
-	testAccAccessTokenReset = `
-resource "launchdarkly_access_token" "test" {
-	name = "Access token - %s"
-	role = "reader"
-	expire = %d
 }
 `
 )
@@ -233,38 +214,6 @@ func TestAccAccessToken_CreateWithInlineRoles(t *testing.T) {
 	})
 }
 
-func TestAccAccessToken_CreateWithPolicyStatements(t *testing.T) {
-	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	resourceName := "launchdarkly_access_token.test"
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:             testAccCheckAccessTokenDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(testAccAccessTokenCreateWithPolicyStatements, name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAccessTokenExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, NAME, "Access token - "+name),
-					resource.TestCheckResourceAttr(resourceName, "policy_statements.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "policy_statements.0.actions.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "policy_statements.0.actions.0", "*"),
-					resource.TestCheckResourceAttr(resourceName, "policy_statements.0.resources.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "policy_statements.0.resources.0", "proj/*:env/staging"),
-					resource.TestCheckResourceAttr(resourceName, "policy_statements.0.effect", "allow"),
-					resource.TestCheckResourceAttr(resourceName, SERVICE_TOKEN, "false"),
-					resource.TestCheckResourceAttrSet(resourceName, DEFAULT_API_VERSION),
-					resource.TestCheckResourceAttrSet(resourceName, TOKEN),
-					resource.TestCheckNoResourceAttr(resourceName, ROLE),
-					resource.TestCheckNoResourceAttr(resourceName, CUSTOM_ROLES),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAccessToken_Update(t *testing.T) {
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	resourceName := "launchdarkly_access_token.test"
@@ -296,70 +245,6 @@ func TestAccAccessToken_Update(t *testing.T) {
 			},
 		},
 	})
-}
-
-func TestAccAccessToken_Reset(t *testing.T) {
-	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	resourceName := "launchdarkly_access_token.test"
-
-	original := new(string)
-	updated := new(string)
-
-	hourFromNow := time.Now().Add(time.Hour).Unix() * 1000
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:             testAccCheckAccessTokenDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(testAccAccessTokenCreate, name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAccessTokenExists(resourceName),
-					testAccStoreAccessTokenSecret(original, resourceName),
-				),
-			},
-			{
-				Config: fmt.Sprintf(testAccAccessTokenReset, name, -1),
-				Check: resource.ComposeTestCheckFunc(
-					testAccStoreAccessTokenSecret(updated, resourceName),
-					testAccCheckAccessTokenChanged(original, updated),
-					resource.TestCheckResourceAttr(resourceName, "expire", "-1"),
-					// reset the original secret for the next test
-					testAccStoreAccessTokenSecret(original, resourceName),
-				),
-			},
-			{
-				Config: fmt.Sprintf(testAccAccessTokenReset, name, hourFromNow),
-				Check: resource.ComposeTestCheckFunc(
-					testAccStoreAccessTokenSecret(updated, resourceName),
-					testAccCheckAccessTokenChanged(original, updated),
-					resource.TestCheckResourceAttr(resourceName, "expire", strconv.Itoa(int(hourFromNow))),
-				),
-			},
-		},
-	})
-}
-
-func testAccStoreAccessTokenSecret(ptr *string, resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("not found: %s", resourceName)
-		}
-		*ptr = rs.Primary.Attributes[TOKEN]
-		return nil
-	}
-}
-
-func testAccCheckAccessTokenChanged(original, updated *string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if *original == *updated {
-			return fmt.Errorf("access token secret did not changed")
-		}
-		return nil
-	}
 }
 
 func testAccCheckAccessTokenExists(resourceName string) resource.TestCheckFunc {

--- a/scripts/migrate-tf-syntax/main.go
+++ b/scripts/migrate-tf-syntax/main.go
@@ -323,6 +323,10 @@ func applyDeprecations(body *hclwrite.Body, deps []*DeprecationSpec) bool {
 			if convertPolicyToPolicyStatements(body, d.Name, d.To) {
 				changed = true
 			}
+		case "rename":
+			if renameAttribute(body, d.Name, d.To) {
+				changed = true
+			}
 		default:
 			fmt.Fprintf(os.Stderr, "warning: unknown deprecation action %q for attribute %q (skipping)\n", d.Action, d.Name)
 		}
@@ -376,6 +380,28 @@ func dropOrConvertIISToCSA(body *hclwrite.Body, name, to, mobile string) bool {
 		&hclwrite.Token{Type: hclsyntax.TokenCBrace, Bytes: []byte("}")},
 		&hclwrite.Token{Type: hclsyntax.TokenCBrack, Bytes: []byte("]")},
 	)
+	body.RemoveAttribute(name)
+	body.SetAttributeRaw(to, tokens)
+	return true
+}
+
+// renameAttribute moves the value of `name` onto `to`, preserving the right-hand-side expression
+// tokens verbatim. If `to` already exists in the body, the original wins and `name` is dropped
+// silently — same convention as the other deprecation actions (config wins over deprecated alias).
+func renameAttribute(body *hclwrite.Body, name, to string) bool {
+	if to == "" {
+		fmt.Fprintf(os.Stderr, "warning: rename action on %q requires \"to\" target (skipping)\n", name)
+		return false
+	}
+	src := body.GetAttribute(name)
+	if src == nil {
+		return false
+	}
+	if body.GetAttribute(to) != nil {
+		body.RemoveAttribute(name)
+		return true
+	}
+	tokens := src.Expr().BuildTokens(nil)
 	body.RemoveAttribute(name)
 	body.SetAttributeRaw(to, tokens)
 	return true

--- a/scripts/migrate-tf-syntax/mappings.json
+++ b/scripts/migrate-tf-syntax/mappings.json
@@ -3,6 +3,10 @@
     "blocks": [
       {"name": "inline_roles"},
       {"name": "policy_statements"}
+    ],
+    "deprecations": [
+      {"name": "expire", "action": "drop"},
+      {"name": "policy_statements", "action": "rename", "to": "inline_roles"}
     ]
   },
   "launchdarkly_audit_log_subscription": {


### PR DESCRIPTION
Both were deprecated in v1.7.0 (Aug 2021). expire never worked
against the public LaunchDarkly API — it issued a private reset
endpoint call — and goes away outright. policy_statements is a pure
alias of inline_roles (identical shape, both built from
frameworkPolicyStatementsResourceAttribute) and gets folded into
inline_roles.

State-upgrade path: the existing v0->v1 upgrader decodes prior state
into AccessTokenResourceModelV0 (with expire and policy_statements)
and projects to the current model. expire is silently discarded.
policy_statements is renamed to inline_roles when only the former is
set. If both are populated in prior state (shouldn't happen — v2
Conflicting validator blocked it) the upgrader errors with a clear
message instructing the user to drop one before re-applying.

Side effects in the resource: the expire-driven token-reset path in
Update is gone, and with it the raw-HTTP resetAccessTokenFramework
helper. ConfigValidators drops policy_statements from the
Conflicting set. Create/Update/Read paths simplify to read only
inline_roles.

HCL migration: scripts/migrate-tf-syntax gains a new rename action
that moves the right-hand-side expression tokens from `name` onto
`to`, dropping the source. Also uses the existing drop action for
expire. mappings.json entries: drop expire, rename policy_statements
to inline_roles.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking schema change affects access-token Terraform config and state; mitigated by v0→v1 state upgrader and HCL migrate script, but upgrades can fail if both deprecated inline-role fields were set in state.
> 
> **Overview**
> **Breaking change for `launchdarkly_access_token`:** removes deprecated **`expire`** and **`policy_statements`**. Role configuration is **`role`**, **`custom_roles`**, or **`inline_roles`** only. Docs and schema text no longer mention the old aliases.
> 
> **State upgrade (v0→v1):** prior state is decoded with a frozen **`AccessTokenResourceModelV0`** / **`accessTokenSchemaAttributesV0`**. **`expire`** is dropped; **`policy_statements`** is copied onto **`inline_roles`** when only the former is set. If both are populated, upgrade fails with a clear error.
> 
> **Runtime behavior:** create/update/read no longer prefer **`policy_statements`** or call the private reset endpoint. **`resetAccessTokenFramework`** and the **`expire`**-driven secret rotation in **Update** are removed. **`ModifyPlan`** still preserves **`default_api_version`** when upgrading old state (no longer gated on **`expire`** changes).
> 
> **HCL migration:** **`migrate-tf-syntax`** adds a **`rename`** deprecation action; **`mappings.json`** drops **`expire`** and renames **`policy_statements`** → **`inline_roles`**. Acceptance tests for **`policy_statements`** and **`expire`** reset are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39371edd8ec417b258d61ea369a9a4ce07f8e86d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->