### PR TITLE
fix(feature_flag): demote prereq destroy plan check to a warning

### DIFF
--- a/launchdarkly/resource_feature_flag_framework.go
+++ b/launchdarkly/resource_feature_flag_framework.go
@@ -412,10 +412,16 @@ func (r *FeatureFlagResource) ModifyPlan(ctx context.Context, req resource.Modif
 			return
 		}
 		if deps != nil && len(deps.Items) > 0 {
-			resp.Diagnostics.AddAttributeError(
-				path.Root(KEY),
-				fmt.Sprintf("flag %q in project %q is a prerequisite for other flags and cannot be destroyed", flagKey, projectKey),
-				formatDependentFlagsHint(deps.Items),
+			// Advisory only. At plan time nothing has been destroyed yet, so
+			// a plan that removes both this flag AND the prerequisite links
+			// (e.g. a whole-stack destroy, or one that updates the dependent
+			// flags' launchdarkly_feature_flag_environment) is legitimate and
+			// will succeed. The authoritative gate is the apply-time DELETE,
+			// which returns a 409 if the references still exist. Warn so the
+			// user sees the dependency early without blocking valid destroys.
+			resp.Diagnostics.AddWarning(
+				fmt.Sprintf("flag %q in project %q is referenced as a prerequisite by other flags", flagKey, projectKey),
+				formatDependentFlagsHint(deps.Items)+"\n\nIf those references still exist when this destroy is applied, the apply will fail with a 409 conflict. If the same plan also removes them, the destroy will succeed.",
 			)
 		}
 		return

--- a/launchdarkly/resource_launchdarkly_feature_flag_test.go
+++ b/launchdarkly/resource_launchdarkly_feature_flag_test.go
@@ -1532,10 +1532,13 @@ resource "launchdarkly_feature_flag" "test" {
 	})
 }
 
-// TestAccFeatureFlag_DeletePrerequisitePlanError exercises the
-// destroy-plan dependent-flag validator in FeatureFlagResource.ModifyPlan
-// (issue #372).
-func TestAccFeatureFlag_DeletePrerequisitePlanError(t *testing.T) {
+// TestAccFeatureFlag_DeletePrerequisiteApplyError exercises the
+// apply-time gate on destroying a flag that is still referenced as a
+// prerequisite. The plan-time dependent-flag check in
+// FeatureFlagResource.ModifyPlan is advisory only (emits a warning, not
+// an error) so whole-stack destroys are not blocked (issue #372); the
+// authoritative gate is the DELETE 409, asserted here.
+func TestAccFeatureFlag_DeletePrerequisiteApplyError(t *testing.T) {
 	projectKey := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	configFull := withRandomProject(projectKey, `
@@ -1580,8 +1583,8 @@ resource "launchdarkly_feature_flag_environment" "dependent_env" {
 	// flag resource is removed from config. HCL keeps the literal flag
 	// key string in the prerequisites block so the file still compiles;
 	// Terraform plans destruction of `launchdarkly_feature_flag.prereq`
-	// and ModifyPlan should fail at plan time with the prerequisite
-	// hint rather than waiting for the apply-time 409.
+	// while the FFE still references it, so the apply-time DELETE returns
+	// a 409 and the destroy fails (the plan-time check only warns).
 	configMissingPrereq := withRandomProject(projectKey, `
 resource "launchdarkly_feature_flag" "dependent" {
 	project_key    = launchdarkly_project.test.key
@@ -1660,13 +1663,14 @@ resource "launchdarkly_feature_flag_environment" "dependent_env" {
 			},
 			{
 				// The dependent-flags beta endpoint is eventually
-				// consistent. Poll until the dependency is visible so
-				// the plan-time validator in Step 2 sees it; otherwise
-				// the destroy plan slips through with no error.
+				// consistent. Poll until the dependency is indexed so the
+				// prerequisite link is fully established server-side, then
+				// apply: the destroy of prereq-flag must fail with the
+				// apply-time DELETE 409. The plan-time check only warns now,
+				// so this asserts the authoritative apply-time gate.
 				PreConfig:   waitForDependentFlagIndexed(t, projectKey, "prereq-flag"),
 				Config:      configMissingPrereq,
-				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(`is a prerequisite for other flags and cannot be destroyed`),
+				ExpectError: regexp.MustCompile(`failed to delete flag "prereq-flag" from project`),
 			},
 			{
 				Config: configWithoutPrerequisiteLink,
@@ -1688,7 +1692,7 @@ resource "launchdarkly_feature_flag_environment" "dependent_env" {
 
 // waitForDependentFlagIndexed polls the beta dependent-flags endpoint
 // until at least one dependent is visible, or a timeout elapses. Used
-// before TestAccFeatureFlag_DeletePrerequisitePlanError's Step 2 plan
+// before TestAccFeatureFlag_DeletePrerequisiteApplyError's Step 2 apply
 // because the prerequisite written during Step 1's Apply may take time
 // to become visible server-side.
 func waitForDependentFlagIndexed(t *testing.T, projectKey, flagKey string) func() {


### PR DESCRIPTION
## What

Demotes the plan-time dependent-flag check in `FeatureFlagResource.ModifyPlan` from a hard `AddAttributeError` to an advisory `AddWarning`. The apply-time DELETE 409 remains the authoritative gate.

## Why

The plan-time check added in #430 (issue #372) raised a hard error on a destroy plan whenever the flag was still referenced as a prerequisite. **This is a structural false positive:** at plan time nothing has been destroyed yet, so a whole-stack destroy that removes both the prerequisite flag *and* the `launchdarkly_feature_flag_environment` holding the prerequisite always trips the error — even though the same plan removes the dependency (the ffe `Delete` patches `prerequisites: []`).

It surfaced on `preview-v3` on 2026-06-11 ~11:30Z, breaking the `TestAccFeatureFlagEnvironment_Prereq` post-test destroy on every open preview-v3 PR. The provider code was unchanged from that morning's green runs — `ModifyPlan` degrades to a warning when `getDependentFlags` errors (CI tokens had been hitting the beta endpoint's 403 path all along). A backend change in that window started returning 200, so the call began succeeding and the latent hard error fired for the first time.

## Change

- `ModifyPlan`: `AddAttributeError` → `AddWarning`. Detail keeps `formatDependentFlagsHint(...)` and adds an advisory note: the apply will 409 if the references still exist, but succeeds if the same plan removes them. Wording kept consistent with the existing 403-degradation warning.
- Test: `TestAccFeatureFlag_DeletePrerequisitePlanError` → `TestAccFeatureFlag_DeletePrerequisiteApplyError`. Step 2 drops `PlanOnly` and now asserts the **apply-time** delete failure (`failed to delete flag "prereq-flag" from project`) instead of the plan-time error. The `waitForDependentFlagIndexed` / `waitForDependentFlagUnindexed` poll helpers are retained.

## Validation

- `gofmt`, `go vet ./launchdarkly/`, `go build ./...` — clean locally.
- No schema descriptions / integration-config logic touched → `make generate` is a no-op diff.
- Acceptance shards (`TestAccFeatureFlag_`, `TestAccFeatureFlagEnvironment`) run via CI (no local token in sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes destroy-plan behavior for a core resource: users no longer get a hard plan failure for prerequisite dependencies, though invalid destroys still fail on apply; risk is mainly operational surprise vs. the previous stricter plan gate.
> 
> **Overview**
> **`launchdarkly_feature_flag` destroy plans** no longer fail when the beta dependent-flags API reports prerequisite references. `FeatureFlagResource.ModifyPlan` now emits an **advisory warning** (with the same `formatDependentFlagsHint` detail plus guidance about apply-time 409 vs. same-plan cleanup) instead of a blocking attribute error, so whole-stack destroys that remove prerequisite links in the same plan are allowed.
> 
> Acceptance coverage shifts from plan-time failure to **apply-time enforcement**: `TestAccFeatureFlag_DeletePrerequisiteApplyError` runs a full apply and expects `failed to delete flag "prereq-flag" from project` when the prerequisite link remains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac7eb27117be18f57b8f50a92c9026a0ce1e22fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->