### PR TITLE
feat(flag_trigger): deprecate flag trigger resource and data source

### DIFF
--- a/docs/data-sources/flag_trigger.md
+++ b/docs/data-sources/flag_trigger.md
@@ -4,6 +4,7 @@ page_title: "launchdarkly_flag_trigger Data Source - launchdarkly"
 subcategory: ""
 description: |-
   Provides a LaunchDarkly flag trigger data source.
+  ~> Deprecation notice: The flag triggers feature is approaching end of life in LaunchDarkly. This data source is deprecated and will be removed in a future major release of the provider.
   -> Note: Flag triggers are available to customers on an Enterprise LaunchDarkly plan. To learn more, read about our pricing https://launchdarkly.com/pricing/. To upgrade your plan, contact LaunchDarkly Sales https://launchdarkly.com/contact-sales/.
   This data source allows you to retrieve information about flag triggers from your LaunchDarkly organization.
 ---
@@ -11,6 +12,8 @@ description: |-
 # launchdarkly_flag_trigger (Data Source)
 
 Provides a LaunchDarkly flag trigger data source.
+
+~> **Deprecation notice:** The flag triggers feature is approaching end of life in LaunchDarkly. This data source is deprecated and will be removed in a future major release of the provider.
 
 -> **Note:** Flag triggers are available to customers on an Enterprise LaunchDarkly plan. To learn more, [read about our pricing](https://launchdarkly.com/pricing/). To upgrade your plan, [contact LaunchDarkly Sales](https://launchdarkly.com/contact-sales/).
 

--- a/docs/resources/flag_trigger.md
+++ b/docs/resources/flag_trigger.md
@@ -3,6 +3,7 @@ page_title: "launchdarkly_flag_trigger Resource - launchdarkly"
 subcategory: ""
 description: |-
   Provides a LaunchDarkly flag trigger resource.
+  ~> Deprecation notice: The flag triggers feature is approaching end of life in LaunchDarkly. This resource is deprecated and will be removed in a future major release of the provider.
   -> Note: Flag triggers are available to customers on an Enterprise LaunchDarkly plan. To learn more, read about our pricing https://launchdarkly.com/pricing/. To upgrade your plan, contact LaunchDarkly Sales https://launchdarkly.com/contact-sales/.
   This resource allows you to create and manage flag triggers within your LaunchDarkly organization.
   -> Note: This resource stores the sensitive unique trigger URL value in plaintext in your Terraform state. Be sure your state is configured securely before using this resource. To learn more, read Sensitive data in state https://www.terraform.io/docs/state/sensitive-data.html.
@@ -11,6 +12,8 @@ description: |-
 # launchdarkly_flag_trigger (Resource)
 
 Provides a LaunchDarkly flag trigger resource.
+
+~> **Deprecation notice:** The flag triggers feature is approaching end of life in LaunchDarkly. This resource is deprecated and will be removed in a future major release of the provider.
 
 -> **Note:** Flag triggers are available to customers on an Enterprise LaunchDarkly plan. To learn more, [read about our pricing](https://launchdarkly.com/pricing/). To upgrade your plan, [contact LaunchDarkly Sales](https://launchdarkly.com/contact-sales/).
 

--- a/launchdarkly/data_source_flag_trigger_framework.go
+++ b/launchdarkly/data_source_flag_trigger_framework.go
@@ -43,7 +43,8 @@ func (d *FlagTriggerDataSource) Metadata(_ context.Context, req datasource.Metad
 
 func (d *FlagTriggerDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Provides a LaunchDarkly flag trigger data source.\n\n-> **Note:** Flag triggers are available to customers on an Enterprise LaunchDarkly plan. To learn more, [read about our pricing](https://launchdarkly.com/pricing/). To upgrade your plan, [contact LaunchDarkly Sales](https://launchdarkly.com/contact-sales/).\n\nThis data source allows you to retrieve information about flag triggers from your LaunchDarkly organization.",
+		DeprecationMessage: "This data source is deprecated and will be removed in a future major release of the provider. The flag triggers feature is approaching end of life in LaunchDarkly.",
+		Description:        "Provides a LaunchDarkly flag trigger data source.\n\n~> **Deprecation notice:** The flag triggers feature is approaching end of life in LaunchDarkly. This data source is deprecated and will be removed in a future major release of the provider.\n\n-> **Note:** Flag triggers are available to customers on an Enterprise LaunchDarkly plan. To learn more, [read about our pricing](https://launchdarkly.com/pricing/). To upgrade your plan, [contact LaunchDarkly Sales](https://launchdarkly.com/contact-sales/).\n\nThis data source allows you to retrieve information about flag triggers from your LaunchDarkly organization.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Required:    true,

--- a/launchdarkly/resource_flag_trigger_framework.go
+++ b/launchdarkly/resource_flag_trigger_framework.go
@@ -50,7 +50,10 @@ func (r *FlagTriggerResource) Metadata(_ context.Context, req resource.MetadataR
 
 func (r *FlagTriggerResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		DeprecationMessage: "This resource is deprecated and will be removed in a future major release of the provider. The flag triggers feature is approaching end of life in LaunchDarkly.",
 		Description: `Provides a LaunchDarkly flag trigger resource.
+
+~> **Deprecation notice:** The flag triggers feature is approaching end of life in LaunchDarkly. This resource is deprecated and will be removed in a future major release of the provider.
 
 -> **Note:** Flag triggers are available to customers on an Enterprise LaunchDarkly plan. To learn more, [read about our pricing](https://launchdarkly.com/pricing/). To upgrade your plan, [contact LaunchDarkly Sales](https://launchdarkly.com/contact-sales/).
 


### PR DESCRIPTION
## Summary

Marks `launchdarkly_flag_trigger` (resource and data source) as deprecated. The flag triggers feature is approaching end of life in the LaunchDarkly API; this surfaces a deprecation warning on plan/apply ahead of removal in a future major release.

- Adds schema-level `DeprecationMessage` to both the resource and data source
- Adds a deprecation notice to the schema descriptions so it renders in the registry docs
- Docs regenerated via `tfplugindocs` (no integration-manifest changes)

## Testing

- `go build ./...`, `go vet` clean
- Docs diff limited to the two flag_trigger pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and schema deprecation metadata only; no changes to flag trigger CRUD or API calls.
> 
> **Overview**
> **Deprecates** `launchdarkly_flag_trigger` and its data source ahead of LaunchDarkly flag triggers end-of-life and a future provider major release.
> 
> Schema changes add `DeprecationMessage` on both types so **plan/apply** surfaces Terraform deprecation warnings, and extend descriptions with a matching notice. **Registry docs** for the resource and data source are regenerated to show the same messaging; runtime behavior and API usage are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5946b4105d23dae6d6b96956a899c94d15d0842. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->