### PR TITLE
ci: register autogen dispatch workflows on the default branch

### DIFF
--- a/.github/workflows/drift-report.yml
+++ b/.github/workflows/drift-report.yml
@@ -1,0 +1,96 @@
+# API-coverage drift report (stage 1 of the autogen pipeline — see
+# .claude/plans/AUTOGEN_PIPELINE.md).
+#
+# Diffs the endpoint families of LaunchDarkly's public OpenAPI spec against the
+# resources registered in the provider, using the curated mapping at
+# scripts/driftreport/mapping.yaml. On drift, posts to a private Slack channel
+# via the SLACK_DRIFT_WEBHOOK_URL secret. This repo is PUBLIC, so internal
+# drift tracking must not use GitHub issues.
+name: API drift report
+
+on:
+  # This file lives on `main` only so GitHub registers the workflow_dispatch
+  # trigger (dispatch requires the workflow on the default branch). The tool
+  # itself always runs against the v3 line via the pinned checkout below.
+  # No `schedule:` yet — add a weekly cron once v3 becomes `main` and the
+  # checkout pin is dropped.
+  workflow_dispatch: # manual runs only
+
+permissions:
+  contents: read
+
+jobs:
+  drift-report:
+    name: Drift report
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # All autogen work targets the v3 line. Without this pin a dispatch
+          # from main would enumerate the v2 (SDKv2) provider against the spec
+          # and report garbage drift. Drop the pin when v3 becomes `main`.
+          ref: preview-v3
+      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+        with:
+          go-version-file: "go.mod"
+          cache: true
+      - run: go mod download
+      # Build first: `go run` collapses the tool's exit code (2 = drift) to 1.
+      - run: go build -o /tmp/driftreport ./scripts/driftreport
+      - name: Run drift report
+        id: drift
+        run: |
+          set +e
+          /tmp/driftreport -out drift-report.md
+          code=$?
+          set -e
+          if [ "$code" -ne 0 ] && [ "$code" -ne 2 ]; then
+            echo "driftreport failed with exit code $code" >&2
+            exit "$code"
+          fi
+          drift=$([ "$code" -eq 2 ] && echo true || echo false)
+          echo "drift=$drift" >> "$GITHUB_OUTPUT"
+          # PUBLIC-REPO SAFETY: this run's logs/summary are world-readable, so the
+          # report body must NOT land here. Summary states only whether drift was
+          # found; the detail goes to the private Slack channel. drift-report.md
+          # stays on the ephemeral runner (never uploaded as an artifact).
+          if [ "$drift" = "true" ]; then
+            echo "Drift detected — full report sent to the private Slack channel." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No drift detected." >> "$GITHUB_STEP_SUMMARY"
+          fi
+      # Build the Slack payload with jq so the report markdown is correctly
+      # JSON-escaped (quotes/newlines/backticks can't break the payload).
+      # Truncated to stay under Slack's ~4000-char webhook-variable limit;
+      # full detail is one re-dispatch away.
+      - name: Build Slack payload
+        id: slack_payload
+        if: steps.drift.outputs.drift == 'true'
+        run: |
+          limit=3500
+          report="$(head -c "$limit" drift-report.md)"
+          if [ "$(wc -c < drift-report.md)" -gt "$limit" ]; then
+            report="${report}"$'\n\n…(truncated — re-dispatch the workflow for the full report)'
+          fi
+          payload="$(jq -nc \
+            --arg message "API coverage drift detected — the provider lags behind the public API. Review and decide whether to scaffold." \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg run_url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --arg report "$report" \
+            '{message: $message, repo: $repo, run_url: $run_url, report: $report}')"
+          {
+            printf '%s\n' 'payload<<SLACK_PAYLOAD_EOF'
+            printf '%s\n' "$payload"
+            printf '%s\n' 'SLACK_PAYLOAD_EOF'
+          } >> "$GITHUB_OUTPUT"
+      # Notify a private Slack channel on drift. The Workflow Builder trigger
+      # behind SLACK_DRIFT_WEBHOOK_URL should declare these Text variables:
+      # message, repo, run_url, report.
+      - name: Notify Slack on drift
+        if: steps.drift.outputs.drift == 'true'
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_DRIFT_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: ${{ steps.slack_payload.outputs.payload }}

--- a/.github/workflows/scaffold-resource.yml
+++ b/.github/workflows/scaffold-resource.yml
@@ -1,0 +1,102 @@
+# Stage 2 of the autogen pipeline (see .claude/plans/AUTOGEN_PIPELINE.md):
+# one-shot scaffolding of a new provider resource for an endpoint family
+# surfaced by the drift report (stage 1).
+#
+# Manually triggered only — never wired to the drift cron. The agent's output
+# is a DRAFT pull request; it never merges anything. Existing CI (build, lint,
+# generate-diff, acceptance shards) is the quality floor for the draft.
+#
+# This file lives on `main` only so GitHub registers the workflow_dispatch
+# trigger (dispatch requires the workflow on the default branch). The checkout
+# below pins preview-v3 — all scaffolding targets the v3 line regardless.
+#
+# Kill switch: the repository variable SCAFFOLD_AGENT_ENABLED must be "true".
+# TODO(stage 2b): replace the variable gate with a LaunchDarkly AI Config
+# ("tf-provider-scaffolder") for model/prompt/kill-switch control — reference
+# implementation in ld-docs-private ffeldberg/validate-ai-configs-sdk.
+name: Scaffold resource from API family
+
+on:
+  workflow_dispatch:
+    inputs:
+      family:
+        description: "Endpoint family tag from the drift report (e.g. AgentControl)"
+        required: true
+        type: string
+      notes:
+        description: "Optional extra instructions for the scaffolding agent"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  scaffold:
+    name: Scaffold ${{ inputs.family }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check kill switch
+        if: vars.SCAFFOLD_AGENT_ENABLED != 'true'
+        run: |
+          echo "::error::Scaffolding agent is disabled (repository variable SCAFFOLD_AGENT_ENABLED != 'true')."
+          exit 1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: preview-v3 # scaffolds always target the v3 line
+          fetch-depth: 0
+      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+        with:
+          go-version-file: "go.mod"
+          cache: true
+      - name: Extract endpoint-family context
+        run: |
+          go build -o /tmp/driftreport ./scripts/driftreport
+          # Write the slice into the workspace so the agent's repo-scoped file
+          # tools can read it (an absolute /tmp path may be outside their scope).
+          /tmp/driftreport -family "${{ inputs.family }}" -out "$GITHUB_WORKSPACE/family-slice.json"
+          # Public repo: don't print the slice into world-readable logs (same
+          # discipline as the drift report). Log only a size/path-count summary.
+          echo "family-slice.json written ($(wc -c < "$GITHUB_WORKSPACE/family-slice.json") bytes, $(jq '.paths | length' "$GITHUB_WORKSPACE/family-slice.json") paths)"
+      - name: Run scaffolding agent
+        uses: anthropics/claude-code-action@0f97b95b6536c26e5f6bd90faec370d41695beca # v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            Scaffold a new resource for the LaunchDarkly Terraform provider covering
+            the "${{ inputs.family }}" API endpoint family.
+
+            Inputs:
+            - Endpoint summary for the family: ./family-slice.json (repo root).
+              This is input context only — read it, but do NOT commit it.
+            - Full OpenAPI spec (for schemas): https://app.launchdarkly.com/api/v2/openapi.json
+            - Read .claude/skills/terraform-provider-add-resource/SKILL.md and its
+              references/patterns.md (both vendored into this repo), and follow that
+              playbook's Steps 0-10 exactly. Also obey the conventions in CLAUDE.md:
+              keys.go constants, framework nested attributes (never blocks), helpers
+              from framework_helpers.go, patch helpers, handleLdapiErr wrapping,
+              acceptance-test CI matrix entry, docs templates.
+            - Use the generated API client (github.com/launchdarkly/api-client-go/v22)
+              for all API calls. If the client lacks this surface, stop and report that
+              instead of hand-rolling HTTP.
+
+            Additional notes from the operator: ${{ inputs.notes }}
+
+            Deliverable:
+            1. Create a branch named scaffold/${{ inputs.family }} (lowercased,
+               non-alphanumerics replaced with '-') off preview-v3.
+            2. Implement the resource (and data source if the family has GET-by-key),
+               unit-testable helpers, acceptance tests, docs templates, and provider
+               registration. Update scripts/driftreport/mapping.yaml to mark the family
+               covered.
+            3. Run go build ./... and make fmt; fix what they surface.
+            4. Commit, push the branch, and open a DRAFT pull request against
+               preview-v3 titled "feat: scaffold ${{ inputs.family }} resource
+               (autogen stage 2)". The PR body must state it is agent-scaffolded and
+               needs human review per stage 3 of the autogen pipeline.
+            Never push to preview-v3 directly and never merge anything.
+          claude_args: |
+            --allowedTools "Read,Edit,Write,Glob,Grep,Bash(go:*),Bash(make:*),Bash(git:*),Bash(gh pr create:*),Bash(gofmt:*),WebFetch(domain:app.launchdarkly.com)"


### PR DESCRIPTION
Want these workflows to run against the v3 preview branch, but they need to be in main for that to happen - not something that actually affects anything on `main`

## Why

GitHub only registers `workflow_dispatch` triggers for workflow files on the **default branch**. The autogen-pipeline workflows (drift report #445, scaffold #446) merged to `preview-v3`, so `gh workflow run` and the Actions UI can't see them — the pilot dispatch is blocked.

## What

Copies both workflow files to `main`, unchanged except:

- `drift-report.yml` gains `ref: preview-v3` on its checkout — without it, a dispatch from main would enumerate the **v2 (SDKv2)** provider against the spec and report garbage drift. (`scaffold-resource.yml` already pinned preview-v3.)
- Header comments documenting why the files live here and what to undo when v3 becomes `main` (drop the pins, add the drift cron).

## Safety

- No behavior change to anything on `main` — both workflows are `workflow_dispatch`-only, no cron, and operate exclusively on the v3 line via pinned checkouts.
- Scaffold guardrails unchanged: `SCAFFOLD_AGENT_ENABLED` kill switch, draft-PR-only deliverable, never pushes to `preview-v3`.
- Public-repo output discipline unchanged: drift detail goes to private Slack only; scaffold logs a slice size summary, not content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only, manual `workflow_dispatch` workflows with read-only drift job and existing scaffold guardrails; no runtime provider or merge automation changes on `main`.
> 
> **Overview**
> Adds the autogen **API drift report** and **scaffold resource** GitHub Actions workflows to the **default branch** so `workflow_dispatch` and `gh workflow run` can discover them (GitHub only registers manual triggers from `main`).
> 
> **`drift-report.yml`** is new here with **`ref: preview-v3`** on checkout so a dispatch from `main` still compares OpenAPI coverage against the v3 provider instead of v2. Comments note future cleanup (drop pins, add cron when v3 is default). Behavior stays manual-only: drift details go to private Slack, not public logs/artifacts.
> 
> **`scaffold-resource.yml`** is registered the same way (checkout already pinned to `preview-v3`); kill switch, draft-PR-only agent flow, and public-repo logging discipline are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16143ec529522897c3d3cf97af4712621ca1426f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->