### PR TITLE
feat: operation-level coverage in API drift report (autogen pipeline stage 1b)

### DIFF
--- a/scripts/driftreport/main.go
+++ b/scripts/driftreport/main.go
@@ -64,7 +64,7 @@ func run(specSource, mappingPath, outPath, format string) error {
 	if err != nil {
 		return err
 	}
-	families, err := specFamilies(rawSpec)
+	families, err := specOperations(rawSpec)
 	if err != nil {
 		return err
 	}

--- a/scripts/driftreport/mapping.yaml
+++ b/scripts/driftreport/mapping.yaml
@@ -4,20 +4,22 @@
 #
 # Statuses:
 #   covered — family is modeled by the listed resources/data sources
-#   partial — some endpoints modeled; note says what's missing
+#   partial — some endpoints modeled; requires per-resource operationId lists,
+#             plus ignored_operations (id + reason) for deliberately unmodeled
+#             endpoints and/or triage_operations (bare opIds; acknowledged,
+#             decision pending — listed in report, not drift). Any other spec
+#             operation in the family is drift.
 #   ignored — deliberately not an IaC surface; reason required
 #   triage  — acknowledged, coverage decision pending (listed in report, not drift)
 #
+# Resource entries are either a bare string (tag-level claim, covered families)
+# or {name, operations: [opId, ...]} (operation-level claim, partial families).
 # A spec tag missing from this file is reported as drift (new API family).
 version: 1
 families:
   - tag: AI Configs
-    status: covered
-    resources:
-      - launchdarkly_ai_config
-      - launchdarkly_ai_config_variation
-      - launchdarkly_ai_tool
-      - launchdarkly_model_config
+    status: ignored
+    reason: Two stray read-only analytics endpoints (AI tool references, agent-optimization runs). The AI Config CRUD surface is tagged AgentControl — see that entry.
 
   - tag: Access tokens
     status: covered
@@ -35,8 +37,81 @@ families:
     reason: Read-only usage metering/analytics, not a declarative IaC surface.
 
   - tag: AgentControl
-    status: triage
-    notes: Large new product area (26 paths). Prime candidate for the first stage-2 scaffolding pilot.
+    status: partial
+    resources:
+      - name: launchdarkly_ai_config
+        operations:
+          - postAIConfig
+          - getAIConfig
+          - patchAIConfig
+          - deleteAIConfig
+      - name: launchdarkly_ai_config_variation
+        operations:
+          - postAIConfigVariation
+          - getAIConfigVariation
+          - patchAIConfigVariation
+          - deleteAIConfigVariation
+      - name: launchdarkly_ai_tool
+        operations:
+          - postAITool
+          - getAITool
+          - patchAITool
+          - deleteAITool
+      - name: launchdarkly_model_config
+        operations:
+          - postModelConfig
+          - getModelConfig
+          - deleteModelConfig
+    ignored_operations:
+      - id: getAIConfigs
+        reason: List/index endpoint; the singular get covers declarative reads.
+      - id: getAIConfigQuickStats
+        reason: Read-only analytics, not declarative configuration.
+      - id: getAIConfigMetrics
+        reason: Read-only analytics, not declarative configuration.
+      - id: getAIConfigMetricsByVariation
+        reason: Read-only analytics, not declarative configuration.
+      - id: listModelConfigs
+        reason: List/index endpoint; the singular get covers declarative reads.
+      - id: listAITools
+        reason: List/index endpoint; the singular get covers declarative reads.
+      - id: listAIToolVersions
+        reason: Read-only version history, not declarative configuration.
+    triage_operations:
+      # AI Config targeting — declarative-adjacent, pairs with a future
+      # ai_config_environment-style resource.
+      - getAIConfigTargeting
+      - patchAIConfigTargeting
+      # Agent graphs — new product surface, no resource yet.
+      - listAgentGraphs
+      - postAgentGraph
+      - getAgentGraph
+      - patchAgentGraph
+      - deleteAgentGraph
+      # Agent optimizations — new product surface, no resource yet.
+      - listAgentOptimizations
+      - postAgentOptimization
+      - getAgentOptimization
+      - patchAgentOptimization
+      - deleteAgentOptimization
+      - listAgentOptimizationResults
+      - listAllAgentOptimizationResults
+      - postAgentOptimizationResult
+      - patchAgentOptimizationResult
+      - deleteAgentOptimizationRun
+      - listAgentOptimizationResultsByRunId
+      # Prompt snippets — plausible resource once the surface stabilizes.
+      - listPromptSnippets
+      - postPromptSnippet
+      - getPromptSnippet
+      - patchPromptSnippet
+      - deletePromptSnippet
+      - listPromptSnippetReferences
+      - listPromptSnippetVersions
+      # Restricted models — account-level allow/deny, plausible resource.
+      - postRestrictedModels
+      - deleteRestrictedModels
+    notes: Despite the tag name, this family carries the AI Config CRUD surface — the spec's "AI Configs" tag holds only two stray analytics endpoints. The four AI resources cover 15 of 49 ops; agent graphs/optimizations, prompt snippets, targeting, and restricted models are pending triage.
 
   - tag: Announcements
     status: triage
@@ -69,7 +144,27 @@ families:
   - tag: Contexts
     status: partial
     resources:
-      - launchdarkly_context_kind
+      - name: launchdarkly_context_kind
+        operations:
+          - getContextKindsByProjectKey
+          - putContextKind
+    ignored_operations:
+      - id: getContextAttributeNames
+        reason: Runtime context-attribute analytics, not declarative configuration.
+      - id: getContextAttributeValues
+        reason: Runtime context-attribute analytics, not declarative configuration.
+      - id: searchContextInstances
+        reason: Runtime context-instance data, not declarative configuration.
+      - id: getContextInstances
+        reason: Runtime context-instance data, not declarative configuration.
+      - id: deleteContextInstances
+        reason: Runtime context-instance data, not declarative configuration.
+      - id: searchContexts
+        reason: Runtime context-instance data, not declarative configuration.
+      - id: getContexts
+        reason: Runtime context-instance data, not declarative configuration.
+      - id: evaluateContextInstance
+        reason: Imperative flag-evaluation debugging endpoint, not declarative configuration.
     notes: context-kinds endpoints are covered; context instance/search endpoints are runtime data, intentionally unmodeled.
 
   - tag: Custom roles
@@ -172,9 +267,18 @@ families:
       - launchdarkly_metric
 
   - tag: Metrics (beta)
-    status: covered
+    status: partial
     resources:
-      - launchdarkly_metric_group
+      - name: launchdarkly_metric_group
+        operations:
+          - createMetricGroup
+          - getMetricGroup
+          - patchMetricGroup
+          - deleteMetricGroup
+    ignored_operations:
+      - id: getMetricGroups
+        reason: List/index endpoint; the singular get covers declarative reads.
+    notes: Promoted to operation-level after the metric-group pilot (PR #453) merged — dogfood entry for drift tool v2.
 
   - tag: OAuth2 Clients
     status: triage
@@ -243,10 +347,6 @@ families:
     reason: Legacy users API (superseded by contexts); runtime data.
 
   - tag: Users
-    status: ignored
-    reason: Legacy users API (superseded by contexts); runtime data.
-
-  - tag: Users (beta)
     status: ignored
     reason: Legacy users API (superseded by contexts); runtime data.
 

--- a/scripts/driftreport/mapping.yaml
+++ b/scripts/driftreport/mapping.yaml
@@ -15,6 +15,31 @@
 # Resource entries are either a bare string (tag-level claim, covered families)
 # or {name, operations: [opId, ...]} (operation-level claim, partial families).
 # A spec tag missing from this file is reported as drift (new API family).
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# BLIND SPOTS — product surfaces with NO openapi.json tag (2026-06-15 audit of
+# launchdarkly.com/docs vs the live spec). This tool only sees the spec, so
+# "no drift" does NOT mean "fully covered" for these. They will only ever
+# surface here if/when LD adds public REST tags for them:
+#   - SSO / SAML / SCIM / domain verification (Okta, Entra, OneLogin, etc.) —
+#     SCIM is a separate API; SSO config is account/UI-level, not in the REST
+#     spec. Not Terraform-able via the v2 API today.
+#   - Observability product config (dashboards, alerts, service map, session
+#     replay, traces/logs). Spec carries only read-only `Insights * (beta)`
+#     tags (all ignored). No config tags yet — a real IaC gap until LD ships them.
+#
+# PRODUCT-PILLAR → FAMILY MAP (context for future scaffolding agents). The docs
+# home presents three product brands; mapping them to spec tags:
+#   - CodeControl (feature management): Feature flags, Flag triggers, Segments,
+#     Contexts, Scheduled changes, Projects, Environments.
+#   - AgentControl (AI): the `AgentControl` tag IS the AI Config CRUD surface
+#     (configs/variations/tools/model-configs) — NOT the near-empty `AI Configs`
+#     tag, which holds 2 stray analytics ops. Agent graphs/optimizations,
+#     prompt snippets, restricted models, targeting are triage_operations there.
+#   - Release Management: Release pipelines/policies/releases, Workflows,
+#     Workflow templates, Layers — ALL currently `triage`; highest-value
+#     cluster to promote next (named GA pillar, not experimental).
+# ─────────────────────────────────────────────────────────────────────────────
 version: 1
 families:
   - tag: AI Configs

--- a/scripts/driftreport/report.go
+++ b/scripts/driftreport/report.go
@@ -27,7 +27,7 @@ import (
 const providerTypeName = "launchdarkly"
 
 // untaggedFamily is the synthetic family name for operations the spec leaves
-// untagged. specFamilies and familySlice must agree on this sentinel so that
+// untagged. specOperations and familySlice must agree on this sentinel so that
 // `driftreport -family "<untagged>"` returns the same paths the report lists.
 const untaggedFamily = "<untagged>"
 
@@ -53,11 +53,47 @@ type Mapping struct {
 }
 
 type MappingFamily struct {
-	Tag       string   `yaml:"tag"`
-	Status    string   `yaml:"status"`
-	Resources []string `yaml:"resources,omitempty"`
-	Reason    string   `yaml:"reason,omitempty"`
-	Notes     string   `yaml:"notes,omitempty"`
+	Tag               string             `yaml:"tag"`
+	Status            string             `yaml:"status"`
+	Resources         []ResourceEntry    `yaml:"resources,omitempty"`
+	IgnoredOperations []IgnoredOperation `yaml:"ignored_operations,omitempty"`
+	TriageOperations  []string           `yaml:"triage_operations,omitempty"`
+	Reason            string             `yaml:"reason,omitempty"`
+	Notes             string             `yaml:"notes,omitempty"`
+}
+
+// ResourceEntry is one resource claim under a family. A bare YAML string is a
+// tag-level claim; the object shape additionally claims the specific
+// operationIds the resource implements (required for partial families).
+type ResourceEntry struct {
+	Name       string   `yaml:"name"`
+	Operations []string `yaml:"operations,omitempty"`
+}
+
+func (r *ResourceEntry) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		return value.Decode(&r.Name)
+	}
+	// Alias the type to avoid recursing into this method.
+	type plain ResourceEntry
+	var p plain
+	if err := value.Decode(&p); err != nil {
+		return err
+	}
+	*r = ResourceEntry(p)
+	return nil
+}
+
+// IgnoredOperation marks a spec operation in a partial family as deliberately
+// unmodeled (bulk/UI-only/runtime endpoints). Mirrors the family-level
+// ignored-needs-reason rule.
+//
+// triage_operations is the op-level analogue of a triage family: acknowledged,
+// coverage decision pending. Triage ops are listed in the report but don't
+// fail the run, and need no reason — the pending decision is the point.
+type IgnoredOperation struct {
+	ID     string `yaml:"id"`
+	Reason string `yaml:"reason"`
 }
 
 func (m *Mapping) validate() error {
@@ -79,6 +115,67 @@ func (m *Mapping) validate() error {
 		if (f.Status == statusCovered || f.Status == statusPartial) && len(f.Resources) == 0 {
 			return fmt.Errorf("tag %q: %s entries must list at least one resource", f.Tag, f.Status)
 		}
+		if err := f.validateOperations(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateOperations enforces the v2 operation-level rules: partial families
+// require operation lists (that is what distinguishes them from covered);
+// non-partial families must not carry them (op lists on a covered family
+// would silently never be checked).
+func (f *MappingFamily) validateOperations() error {
+	if f.Status != statusPartial {
+		for _, r := range f.Resources {
+			if len(r.Operations) > 0 {
+				return fmt.Errorf("tag %q: resource %q lists operations but family status is %q (only partial families carry operation lists)", f.Tag, r.Name, f.Status)
+			}
+		}
+		if len(f.IgnoredOperations) > 0 {
+			return fmt.Errorf("tag %q: ignored_operations set but family status is %q (only partial families carry operation lists)", f.Tag, f.Status)
+		}
+		if len(f.TriageOperations) > 0 {
+			return fmt.Errorf("tag %q: triage_operations set but family status is %q (only partial families carry operation lists)", f.Tag, f.Status)
+		}
+		return nil
+	}
+	claimed := map[string]bool{}
+	for _, r := range f.Resources {
+		if r.Name == "" {
+			return fmt.Errorf("tag %q: resource entry with empty name", f.Tag)
+		}
+		if len(r.Operations) == 0 {
+			return fmt.Errorf("tag %q: partial families require an operations list on every resource (resource %q has none)", f.Tag, r.Name)
+		}
+		for _, op := range r.Operations {
+			if op == "" {
+				return fmt.Errorf("tag %q: resource %q lists an empty operationId", f.Tag, r.Name)
+			}
+			if claimed[op] {
+				return fmt.Errorf("tag %q: operation %q claimed more than once", f.Tag, op)
+			}
+			claimed[op] = true
+		}
+	}
+	for _, ig := range f.IgnoredOperations {
+		if ig.ID == "" || ig.Reason == "" {
+			return fmt.Errorf("tag %q: ignored_operations entries require both id and reason", f.Tag)
+		}
+		if claimed[ig.ID] {
+			return fmt.Errorf("tag %q: operation %q claimed more than once", f.Tag, ig.ID)
+		}
+		claimed[ig.ID] = true
+	}
+	for _, op := range f.TriageOperations {
+		if op == "" {
+			return fmt.Errorf("tag %q: triage_operations lists an empty operationId", f.Tag)
+		}
+		if claimed[op] {
+			return fmt.Errorf("tag %q: operation %q claimed more than once", f.Tag, op)
+		}
+		claimed[op] = true
 	}
 	return nil
 }
@@ -98,8 +195,27 @@ func loadMapping(path string) (*Mapping, error) {
 	return &m, nil
 }
 
-// specFamilies extracts tag -> sorted unique paths from raw OpenAPI JSON.
-func specFamilies(rawSpec []byte) (map[string][]string, error) {
+// SpecOperation is one operation (method + path) in the spec, keyed for
+// mapping claims by its operationId.
+type SpecOperation struct {
+	Path        string
+	Method      string
+	OperationID string
+}
+
+// key identifies the operation for mapping claims. The LD spec assigns an
+// operationId to every operation; "METHOD path" is a defensive fallback so a
+// spec hygiene slip surfaces as an unclaimed op instead of a silent skip.
+func (o SpecOperation) key() string {
+	if o.OperationID != "" {
+		return o.OperationID
+	}
+	return o.Method + " " + o.Path
+}
+
+// specOperations extracts tag -> operations from raw OpenAPI JSON, sorted by
+// path then method.
+func specOperations(rawSpec []byte) (map[string][]SpecOperation, error) {
 	// Path items mix operation objects with non-operation keys of other JSON
 	// types (e.g. "parameters" is an array), so decode in two stages.
 	var spec struct {
@@ -111,14 +227,15 @@ func specFamilies(rawSpec []byte) (map[string][]string, error) {
 	if len(spec.Paths) == 0 {
 		return nil, fmt.Errorf("OpenAPI spec contains no paths")
 	}
-	families := map[string]map[string]bool{}
+	families := map[string][]SpecOperation{}
 	for path, ops := range spec.Paths {
 		for method, rawOp := range ops {
 			if !specMethods[strings.ToLower(method)] {
 				continue
 			}
 			var op struct {
-				Tags []string `json:"tags"`
+				Tags        []string `json:"tags"`
+				OperationID string   `json:"operationId"`
 			}
 			if err := json.Unmarshal(rawOp, &op); err != nil {
 				return nil, fmt.Errorf("parsing operation %s %s: %w", method, path, err)
@@ -128,23 +245,37 @@ func specFamilies(rawSpec []byte) (map[string][]string, error) {
 				tags = []string{untaggedFamily}
 			}
 			for _, tag := range tags {
-				if families[tag] == nil {
-					families[tag] = map[string]bool{}
-				}
-				families[tag][path] = true
+				families[tag] = append(families[tag], SpecOperation{
+					Path:        path,
+					Method:      strings.ToUpper(method),
+					OperationID: op.OperationID,
+				})
 			}
 		}
 	}
-	out := make(map[string][]string, len(families))
-	for tag, paths := range families {
-		sorted := make([]string, 0, len(paths))
-		for p := range paths {
-			sorted = append(sorted, p)
-		}
-		sort.Strings(sorted)
-		out[tag] = sorted
+	for _, ops := range families {
+		sort.Slice(ops, func(i, j int) bool {
+			if ops[i].Path != ops[j].Path {
+				return ops[i].Path < ops[j].Path
+			}
+			return ops[i].Method < ops[j].Method
+		})
 	}
-	return out, nil
+	return families, nil
+}
+
+// uniquePaths flattens a family's operations to its sorted unique paths.
+func uniquePaths(ops []SpecOperation) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, op := range ops {
+		if !seen[op.Path] {
+			seen[op.Path] = true
+			out = append(out, op.Path)
+		}
+	}
+	sort.Strings(out)
+	return out
 }
 
 // familySlice extracts a compact JSON description of one endpoint family —
@@ -247,14 +378,17 @@ type Report struct {
 	SpecSource  string    `json:"spec_source"`
 
 	// Drift signals (any non-empty => exit code 2).
-	NewFamilies       []FamilyDetail `json:"new_families"`
-	StaleFamilies     []string       `json:"stale_families"`
-	UnmappedResources []string       `json:"unmapped_resources"`
+	NewFamilies         []FamilyDetail    `json:"new_families"`
+	StaleFamilies       []string          `json:"stale_families"`
+	UnmappedResources   []string          `json:"unmapped_resources"`
+	UnclaimedOperations []OperationDetail `json:"unclaimed_operations"`
+	StaleOperations     []OperationDetail `json:"stale_operations"`
 
 	// Informational.
-	TriageFamilies []string       `json:"triage_families"`
-	StatusCounts   map[string]int `json:"status_counts"`
-	TotalFamilies  int            `json:"total_families"`
+	TriageFamilies   []string          `json:"triage_families"`
+	TriageOperations []OperationDetail `json:"triage_operations"`
+	StatusCounts     map[string]int    `json:"status_counts"`
+	TotalFamilies    int               `json:"total_families"`
 }
 
 type FamilyDetail struct {
@@ -262,21 +396,35 @@ type FamilyDetail struct {
 	Paths []string `json:"paths"`
 }
 
-func (r *Report) HasDrift() bool {
-	return len(r.NewFamilies) > 0 || len(r.StaleFamilies) > 0 || len(r.UnmappedResources) > 0
+// OperationDetail is one operation-level drift item in a partial family.
+// Stale entries (operationId in the mapping but gone from the spec) carry
+// only Tag and OperationID.
+type OperationDetail struct {
+	Tag         string `json:"tag"`
+	OperationID string `json:"operation_id"`
+	Method      string `json:"method,omitempty"`
+	Path        string `json:"path,omitempty"`
 }
 
-func buildReport(families map[string][]string, mapping *Mapping, resources, dataSources []string, specSource string) *Report {
+func (r *Report) HasDrift() bool {
+	return len(r.NewFamilies) > 0 || len(r.StaleFamilies) > 0 || len(r.UnmappedResources) > 0 ||
+		len(r.UnclaimedOperations) > 0 || len(r.StaleOperations) > 0
+}
+
+func buildReport(families map[string][]SpecOperation, mapping *Mapping, resources, dataSources []string, specSource string) *Report {
 	report := &Report{
 		GeneratedAt:   time.Now().UTC(),
 		SpecSource:    specSource,
 		StatusCounts:  map[string]int{},
 		TotalFamilies: len(families),
 		// Initialized so empty lists serialize as [] rather than null in JSON.
-		NewFamilies:       []FamilyDetail{},
-		StaleFamilies:     []string{},
-		UnmappedResources: []string{},
-		TriageFamilies:    []string{},
+		NewFamilies:         []FamilyDetail{},
+		StaleFamilies:       []string{},
+		UnmappedResources:   []string{},
+		UnclaimedOperations: []OperationDetail{},
+		StaleOperations:     []OperationDetail{},
+		TriageFamilies:      []string{},
+		TriageOperations:    []OperationDetail{},
 	}
 
 	mapped := map[string]MappingFamily{}
@@ -285,9 +433,9 @@ func buildReport(families map[string][]string, mapping *Mapping, resources, data
 	}
 
 	// Spec tags absent from the mapping => new families.
-	for tag, paths := range families {
+	for tag, ops := range families {
 		if _, ok := mapped[tag]; !ok {
-			report.NewFamilies = append(report.NewFamilies, FamilyDetail{Tag: tag, Paths: paths})
+			report.NewFamilies = append(report.NewFamilies, FamilyDetail{Tag: tag, Paths: uniquePaths(ops)})
 		}
 	}
 	sort.Slice(report.NewFamilies, func(i, j int) bool {
@@ -307,11 +455,69 @@ func buildReport(families map[string][]string, mapping *Mapping, resources, data
 	sort.Strings(report.StaleFamilies)
 	sort.Strings(report.TriageFamilies)
 
+	// Operation-level diff for partial families: every spec operation must be
+	// claimed by a resource or deliberately ignored, and every claim must
+	// still exist in the spec. Skipped when the family tag itself is stale —
+	// the stale-family signal already covers it.
+	for _, f := range mapping.Families {
+		if f.Status != statusPartial {
+			continue
+		}
+		specOps, tagInSpec := families[f.Tag]
+		if !tagInSpec {
+			continue
+		}
+		claimed := map[string]bool{}
+		for _, r := range f.Resources {
+			for _, op := range r.Operations {
+				claimed[op] = true
+			}
+		}
+		for _, ig := range f.IgnoredOperations {
+			claimed[ig.ID] = true
+		}
+		triage := map[string]bool{}
+		for _, op := range f.TriageOperations {
+			claimed[op] = true
+			triage[op] = true
+		}
+		inSpec := map[string]bool{}
+		for _, op := range specOps {
+			inSpec[op.key()] = true
+			detail := OperationDetail{
+				Tag:         f.Tag,
+				OperationID: op.key(),
+				Method:      op.Method,
+				Path:        op.Path,
+			}
+			switch {
+			case triage[op.key()]:
+				report.TriageOperations = append(report.TriageOperations, detail)
+			case !claimed[op.key()]:
+				report.UnclaimedOperations = append(report.UnclaimedOperations, detail)
+			}
+		}
+		for op := range claimed {
+			if !inSpec[op] {
+				report.StaleOperations = append(report.StaleOperations, OperationDetail{Tag: f.Tag, OperationID: op})
+			}
+		}
+	}
+	sortOperationDetails(report.UnclaimedOperations)
+	sortOperationDetails(report.TriageOperations)
+	sort.Slice(report.StaleOperations, func(i, j int) bool {
+		a, b := report.StaleOperations[i], report.StaleOperations[j]
+		if a.Tag != b.Tag {
+			return a.Tag < b.Tag
+		}
+		return a.OperationID < b.OperationID
+	})
+
 	// Registered types never referenced by any family => mapping is incomplete.
 	referenced := map[string]bool{}
 	for _, f := range mapping.Families {
 		for _, r := range f.Resources {
-			referenced[r] = true
+			referenced[r.Name] = true
 		}
 	}
 	seen := map[string]bool{}
@@ -324,6 +530,19 @@ func buildReport(families map[string][]string, mapping *Mapping, resources, data
 	sort.Strings(report.UnmappedResources)
 
 	return report
+}
+
+func sortOperationDetails(ops []OperationDetail) {
+	sort.Slice(ops, func(i, j int) bool {
+		a, b := ops[i], ops[j]
+		if a.Tag != b.Tag {
+			return a.Tag < b.Tag
+		}
+		if a.Path != b.Path {
+			return a.Path < b.Path
+		}
+		return a.Method < b.Method
+	})
 }
 
 // errWriter captures the first write error so renderMarkdown can stay
@@ -383,10 +602,45 @@ func renderMarkdown(out io.Writer, r *Report) error {
 		fmt.Fprintf(w, "\n")
 	}
 
+	if len(r.UnclaimedOperations) > 0 {
+		fmt.Fprintf(w, "## Unclaimed operations in partial families\n\n")
+		fmt.Fprintf(w, "Claim each operation on a resource entry or add it to the family's `ignored_operations`.\n\n")
+		lastTag := ""
+		for _, op := range r.UnclaimedOperations {
+			if op.Tag != lastTag {
+				fmt.Fprintf(w, "### %s\n\n", op.Tag)
+				lastTag = op.Tag
+			}
+			fmt.Fprintf(w, "- `%s %s` (`%s`)\n", op.Method, op.Path, op.OperationID)
+		}
+		fmt.Fprintf(w, "\n")
+	}
+
+	if len(r.StaleOperations) > 0 {
+		fmt.Fprintf(w, "## Stale operation claims (operationId no longer in spec — renamed or removed)\n\n")
+		for _, op := range r.StaleOperations {
+			fmt.Fprintf(w, "- %s: `%s`\n", op.Tag, op.OperationID)
+		}
+		fmt.Fprintf(w, "\n")
+	}
+
 	if len(r.TriageFamilies) > 0 {
 		fmt.Fprintf(w, "## Families pending triage (acknowledged, decision pending)\n\n")
 		for _, t := range r.TriageFamilies {
 			fmt.Fprintf(w, "- %s\n", t)
+		}
+		fmt.Fprintf(w, "\n")
+	}
+
+	if len(r.TriageOperations) > 0 {
+		fmt.Fprintf(w, "## Operations pending triage in partial families (acknowledged, decision pending)\n\n")
+		lastTag := ""
+		for _, op := range r.TriageOperations {
+			if op.Tag != lastTag {
+				fmt.Fprintf(w, "### %s\n\n", op.Tag)
+				lastTag = op.Tag
+			}
+			fmt.Fprintf(w, "- `%s %s` (`%s`)\n", op.Method, op.Path, op.OperationID)
 		}
 		fmt.Fprintf(w, "\n")
 	}

--- a/scripts/driftreport/report_test.go
+++ b/scripts/driftreport/report_test.go
@@ -6,22 +6,31 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 const fixtureSpec = `{
   "paths": {
     "/api/v2/projects": {
-      "get": {"tags": ["Projects"]},
-      "post": {"tags": ["Projects"]},
+      "get": {"tags": ["Projects"], "operationId": "getProjects"},
+      "post": {"tags": ["Projects"], "operationId": "postProject"},
       "parameters": [{"name": "ignored"}]
     },
     "/api/v2/projects/{projectKey}": {
-      "get": {"tags": ["Projects"]},
-      "delete": {"tags": ["Projects"]}
+      "get": {"tags": ["Projects"], "operationId": "getProject"},
+      "delete": {"tags": ["Projects"], "operationId": "deleteProject"}
     },
     "/api/v2/shiny/{key}": {
-      "get": {"tags": ["Shiny new feature"]},
-      "post": {"tags": ["Shiny new feature"]}
+      "get": {"tags": ["Shiny new feature"], "operationId": "getShiny"},
+      "post": {"tags": ["Shiny new feature"], "operationId": "postShiny"}
+    },
+    "/api/v2/widgets": {
+      "get": {"tags": ["Widgets"], "operationId": "getWidgets"},
+      "post": {"tags": ["Widgets"], "operationId": "postWidget"}
+    },
+    "/api/v2/widgets/{key}": {
+      "delete": {"tags": ["Widgets"], "operationId": "deleteWidget"}
     },
     "/api/v2/untagged-thing": {
       "get": {}
@@ -38,35 +47,50 @@ func fixtureMapping(t *testing.T, families ...MappingFamily) *Mapping {
 	return m
 }
 
-func TestSpecFamilies(t *testing.T) {
-	families, err := specFamilies([]byte(fixtureSpec))
+func fixtureOperations(t *testing.T) map[string][]SpecOperation {
+	t.Helper()
+	families, err := specOperations([]byte(fixtureSpec))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := len(families["Projects"]); got != 2 {
+	return families
+}
+
+func TestSpecOperations(t *testing.T) {
+	families := fixtureOperations(t)
+	if got := len(families["Projects"]); got != 4 {
+		t.Errorf("Projects operations = %d, want 4", got)
+	}
+	if got := len(uniquePaths(families["Projects"])); got != 2 {
 		t.Errorf("Projects paths = %d, want 2", got)
 	}
 	if got := len(families["<untagged>"]); got != 1 {
-		t.Errorf("<untagged> paths = %d, want 1", got)
+		t.Errorf("<untagged> operations = %d, want 1", got)
 	}
 	if _, ok := families["parameters"]; ok {
 		t.Error("non-method path-item keys must not become families")
 	}
+	first := families["Projects"][0]
+	if first.Method != "GET" || first.Path != "/api/v2/projects" || first.OperationID != "getProjects" {
+		t.Errorf("first Projects op = %+v, want GET /api/v2/projects getProjects", first)
+	}
+	// Untagged fixture op has no operationId; the claim key falls back to method+path.
+	if got := families["<untagged>"][0].key(); got != "GET /api/v2/untagged-thing" {
+		t.Errorf("untagged op key = %q, want method+path fallback", got)
+	}
 }
 
-func TestSpecFamiliesEmptySpec(t *testing.T) {
-	if _, err := specFamilies([]byte(`{"paths": {}}`)); err == nil {
+func TestSpecOperationsEmptySpec(t *testing.T) {
+	if _, err := specOperations([]byte(`{"paths": {}}`)); err == nil {
 		t.Error("empty spec should error, not report full coverage")
 	}
 }
 
 func TestBuildReportDetectsDrift(t *testing.T) {
-	families, err := specFamilies([]byte(fixtureSpec))
-	if err != nil {
-		t.Fatal(err)
-	}
+	families := fixtureOperations(t)
 	mapping := fixtureMapping(t,
-		MappingFamily{Tag: "Projects", Status: statusCovered, Resources: []string{"launchdarkly_project"}},
+		MappingFamily{Tag: "Projects", Status: statusCovered, Resources: []ResourceEntry{{Name: "launchdarkly_project"}}},
+		MappingFamily{Tag: "Widgets", Status: statusIgnored, Reason: "fixture filler"},
 		MappingFamily{Tag: "<untagged>", Status: statusIgnored, Reason: "spec hygiene bucket"},
 		MappingFamily{Tag: "Renamed family", Status: statusIgnored, Reason: "was removed from spec"},
 	)
@@ -90,13 +114,11 @@ func TestBuildReportDetectsDrift(t *testing.T) {
 }
 
 func TestBuildReportClean(t *testing.T) {
-	families, err := specFamilies([]byte(fixtureSpec))
-	if err != nil {
-		t.Fatal(err)
-	}
+	families := fixtureOperations(t)
 	mapping := fixtureMapping(t,
-		MappingFamily{Tag: "Projects", Status: statusCovered, Resources: []string{"launchdarkly_project"}},
+		MappingFamily{Tag: "Projects", Status: statusCovered, Resources: []ResourceEntry{{Name: "launchdarkly_project"}}},
 		MappingFamily{Tag: "Shiny new feature", Status: statusTriage},
+		MappingFamily{Tag: "Widgets", Status: statusIgnored, Reason: "fixture filler"},
 		MappingFamily{Tag: "<untagged>", Status: statusIgnored, Reason: "spec hygiene bucket"},
 	)
 	report := buildReport(families, mapping, []string{"launchdarkly_project"}, nil, "fixture")
@@ -120,10 +142,154 @@ func TestBuildReportClean(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, key := range []string{"new_families", "stale_families", "unmapped_resources"} {
+	for _, key := range []string{"new_families", "stale_families", "unmapped_resources", "unclaimed_operations", "stale_operations", "triage_operations"} {
 		if strings.Contains(string(raw), fmt.Sprintf("%q:null", key)) {
 			t.Errorf("%s serializes as null, want []", key)
 		}
+	}
+}
+
+// partialWidgets returns a partial-family entry claiming the given operations
+// on a fixture resource, with optional ignored ops.
+func partialWidgets(claims []string, ignored ...IgnoredOperation) MappingFamily {
+	return MappingFamily{
+		Tag:               "Widgets",
+		Status:            statusPartial,
+		Resources:         []ResourceEntry{{Name: "launchdarkly_widget", Operations: claims}},
+		IgnoredOperations: ignored,
+	}
+}
+
+func TestBuildReportUnclaimedOperations(t *testing.T) {
+	families := fixtureOperations(t)
+	mapping := fixtureMapping(t,
+		MappingFamily{Tag: "Projects", Status: statusCovered, Resources: []ResourceEntry{{Name: "launchdarkly_project"}}},
+		MappingFamily{Tag: "Shiny new feature", Status: statusTriage},
+		MappingFamily{Tag: "<untagged>", Status: statusIgnored, Reason: "spec hygiene bucket"},
+		partialWidgets([]string{"getWidgets", "postWidget"}),
+	)
+	report := buildReport(families, mapping, []string{"launchdarkly_project", "launchdarkly_widget"}, nil, "fixture")
+
+	if !report.HasDrift() {
+		t.Fatal("expected drift from unclaimed deleteWidget")
+	}
+	if len(report.UnclaimedOperations) != 1 {
+		t.Fatalf("UnclaimedOperations = %+v, want exactly 1", report.UnclaimedOperations)
+	}
+	got := report.UnclaimedOperations[0]
+	want := OperationDetail{Tag: "Widgets", OperationID: "deleteWidget", Method: "DELETE", Path: "/api/v2/widgets/{key}"}
+	if got != want {
+		t.Errorf("UnclaimedOperations[0] = %+v, want %+v", got, want)
+	}
+
+	var buf bytes.Buffer
+	if err := renderMarkdown(&buf, report); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "Unclaimed operations in partial families") {
+		t.Error("markdown should include the unclaimed-operations section")
+	}
+}
+
+func TestBuildReportTriageOperations(t *testing.T) {
+	families := fixtureOperations(t)
+	widgets := partialWidgets([]string{"getWidgets", "postWidget"})
+	widgets.TriageOperations = []string{"deleteWidget"}
+	mapping := fixtureMapping(t,
+		MappingFamily{Tag: "Projects", Status: statusCovered, Resources: []ResourceEntry{{Name: "launchdarkly_project"}}},
+		MappingFamily{Tag: "Shiny new feature", Status: statusTriage},
+		MappingFamily{Tag: "<untagged>", Status: statusIgnored, Reason: "spec hygiene bucket"},
+		widgets,
+	)
+	report := buildReport(families, mapping, []string{"launchdarkly_project", "launchdarkly_widget"}, nil, "fixture")
+
+	// Triage ops are informational: listed, but never drift.
+	if report.HasDrift() {
+		t.Fatalf("triage operation must not drift, got %+v", report)
+	}
+	if len(report.TriageOperations) != 1 || report.TriageOperations[0].OperationID != "deleteWidget" {
+		t.Errorf("TriageOperations = %+v, want exactly [deleteWidget]", report.TriageOperations)
+	}
+	if report.TriageOperations[0].Method != "DELETE" || report.TriageOperations[0].Path != "/api/v2/widgets/{key}" {
+		t.Errorf("TriageOperations[0] = %+v, want method+path resolved from spec", report.TriageOperations[0])
+	}
+
+	var buf bytes.Buffer
+	if err := renderMarkdown(&buf, report); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "Operations pending triage in partial families") {
+		t.Error("markdown should include the triage-operations section")
+	}
+
+	// A triage opId that vanishes from the spec is stale, same as a claim.
+	widgets.TriageOperations = []string{"deleteWidget", "ghostTriageOp"}
+	report = buildReport(families, fixtureMapping(t,
+		MappingFamily{Tag: "Projects", Status: statusCovered, Resources: []ResourceEntry{{Name: "launchdarkly_project"}}},
+		MappingFamily{Tag: "Shiny new feature", Status: statusTriage},
+		MappingFamily{Tag: "<untagged>", Status: statusIgnored, Reason: "spec hygiene bucket"},
+		widgets,
+	), []string{"launchdarkly_project", "launchdarkly_widget"}, nil, "fixture")
+	if len(report.StaleOperations) != 1 || report.StaleOperations[0].OperationID != "ghostTriageOp" {
+		t.Errorf("StaleOperations = %+v, want [ghostTriageOp]", report.StaleOperations)
+	}
+}
+
+func TestBuildReportIgnoredOperationSuppression(t *testing.T) {
+	families := fixtureOperations(t)
+	mapping := fixtureMapping(t,
+		MappingFamily{Tag: "Projects", Status: statusCovered, Resources: []ResourceEntry{{Name: "launchdarkly_project"}}},
+		MappingFamily{Tag: "Shiny new feature", Status: statusTriage},
+		MappingFamily{Tag: "<untagged>", Status: statusIgnored, Reason: "spec hygiene bucket"},
+		partialWidgets([]string{"getWidgets", "postWidget"},
+			IgnoredOperation{ID: "deleteWidget", Reason: "bulk delete is UI-only"}),
+	)
+	report := buildReport(families, mapping, []string{"launchdarkly_project", "launchdarkly_widget"}, nil, "fixture")
+	if report.HasDrift() {
+		t.Fatalf("ignored operation must suppress drift, got %+v", report)
+	}
+}
+
+func TestBuildReportStaleOperations(t *testing.T) {
+	families := fixtureOperations(t)
+	mapping := fixtureMapping(t,
+		MappingFamily{Tag: "Projects", Status: statusCovered, Resources: []ResourceEntry{{Name: "launchdarkly_project"}}},
+		MappingFamily{Tag: "Shiny new feature", Status: statusTriage},
+		MappingFamily{Tag: "<untagged>", Status: statusIgnored, Reason: "spec hygiene bucket"},
+		partialWidgets([]string{"getWidgets", "postWidget", "ghostOperation"},
+			IgnoredOperation{ID: "deleteWidget", Reason: "bulk delete is UI-only"}),
+	)
+	report := buildReport(families, mapping, []string{"launchdarkly_project", "launchdarkly_widget"}, nil, "fixture")
+
+	if !report.HasDrift() {
+		t.Fatal("expected drift from stale ghostOperation claim")
+	}
+	if len(report.StaleOperations) != 1 || report.StaleOperations[0].OperationID != "ghostOperation" {
+		t.Errorf("StaleOperations = %+v, want exactly [ghostOperation]", report.StaleOperations)
+	}
+	if len(report.UnclaimedOperations) != 0 {
+		t.Errorf("UnclaimedOperations = %+v, want none", report.UnclaimedOperations)
+	}
+}
+
+func TestBuildReportSkipsOperationChecksForStaleFamily(t *testing.T) {
+	families := fixtureOperations(t)
+	mapping := fixtureMapping(t,
+		MappingFamily{Tag: "Projects", Status: statusCovered, Resources: []ResourceEntry{{Name: "launchdarkly_project"}}},
+		MappingFamily{Tag: "Shiny new feature", Status: statusTriage},
+		MappingFamily{Tag: "Widgets", Status: statusIgnored, Reason: "fixture filler"},
+		MappingFamily{Tag: "<untagged>", Status: statusIgnored, Reason: "spec hygiene bucket"},
+		MappingFamily{Tag: "Vanished", Status: statusPartial,
+			Resources: []ResourceEntry{{Name: "launchdarkly_project", Operations: []string{"goneOp"}}}},
+	)
+	report := buildReport(families, mapping, []string{"launchdarkly_project"}, nil, "fixture")
+	if len(report.StaleFamilies) != 1 || report.StaleFamilies[0] != "Vanished" {
+		t.Fatalf("StaleFamilies = %v, want [Vanished]", report.StaleFamilies)
+	}
+	// The stale-family signal covers the whole entry; its ops must not be
+	// double-reported as stale operations.
+	if len(report.StaleOperations) != 0 {
+		t.Errorf("StaleOperations = %+v, want none for a stale family", report.StaleOperations)
 	}
 }
 
@@ -149,6 +315,32 @@ func TestMappingValidation(t *testing.T) {
 		{"ignored without reason", MappingFamily{Tag: "X", Status: statusIgnored}},
 		{"covered without resources", MappingFamily{Tag: "X", Status: statusCovered}},
 		{"empty tag", MappingFamily{Status: statusTriage}},
+		{"partial resource without operations", MappingFamily{Tag: "X", Status: statusPartial,
+			Resources: []ResourceEntry{{Name: "launchdarkly_x"}}}},
+		{"operations on covered family", MappingFamily{Tag: "X", Status: statusCovered,
+			Resources: []ResourceEntry{{Name: "launchdarkly_x", Operations: []string{"getX"}}}}},
+		{"ignored_operations on covered family", MappingFamily{Tag: "X", Status: statusCovered,
+			Resources:         []ResourceEntry{{Name: "launchdarkly_x"}},
+			IgnoredOperations: []IgnoredOperation{{ID: "getX", Reason: "r"}}}},
+		{"ignored operation without reason", MappingFamily{Tag: "X", Status: statusPartial,
+			Resources:         []ResourceEntry{{Name: "launchdarkly_x", Operations: []string{"getX"}}},
+			IgnoredOperations: []IgnoredOperation{{ID: "putX"}}}},
+		{"operation claimed twice across resources", MappingFamily{Tag: "X", Status: statusPartial,
+			Resources: []ResourceEntry{
+				{Name: "launchdarkly_x", Operations: []string{"getX"}},
+				{Name: "launchdarkly_y", Operations: []string{"getX"}}}}},
+		{"operation both claimed and ignored", MappingFamily{Tag: "X", Status: statusPartial,
+			Resources:         []ResourceEntry{{Name: "launchdarkly_x", Operations: []string{"getX"}}},
+			IgnoredOperations: []IgnoredOperation{{ID: "getX", Reason: "r"}}}},
+		{"triage_operations on covered family", MappingFamily{Tag: "X", Status: statusCovered,
+			Resources:        []ResourceEntry{{Name: "launchdarkly_x"}},
+			TriageOperations: []string{"getX"}}},
+		{"operation both claimed and triaged", MappingFamily{Tag: "X", Status: statusPartial,
+			Resources:        []ResourceEntry{{Name: "launchdarkly_x", Operations: []string{"getX"}}},
+			TriageOperations: []string{"getX"}}},
+		{"empty triage operationId", MappingFamily{Tag: "X", Status: statusPartial,
+			Resources:        []ResourceEntry{{Name: "launchdarkly_x", Operations: []string{"getX"}}},
+			TriageOperations: []string{""}}},
 	}
 	for _, tc := range cases {
 		m := &Mapping{Version: 1, Families: []MappingFamily{tc.fam}}
@@ -161,6 +353,51 @@ func TestMappingValidation(t *testing.T) {
 	}}
 	if err := dup.validate(); err == nil {
 		t.Error("duplicate tags: expected validation error")
+	}
+}
+
+func TestResourceEntryYAMLParsing(t *testing.T) {
+	doc := `
+version: 1
+families:
+  - tag: Tag-level
+    status: covered
+    resources:
+      - launchdarkly_plain
+  - tag: Op-level
+    status: partial
+    resources:
+      - name: launchdarkly_rich
+        operations:
+          - getThing
+          - putThing
+    ignored_operations:
+      - id: searchThings
+        reason: runtime search, not declarative
+    triage_operations:
+      - postThingBulk
+`
+	var m Mapping
+	if err := yaml.Unmarshal([]byte(doc), &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := m.validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	plain := m.Families[0].Resources[0]
+	if plain.Name != "launchdarkly_plain" || len(plain.Operations) != 0 {
+		t.Errorf("bare-string entry = %+v, want name-only", plain)
+	}
+	rich := m.Families[1].Resources[0]
+	if rich.Name != "launchdarkly_rich" || len(rich.Operations) != 2 {
+		t.Errorf("object entry = %+v, want name + 2 operations", rich)
+	}
+	ig := m.Families[1].IgnoredOperations[0]
+	if ig.ID != "searchThings" || ig.Reason == "" {
+		t.Errorf("ignored_operations entry = %+v, want id + reason", ig)
+	}
+	if tr := m.Families[1].TriageOperations; len(tr) != 1 || tr[0] != "postThingBulk" {
+		t.Errorf("triage_operations = %v, want [postThingBulk]", tr)
 	}
 }
 
@@ -190,7 +427,7 @@ func TestFamilySlice(t *testing.T) {
 	}
 
 	// The synthetic <untagged> family must resolve the same untagged paths
-	// specFamilies reports, not look for a literal tag named "<untagged>".
+	// specOperations reports, not look for a literal tag named "<untagged>".
 	untagged, err := familySlice([]byte(fixtureSpec), untaggedFamily)
 	if err != nil {
 		t.Fatalf("familySlice(%q) = %v, want untagged paths", untaggedFamily, err)


### PR DESCRIPTION
## Summary

Stage 1b of the autogen pipeline (see `.claude/plans/AUTOGEN_PIPELINE.md`). Extends `scripts/driftreport/` from **family-level** to **operation-level** coverage for `partial` families.

v1 (#445) classified every spec *tag* as covered/triage/ignored. `partial` was a placeholder. v2 makes it real: a partial family must enumerate which `operationId`s each resource implements, and **every** spec op in that family must be claimed, ignored, or triaged — otherwise it's drift.

## What changed

- **Schema** (`mapping.yaml` + `report.go`): `resources` entries gain an optional `{name, operations: [opId, ...]}` object shape (bare string still valid = tag-level claim). New per-family `ignored_operations: [{id, reason}]` and `triage_operations: [opId, ...]`.
- **Parser**: `specFamilies` → `specOperations` — tag → `[]SpecOperation{method, path, operationId}`; key is `operationId` with a `"METHOD path"` fallback so a spec-hygiene slip surfaces as unclaimed rather than a silent skip.
- **Drift logic** (new exit-2 conditions): (a) a spec op in a partial family claimed by no resource and not ignored → **unclaimed**; (b) a mapping `operationId` no longer in the spec → **stale**. Op-level checks are skipped when the family tag itself is stale (no double-report). New markdown sections + JSON fields for unclaimed / stale / triage ops.
- **Validation**: partial families require op lists; op lists rejected on non-partial families; `ignored_operations` require id+reason; duplicate claims rejected.
- **Mapping re-curation**:
  - `AgentControl` triage → **partial** (15 ops claimed by the 4 AI resources / 7 ignored analytics+list / 27 triage: agent-graphs, agent-optimizations, prompt-snippets, restricted-models, targeting).
  - `AI Configs` covered → **ignored** — the spec's "AI Configs" tag holds only 2 stray analytics endpoints; the CRUD surface lives under `AgentControl`.
  - `Contexts` and `Metrics (beta)` → **partial** (Metrics dogfoods the post-#453 metric-group resource).
  - Removed stale `Users (beta)` tag (dropped from the spec upstream — genuine drift caught during curation).
- **Tests**: 8 → 14 (unclaimed / triage / stale / ignored-suppression / stale-family-skip / `ResourceEntry` string|object YAML parsing).

## Validation

- `go build`, `go vet`, `go test ./scripts/driftreport/...` → **14 pass**, vet clean, `gofmt` clean.
- Live run against `https://app.launchdarkly.com/api/v2/openapi.json` → **exit 0 (no drift)**. 57 families; summary `covered:16, ignored:19, partial:3, triage:19`.

## Scope / safety

- Internal tooling only — **v3 line, not customer-facing**; no provider resource/schema changes.
- Exit-code contract (0/1/2) and Slack-only output discipline **unchanged**.
- **No workflow changes.** The `drift-report.yml` on `main` already checks out the v3 line (`ref: preview-v3`), so once this merges it picks up the v2 tool on the next `workflow_dispatch` — no PR to `main` needed.

> Note: the repo PR template targets resource/data-source changes (acceptance tests, docs). N/A here — this is a standalone Go tool under `scripts/`, covered by its own unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal `scripts/driftreport` tooling only; no provider resources or customer-facing behavior. CI exit-code contract is preserved with additional drift signals.
> 
> **Overview**
> Extends **`scripts/driftreport`** (autogen pipeline stage 1b) from tag-level families to **per-`operationId` accounting** for `partial` families. OpenAPI parsing now builds tag → operations (`method`, `path`, `operationId`) via `specOperations` instead of path-only `specFamilies`.
> 
> **`mapping.yaml`** gains resource entries as bare names (covered) or `{name, operations: [...]}`, plus `ignored_operations` (id + reason) and `triage_operations` (informational, not drift). Validation enforces op lists only on `partial` families and rejects duplicate claims. **`buildReport`** adds drift for **unclaimed** spec ops and **stale** mapping opIds (skipped when the family tag itself is stale); markdown/JSON report new sections and fields. Exit code 2 still means drift; triage ops never fail the run.
> 
> **Mapping re-curation:** `AgentControl` → partial with AI resources + ignored analytics/lists + triage for agent graphs/optimizations/snippets; `AI Configs` → ignored (CRUD lives under `AgentControl`); `Contexts` and `Metrics (beta)` → partial; removed stale `Users (beta)`. Tests grow from 8 to 14 covering op-level drift, YAML shapes, and validation edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e96230297fba9be3498f39d352fa0fb5217cd77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->