### PR TITLE
feat: net-new resource candidates in partial families (drift report)

### DIFF
--- a/launchdarkly/integration_configs_generated.go
+++ b/launchdarkly/integration_configs_generated.go
@@ -395,6 +395,14 @@ var SUBSCRIPTION_CONFIGURATION_FIELDS = map[string]IntegrationConfig{
 			IsSecret:      false,
 			Type:          "string",
 		},
+		"url": {
+			AllowedValues: []string{},
+			DefaultValue:  "",
+			Description:   "A link to the user's installation page on vercel.com",
+			IsOptional:    true,
+			IsSecret:      false,
+			Type:          "string",
+		},
 	},
 }
 

--- a/scripts/driftreport/mapping.yaml
+++ b/scripts/driftreport/mapping.yaml
@@ -87,6 +87,25 @@ families:
           - postModelConfig
           - getModelConfig
           - deleteModelConfig
+    new_resource_candidates:
+      # Agent graphs — clean CRUD on their own path; a net-new resource the
+      # stage-2 scaffolder can add without touching the AI Config resources.
+      - name: launchdarkly_ai_agent_graph
+        operations:
+          - listAgentGraphs
+          - postAgentGraph
+          - getAgentGraph
+          - patchAgentGraph
+          - deleteAgentGraph
+      # Prompt snippets — clean CRUD; the references/versions read endpoints
+      # stay in triage pending a data-source decision.
+      - name: launchdarkly_prompt_snippet
+        operations:
+          - listPromptSnippets
+          - postPromptSnippet
+          - getPromptSnippet
+          - patchPromptSnippet
+          - deletePromptSnippet
     ignored_operations:
       - id: getAIConfigs
         reason: List/index endpoint; the singular get covers declarative reads.
@@ -103,17 +122,13 @@ families:
       - id: listAIToolVersions
         reason: Read-only version history, not declarative configuration.
     triage_operations:
-      # AI Config targeting — declarative-adjacent, pairs with a future
-      # ai_config_environment-style resource.
+      # AI Config targeting — EXTENDS the existing ai_config resource (a future
+      # ai_config_environment-style attribute), not a net-new resource, so it is
+      # not a scaffold candidate.
       - getAIConfigTargeting
       - patchAIConfigTargeting
-      # Agent graphs — new product surface, no resource yet.
-      - listAgentGraphs
-      - postAgentGraph
-      - getAgentGraph
-      - patchAgentGraph
-      - deleteAgentGraph
-      # Agent optimizations — new product surface, no resource yet.
+      # Agent optimizations — resource boundary still unclear (optimizations +
+      # results + runs); promote to a candidate once the shape settles.
       - listAgentOptimizations
       - postAgentOptimization
       - getAgentOptimization
@@ -125,18 +140,14 @@ families:
       - patchAgentOptimizationResult
       - deleteAgentOptimizationRun
       - listAgentOptimizationResultsByRunId
-      # Prompt snippets — plausible resource once the surface stabilizes.
-      - listPromptSnippets
-      - postPromptSnippet
-      - getPromptSnippet
-      - patchPromptSnippet
-      - deletePromptSnippet
+      # Prompt snippet auxiliary reads — the candidate models the CRUD; these
+      # stay pending a data-source decision.
       - listPromptSnippetReferences
       - listPromptSnippetVersions
       # Restricted models — account-level allow/deny, plausible resource.
       - postRestrictedModels
       - deleteRestrictedModels
-    notes: Despite the tag name, this family carries the AI Config CRUD surface — the spec's "AI Configs" tag holds only two stray analytics endpoints. The four AI resources cover 15 of 49 ops; agent graphs/optimizations, prompt snippets, targeting, and restricted models are pending triage.
+    notes: Despite the tag name, this family carries the AI Config CRUD surface — the spec's "AI Configs" tag holds only two stray analytics endpoints. The four AI resources cover 15 of 49 ops; agent graphs and prompt snippets are curated as scaffoldable net-new resources, while agent optimizations, AI config targeting, prompt-snippet aux reads, and restricted models remain in triage.
 
   - tag: Announcements
     status: triage

--- a/scripts/driftreport/report.go
+++ b/scripts/driftreport/report.go
@@ -421,11 +421,12 @@ type Report struct {
 	SpecSource  string    `json:"spec_source"`
 
 	// Drift signals (any non-empty => exit code 2).
-	NewFamilies         []FamilyDetail    `json:"new_families"`
-	StaleFamilies       []string          `json:"stale_families"`
-	UnmappedResources   []string          `json:"unmapped_resources"`
-	UnclaimedOperations []OperationDetail `json:"unclaimed_operations"`
-	StaleOperations     []OperationDetail `json:"stale_operations"`
+	NewFamilies          []FamilyDetail      `json:"new_families"`
+	StaleFamilies        []string            `json:"stale_families"`
+	UnmappedResources    []string            `json:"unmapped_resources"`
+	UnclaimedOperations  []OperationDetail   `json:"unclaimed_operations"`
+	StaleOperations      []OperationDetail   `json:"stale_operations"`
+	RegisteredCandidates []CandidateConflict `json:"registered_candidates"`
 
 	// Informational.
 	TriageFamilies        []string               `json:"triage_families"`
@@ -433,6 +434,16 @@ type Report struct {
 	ScaffoldableResources []ScaffoldableResource `json:"scaffoldable_resources"`
 	StatusCounts          map[string]int         `json:"status_counts"`
 	TotalFamilies         int                    `json:"total_families"`
+}
+
+// CandidateConflict is a new_resource_candidate whose name is ALREADY a
+// registered provider type — a curation mistake (a candidate must be net-new).
+// It is drift: the operations belong on a real resources entry, not a candidate,
+// and it must never be emitted as scaffoldable (that would re-scaffold an
+// existing resource).
+type CandidateConflict struct {
+	Tag  string `json:"tag"`
+	Name string `json:"name"`
 }
 
 // ScaffoldableResource is a curated net-new resource (from a partial family's
@@ -463,7 +474,7 @@ type OperationDetail struct {
 
 func (r *Report) HasDrift() bool {
 	return len(r.NewFamilies) > 0 || len(r.StaleFamilies) > 0 || len(r.UnmappedResources) > 0 ||
-		len(r.UnclaimedOperations) > 0 || len(r.StaleOperations) > 0
+		len(r.UnclaimedOperations) > 0 || len(r.StaleOperations) > 0 || len(r.RegisteredCandidates) > 0
 }
 
 func buildReport(families map[string][]SpecOperation, mapping *Mapping, resources, dataSources []string, specSource string) *Report {
@@ -481,11 +492,20 @@ func buildReport(families map[string][]SpecOperation, mapping *Mapping, resource
 		TriageFamilies:        []string{},
 		TriageOperations:      []OperationDetail{},
 		ScaffoldableResources: []ScaffoldableResource{},
+		RegisteredCandidates:  []CandidateConflict{},
 	}
 
 	mapped := map[string]MappingFamily{}
 	for _, f := range mapping.Families {
 		mapped[f.Tag] = f
+	}
+
+	// Registered provider types — a new_resource_candidate naming one is a
+	// curation mistake (candidates must be net-new), so it is reported as drift
+	// rather than as scaffoldable.
+	registered := map[string]bool{}
+	for _, t := range append(append([]string{}, resources...), dataSources...) {
+		registered[t] = true
 	}
 
 	// Spec tags absent from the mapping => new families.
@@ -566,6 +586,13 @@ func buildReport(families map[string][]SpecOperation, mapping *Mapping, resource
 		// are listed; a candidate op missing from the spec is caught as a stale
 		// claim by the loop below (candidate ops are in `claimed`).
 		for _, c := range f.NewResourceCandidates {
+			// A candidate naming an already-registered type is a curation
+			// mistake: the resource exists, so it is not net-new and must not be
+			// advertised as scaffoldable. Surface it as drift instead.
+			if registered[c.Name] {
+				report.RegisteredCandidates = append(report.RegisteredCandidates, CandidateConflict{Tag: f.Tag, Name: c.Name})
+				continue
+			}
 			sr := ScaffoldableResource{Tag: f.Tag, Name: c.Name, Operations: []OperationDetail{}}
 			for _, opID := range c.Operations {
 				if so, ok := specByKey[opID]; ok {
@@ -592,6 +619,13 @@ func buildReport(families map[string][]SpecOperation, mapping *Mapping, resource
 	})
 	sort.Slice(report.ScaffoldableResources, func(i, j int) bool {
 		a, b := report.ScaffoldableResources[i], report.ScaffoldableResources[j]
+		if a.Tag != b.Tag {
+			return a.Tag < b.Tag
+		}
+		return a.Name < b.Name
+	})
+	sort.Slice(report.RegisteredCandidates, func(i, j int) bool {
+		a, b := report.RegisteredCandidates[i], report.RegisteredCandidates[j]
 		if a.Tag != b.Tag {
 			return a.Tag < b.Tag
 		}
@@ -683,6 +717,15 @@ func renderMarkdown(out io.Writer, r *Report) error {
 		fmt.Fprintf(w, "## Registered provider types not referenced by any family\n\n")
 		for _, t := range r.UnmappedResources {
 			fmt.Fprintf(w, "- `%s`\n", t)
+		}
+		fmt.Fprintf(w, "\n")
+	}
+
+	if len(r.RegisteredCandidates) > 0 {
+		fmt.Fprintf(w, "## Candidates that already exist (curation error)\n\n")
+		fmt.Fprintf(w, "These `new_resource_candidates` name an already-registered provider type, so they are not net-new. Move each one's operations to a `resources` entry instead of `new_resource_candidates`.\n\n")
+		for _, c := range r.RegisteredCandidates {
+			fmt.Fprintf(w, "- %s: `%s`\n", c.Tag, c.Name)
 		}
 		fmt.Fprintf(w, "\n")
 	}

--- a/scripts/driftreport/report.go
+++ b/scripts/driftreport/report.go
@@ -53,13 +53,29 @@ type Mapping struct {
 }
 
 type MappingFamily struct {
-	Tag               string             `yaml:"tag"`
-	Status            string             `yaml:"status"`
-	Resources         []ResourceEntry    `yaml:"resources,omitempty"`
-	IgnoredOperations []IgnoredOperation `yaml:"ignored_operations,omitempty"`
-	TriageOperations  []string           `yaml:"triage_operations,omitempty"`
-	Reason            string             `yaml:"reason,omitempty"`
-	Notes             string             `yaml:"notes,omitempty"`
+	Tag                   string              `yaml:"tag"`
+	Status                string              `yaml:"status"`
+	Resources             []ResourceEntry     `yaml:"resources,omitempty"`
+	NewResourceCandidates []ResourceCandidate `yaml:"new_resource_candidates,omitempty"`
+	IgnoredOperations     []IgnoredOperation  `yaml:"ignored_operations,omitempty"`
+	TriageOperations      []string            `yaml:"triage_operations,omitempty"`
+	Reason                string              `yaml:"reason,omitempty"`
+	Notes                 string              `yaml:"notes,omitempty"`
+}
+
+// ResourceCandidate is a curated NET-NEW resource the provider does not yet
+// model but should, covering a cluster of a partial family's operations.
+// Unlike triage_operations (decision still pending), a candidate is decided:
+// it is ready for the stage-2 scaffolder to implement as a brand-new resource.
+// That is safe — scaffolding a new resource only ADDS a type and never touches
+// the family's existing resources, so there is no state-compatibility risk
+// (the same reason a wholly new family is scaffoldable). Candidate operations
+// count as claimed, so they do not surface as unclaimed drift; the report lists
+// them under scaffoldable_resources. Once implemented, move the operations to a
+// real resources entry and drop the candidate.
+type ResourceCandidate struct {
+	Name       string   `yaml:"name"`
+	Operations []string `yaml:"operations"`
 }
 
 // ResourceEntry is one resource claim under a family. A bare YAML string is a
@@ -139,6 +155,9 @@ func (f *MappingFamily) validateOperations() error {
 		if len(f.TriageOperations) > 0 {
 			return fmt.Errorf("tag %q: triage_operations set but family status is %q (only partial families carry operation lists)", f.Tag, f.Status)
 		}
+		if len(f.NewResourceCandidates) > 0 {
+			return fmt.Errorf("tag %q: new_resource_candidates set but family status is %q (only partial families carry operation lists)", f.Tag, f.Status)
+		}
 		return nil
 	}
 	claimed := map[string]bool{}
@@ -176,6 +195,30 @@ func (f *MappingFamily) validateOperations() error {
 			return fmt.Errorf("tag %q: operation %q claimed more than once", f.Tag, op)
 		}
 		claimed[op] = true
+	}
+	implemented := map[string]bool{}
+	for _, r := range f.Resources {
+		implemented[r.Name] = true
+	}
+	for _, c := range f.NewResourceCandidates {
+		if c.Name == "" {
+			return fmt.Errorf("tag %q: new_resource_candidates entry with empty name", f.Tag)
+		}
+		if implemented[c.Name] {
+			return fmt.Errorf("tag %q: new_resource_candidate %q is already an implemented resource (move its operations to that resource's entry instead)", f.Tag, c.Name)
+		}
+		if len(c.Operations) == 0 {
+			return fmt.Errorf("tag %q: new_resource_candidate %q must list at least one operation", f.Tag, c.Name)
+		}
+		for _, op := range c.Operations {
+			if op == "" {
+				return fmt.Errorf("tag %q: new_resource_candidate %q lists an empty operationId", f.Tag, c.Name)
+			}
+			if claimed[op] {
+				return fmt.Errorf("tag %q: operation %q claimed more than once", f.Tag, op)
+			}
+			claimed[op] = true
+		}
 	}
 	return nil
 }
@@ -385,10 +428,22 @@ type Report struct {
 	StaleOperations     []OperationDetail `json:"stale_operations"`
 
 	// Informational.
-	TriageFamilies   []string          `json:"triage_families"`
-	TriageOperations []OperationDetail `json:"triage_operations"`
-	StatusCounts     map[string]int    `json:"status_counts"`
-	TotalFamilies    int               `json:"total_families"`
+	TriageFamilies        []string               `json:"triage_families"`
+	TriageOperations      []OperationDetail      `json:"triage_operations"`
+	ScaffoldableResources []ScaffoldableResource `json:"scaffoldable_resources"`
+	StatusCounts          map[string]int         `json:"status_counts"`
+	TotalFamilies         int                    `json:"total_families"`
+}
+
+// ScaffoldableResource is a curated net-new resource (from a partial family's
+// new_resource_candidates) that is ready for the stage-2 scaffolder. It is
+// informational: it never fails the run — it is a backlog signal a human
+// dispatches. Operations carries only the spec operations that still exist;
+// any candidate operation missing from the spec surfaces under StaleOperations.
+type ScaffoldableResource struct {
+	Tag        string            `json:"tag"`
+	Name       string            `json:"name"`
+	Operations []OperationDetail `json:"operations"`
 }
 
 type FamilyDetail struct {
@@ -418,13 +473,14 @@ func buildReport(families map[string][]SpecOperation, mapping *Mapping, resource
 		StatusCounts:  map[string]int{},
 		TotalFamilies: len(families),
 		// Initialized so empty lists serialize as [] rather than null in JSON.
-		NewFamilies:         []FamilyDetail{},
-		StaleFamilies:       []string{},
-		UnmappedResources:   []string{},
-		UnclaimedOperations: []OperationDetail{},
-		StaleOperations:     []OperationDetail{},
-		TriageFamilies:      []string{},
-		TriageOperations:    []OperationDetail{},
+		NewFamilies:           []FamilyDetail{},
+		StaleFamilies:         []string{},
+		UnmappedResources:     []string{},
+		UnclaimedOperations:   []OperationDetail{},
+		StaleOperations:       []OperationDetail{},
+		TriageFamilies:        []string{},
+		TriageOperations:      []OperationDetail{},
+		ScaffoldableResources: []ScaffoldableResource{},
 	}
 
 	mapped := map[string]MappingFamily{}
@@ -481,8 +537,17 @@ func buildReport(families map[string][]SpecOperation, mapping *Mapping, resource
 			claimed[op] = true
 			triage[op] = true
 		}
+		// Curated net-new-resource operations count as claimed so they do not
+		// surface as unclaimed drift; they are emitted under scaffoldable_resources.
+		for _, c := range f.NewResourceCandidates {
+			for _, op := range c.Operations {
+				claimed[op] = true
+			}
+		}
+		specByKey := map[string]SpecOperation{}
 		inSpec := map[string]bool{}
 		for _, op := range specOps {
+			specByKey[op.key()] = op
 			inSpec[op.key()] = true
 			detail := OperationDetail{
 				Tag:         f.Tag,
@@ -496,6 +561,19 @@ func buildReport(families map[string][]SpecOperation, mapping *Mapping, resource
 			case !claimed[op.key()]:
 				report.UnclaimedOperations = append(report.UnclaimedOperations, detail)
 			}
+		}
+		// Emit curated net-new resources as scaffoldable. Only spec-present ops
+		// are listed; a candidate op missing from the spec is caught as a stale
+		// claim by the loop below (candidate ops are in `claimed`).
+		for _, c := range f.NewResourceCandidates {
+			sr := ScaffoldableResource{Tag: f.Tag, Name: c.Name, Operations: []OperationDetail{}}
+			for _, opID := range c.Operations {
+				if so, ok := specByKey[opID]; ok {
+					sr.Operations = append(sr.Operations, OperationDetail{Tag: f.Tag, OperationID: opID, Method: so.Method, Path: so.Path})
+				}
+			}
+			sortOperationDetails(sr.Operations)
+			report.ScaffoldableResources = append(report.ScaffoldableResources, sr)
 		}
 		for op := range claimed {
 			if !inSpec[op] {
@@ -511,6 +589,13 @@ func buildReport(families map[string][]SpecOperation, mapping *Mapping, resource
 			return a.Tag < b.Tag
 		}
 		return a.OperationID < b.OperationID
+	})
+	sort.Slice(report.ScaffoldableResources, func(i, j int) bool {
+		a, b := report.ScaffoldableResources[i], report.ScaffoldableResources[j]
+		if a.Tag != b.Tag {
+			return a.Tag < b.Tag
+		}
+		return a.Name < b.Name
 	})
 
 	// Registered types never referenced by any family => mapping is incomplete.
@@ -622,6 +707,18 @@ func renderMarkdown(out io.Writer, r *Report) error {
 			fmt.Fprintf(w, "- %s: `%s`\n", op.Tag, op.OperationID)
 		}
 		fmt.Fprintf(w, "\n")
+	}
+
+	if len(r.ScaffoldableResources) > 0 {
+		fmt.Fprintf(w, "## Scaffoldable new resources in partial families (curated — ready for stage 2)\n\n")
+		fmt.Fprintf(w, "Net-new resources within a partial family; the stage-2 scaffolder can implement each without touching the family's existing resources.\n\n")
+		for _, sr := range r.ScaffoldableResources {
+			fmt.Fprintf(w, "### %s → `%s`\n\n", sr.Tag, sr.Name)
+			for _, op := range sr.Operations {
+				fmt.Fprintf(w, "- `%s %s` (`%s`)\n", op.Method, op.Path, op.OperationID)
+			}
+			fmt.Fprintf(w, "\n")
+		}
 	}
 
 	if len(r.TriageFamilies) > 0 {

--- a/scripts/driftreport/report_test.go
+++ b/scripts/driftreport/report_test.go
@@ -142,7 +142,7 @@ func TestBuildReportClean(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, key := range []string{"new_families", "stale_families", "unmapped_resources", "unclaimed_operations", "stale_operations", "triage_operations", "scaffoldable_resources"} {
+	for _, key := range []string{"new_families", "stale_families", "unmapped_resources", "unclaimed_operations", "stale_operations", "triage_operations", "scaffoldable_resources", "registered_candidates"} {
 		if strings.Contains(string(raw), fmt.Sprintf("%q:null", key)) {
 			t.Errorf("%s serializes as null, want []", key)
 		}
@@ -314,6 +314,50 @@ func TestBuildReportScaffoldableResources(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "Scaffoldable new resources in partial families") {
 		t.Error("markdown should include the scaffoldable-resources section")
+	}
+}
+
+func TestBuildReportRegisteredCandidateIsDrift(t *testing.T) {
+	families := fixtureOperations(t)
+	widgets := partialWidgets([]string{"getWidgets", "postWidget"})
+	// Curation mistake: the candidate names an already-registered provider type,
+	// so it is not net-new. (A same-family resource collision is caught by
+	// validation; this catches the cross-family / registered case validation
+	// cannot see.)
+	widgets.NewResourceCandidates = []ResourceCandidate{
+		{Name: "launchdarkly_project", Operations: []string{"deleteWidget"}},
+	}
+	mapping := fixtureMapping(t,
+		MappingFamily{Tag: "Projects", Status: statusCovered, Resources: []ResourceEntry{{Name: "launchdarkly_project"}}},
+		MappingFamily{Tag: "Shiny new feature", Status: statusTriage},
+		MappingFamily{Tag: "<untagged>", Status: statusIgnored, Reason: "spec hygiene bucket"},
+		widgets,
+	)
+	report := buildReport(families, mapping, []string{"launchdarkly_project", "launchdarkly_widget"}, nil, "fixture")
+
+	if !report.HasDrift() {
+		t.Fatal("a candidate naming a registered type must be drift")
+	}
+	if len(report.RegisteredCandidates) != 1 ||
+		report.RegisteredCandidates[0].Tag != "Widgets" ||
+		report.RegisteredCandidates[0].Name != "launchdarkly_project" {
+		t.Errorf("RegisteredCandidates = %+v, want [{Widgets launchdarkly_project}]", report.RegisteredCandidates)
+	}
+	// Must NOT be advertised as scaffoldable — that would re-scaffold an existing resource.
+	if len(report.ScaffoldableResources) != 0 {
+		t.Errorf("ScaffoldableResources = %+v, want none (candidate is already registered)", report.ScaffoldableResources)
+	}
+	// Its operation is still claimed, so it is not double-reported as unclaimed.
+	if len(report.UnclaimedOperations) != 0 {
+		t.Errorf("UnclaimedOperations = %+v, want none", report.UnclaimedOperations)
+	}
+
+	var buf bytes.Buffer
+	if err := renderMarkdown(&buf, report); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "Candidates that already exist") {
+		t.Error("markdown should include the registered-candidate section")
 	}
 }
 

--- a/scripts/driftreport/report_test.go
+++ b/scripts/driftreport/report_test.go
@@ -142,7 +142,7 @@ func TestBuildReportClean(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, key := range []string{"new_families", "stale_families", "unmapped_resources", "unclaimed_operations", "stale_operations", "triage_operations"} {
+	for _, key := range []string{"new_families", "stale_families", "unmapped_resources", "unclaimed_operations", "stale_operations", "triage_operations", "scaffoldable_resources"} {
 		if strings.Contains(string(raw), fmt.Sprintf("%q:null", key)) {
 			t.Errorf("%s serializes as null, want []", key)
 		}
@@ -272,6 +272,75 @@ func TestBuildReportStaleOperations(t *testing.T) {
 	}
 }
 
+func TestBuildReportScaffoldableResources(t *testing.T) {
+	families := fixtureOperations(t)
+	widgets := partialWidgets([]string{"getWidgets", "postWidget"})
+	// deleteWidget is curated as a net-new resource rather than claimed on the
+	// existing widget resource or left unclaimed.
+	widgets.NewResourceCandidates = []ResourceCandidate{
+		{Name: "launchdarkly_widget_deletion", Operations: []string{"deleteWidget"}},
+	}
+	mapping := fixtureMapping(t,
+		MappingFamily{Tag: "Projects", Status: statusCovered, Resources: []ResourceEntry{{Name: "launchdarkly_project"}}},
+		MappingFamily{Tag: "Shiny new feature", Status: statusTriage},
+		MappingFamily{Tag: "<untagged>", Status: statusIgnored, Reason: "spec hygiene bucket"},
+		widgets,
+	)
+	report := buildReport(families, mapping, []string{"launchdarkly_project", "launchdarkly_widget"}, nil, "fixture")
+
+	// A curated net-new resource is informational: it must not drift, and its
+	// operations must not surface as unclaimed.
+	if report.HasDrift() {
+		t.Fatalf("scaffoldable candidate must not drift, got %+v", report)
+	}
+	if len(report.UnclaimedOperations) != 0 {
+		t.Errorf("UnclaimedOperations = %+v, want none (candidate op is claimed)", report.UnclaimedOperations)
+	}
+	if len(report.ScaffoldableResources) != 1 {
+		t.Fatalf("ScaffoldableResources = %+v, want exactly 1", report.ScaffoldableResources)
+	}
+	sr := report.ScaffoldableResources[0]
+	if sr.Tag != "Widgets" || sr.Name != "launchdarkly_widget_deletion" {
+		t.Errorf("ScaffoldableResources[0] = %+v, want Widgets/launchdarkly_widget_deletion", sr)
+	}
+	if len(sr.Operations) != 1 || sr.Operations[0].OperationID != "deleteWidget" ||
+		sr.Operations[0].Method != "DELETE" || sr.Operations[0].Path != "/api/v2/widgets/{key}" {
+		t.Errorf("candidate op = %+v, want deleteWidget DELETE /api/v2/widgets/{key}", sr.Operations)
+	}
+
+	var buf bytes.Buffer
+	if err := renderMarkdown(&buf, report); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "Scaffoldable new resources in partial families") {
+		t.Error("markdown should include the scaffoldable-resources section")
+	}
+}
+
+func TestBuildReportStaleCandidateOperation(t *testing.T) {
+	families := fixtureOperations(t)
+	widgets := partialWidgets([]string{"getWidgets", "postWidget"})
+	widgets.NewResourceCandidates = []ResourceCandidate{
+		{Name: "launchdarkly_widget_deletion", Operations: []string{"deleteWidget", "ghostCandidateOp"}},
+	}
+	mapping := fixtureMapping(t,
+		MappingFamily{Tag: "Projects", Status: statusCovered, Resources: []ResourceEntry{{Name: "launchdarkly_project"}}},
+		MappingFamily{Tag: "Shiny new feature", Status: statusTriage},
+		MappingFamily{Tag: "<untagged>", Status: statusIgnored, Reason: "spec hygiene bucket"},
+		widgets,
+	)
+	report := buildReport(families, mapping, []string{"launchdarkly_project", "launchdarkly_widget"}, nil, "fixture")
+
+	// A candidate op missing from the spec is a stale claim (drift); the
+	// scaffoldable entry lists only the spec-present op.
+	if len(report.StaleOperations) != 1 || report.StaleOperations[0].OperationID != "ghostCandidateOp" {
+		t.Errorf("StaleOperations = %+v, want [ghostCandidateOp]", report.StaleOperations)
+	}
+	if len(report.ScaffoldableResources) != 1 || len(report.ScaffoldableResources[0].Operations) != 1 {
+		t.Errorf("ScaffoldableResources = %+v, want 1 entry with 1 spec-present op", report.ScaffoldableResources)
+	}
+}
+
 func TestBuildReportSkipsOperationChecksForStaleFamily(t *testing.T) {
 	families := fixtureOperations(t)
 	mapping := fixtureMapping(t,
@@ -341,6 +410,24 @@ func TestMappingValidation(t *testing.T) {
 		{"empty triage operationId", MappingFamily{Tag: "X", Status: statusPartial,
 			Resources:        []ResourceEntry{{Name: "launchdarkly_x", Operations: []string{"getX"}}},
 			TriageOperations: []string{""}}},
+		{"new_resource_candidates on covered family", MappingFamily{Tag: "X", Status: statusCovered,
+			Resources:             []ResourceEntry{{Name: "launchdarkly_x"}},
+			NewResourceCandidates: []ResourceCandidate{{Name: "launchdarkly_y", Operations: []string{"getX"}}}}},
+		{"candidate with empty name", MappingFamily{Tag: "X", Status: statusPartial,
+			Resources:             []ResourceEntry{{Name: "launchdarkly_x", Operations: []string{"getX"}}},
+			NewResourceCandidates: []ResourceCandidate{{Operations: []string{"putX"}}}}},
+		{"candidate without operations", MappingFamily{Tag: "X", Status: statusPartial,
+			Resources:             []ResourceEntry{{Name: "launchdarkly_x", Operations: []string{"getX"}}},
+			NewResourceCandidates: []ResourceCandidate{{Name: "launchdarkly_y"}}}},
+		{"candidate operation also claimed by a resource", MappingFamily{Tag: "X", Status: statusPartial,
+			Resources:             []ResourceEntry{{Name: "launchdarkly_x", Operations: []string{"getX"}}},
+			NewResourceCandidates: []ResourceCandidate{{Name: "launchdarkly_y", Operations: []string{"getX"}}}}},
+		{"candidate name equals an implemented resource", MappingFamily{Tag: "X", Status: statusPartial,
+			Resources:             []ResourceEntry{{Name: "launchdarkly_x", Operations: []string{"getX"}}},
+			NewResourceCandidates: []ResourceCandidate{{Name: "launchdarkly_x", Operations: []string{"putX"}}}}},
+		{"empty candidate operationId", MappingFamily{Tag: "X", Status: statusPartial,
+			Resources:             []ResourceEntry{{Name: "launchdarkly_x", Operations: []string{"getX"}}},
+			NewResourceCandidates: []ResourceCandidate{{Name: "launchdarkly_y", Operations: []string{""}}}}},
 	}
 	for _, tc := range cases {
 		m := &Mapping{Version: 1, Families: []MappingFamily{tc.fam}}
@@ -376,6 +463,11 @@ families:
         reason: runtime search, not declarative
     triage_operations:
       - postThingBulk
+    new_resource_candidates:
+      - name: launchdarkly_new_thing
+        operations:
+          - postNewThing
+          - getNewThing
 `
 	var m Mapping
 	if err := yaml.Unmarshal([]byte(doc), &m); err != nil {
@@ -383,6 +475,9 @@ families:
 	}
 	if err := m.validate(); err != nil {
 		t.Fatalf("validate: %v", err)
+	}
+	if cands := m.Families[1].NewResourceCandidates; len(cands) != 1 || cands[0].Name != "launchdarkly_new_thing" || len(cands[0].Operations) != 2 {
+		t.Errorf("new_resource_candidates = %+v, want 1 entry with name + 2 operations", m.Families[1].NewResourceCandidates)
 	}
 	plain := m.Families[0].Resources[0]
 	if plain.Name != "launchdarkly_plain" || len(plain.Operations) != 0 {


### PR DESCRIPTION
Stacked follow-up to the autogen pipeline. **Tool-only** change to `scripts/driftreport`; the notification + stage-2 wiring lands separately by updating #457 once this merges.

## What & why
A partial family is one the provider partly models. Some of its un-modeled operations are genuinely a **net-new resource** (e.g. agent graphs), not an extension of an existing one. Scaffolding a *net-new* resource is as safe as a wholly-new family — it only adds a type, never touches existing resources, so there's no state-compatibility risk. This lets the pipeline surface those as scaffoldable instead of lumping them into "needs a manual PR."

## Changes
- `MappingFamily` gains optional `new_resource_candidates: [{name, operations: [opId]}]` (partial families only).
- Candidate operations count as **claimed** (suppressed from unclaimed-operations drift, like `triage_operations`) and are emitted in a new **informational** report field `scaffoldable_resources: [{tag, name, operations:[{method, path, operation_id}]}]`. It is *not* a drift signal — `HasDrift()` is unchanged. A candidate op missing from the spec still surfaces as a stale claim.
- Validation mirrors the existing op-level rules: partial-only; name + non-empty operations required; operations in-spec and not double-claimed; a candidate name may not equal an implemented resource in the same family.
- The net-new-vs-extends-existing call is **curated, not inferred** (consistent with the mapping's no-inference design).
- First curation: `AgentControl` promotes the agent-graph and prompt-snippet CRUD clusters out of `triage` into `launchdarkly_ai_agent_graph` / `launchdarkly_prompt_snippet` candidates (triage 27→17). AI config targeting (extends `ai_config`) and the messier optimization / aux-read / restricted-model ops stay in triage.

## Validation
- 16 unit tests (new: scaffoldable emission, stale candidate op, 6 validation cases, YAML parse) — pass.
- `go vet`, `gofmt`, and `golangci-lint v1.64.8` clean.
- Live spec run still exits 0; `scaffoldable_resources` populates with the two AgentControl candidates (full method/path detail).

## Follow-up (separate, after merge)
Update #457 (`drift-report.yml` + `verify-scaffold.yml` on `main`) to: post a per-candidate Slack message with a *scoped* stage-2 dispatch link, and add `resource_name` + `operations` inputs to the scaffold workflow (+ a `driftreport -family … -operations …` slice filter) so the agent adds exactly the one new resource without touching the family's existing resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to drift-report tooling, mapping curation, tests, and a generated optional integration field—no provider runtime or auth paths.
> 
> **Overview**
> Extends the **drift report** so partial OpenAPI families can declare **`new_resource_candidates`**: curated net-new Terraform resources (name + operationIds) that are ready for stage-2 scaffolding without touching existing resources in that family.
> 
> Candidate operations are treated as **claimed** (like triage), so they no longer show as unclaimed drift. The report adds informational **`scaffoldable_resources`** (tag, name, method/path per op) and drift **`registered_candidates`** when a candidate name already matches a registered provider type. Validation enforces partial-only use, no duplicate claims, and no candidate colliding with an implemented resource in the same family. Markdown output documents both sections.
> 
> **AgentControl** mapping is updated: agent-graph and prompt-snippet CRUD clusters move from `triage_operations` into candidates `launchdarkly_ai_agent_graph` and `launchdarkly_prompt_snippet`; targeting, optimizations, aux reads, and restricted models stay in triage with clearer comments.
> 
> Separately, generated **Vercel native** integration config gains an optional **`url`** field for the installation page link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9505168c51a9f5cbda8813a2fd65c88a0e7c6346. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->