### PR TITLE
fix: handle segment create under segment approvals (#370)

### DIFF
--- a/docs/resources/segment.md
+++ b/docs/resources/segment.md
@@ -5,6 +5,7 @@ subcategory: ""
 description: |-
   Provides a LaunchDarkly segment resource.
   This resource allows you to create and manage segments within your LaunchDarkly organization.
+  -> Note: When segment approvals https://docs.launchdarkly.com/home/releases/approvals are enabled for an environment, segment targeting changes (included, excluded, rules, included_contexts, excluded_contexts) require approval and cannot be applied by Terraform: unlike feature flags, service tokens cannot bypass segment approvals (LaunchDarkly feature request FROPS-190). A segment with no targeting can still be created and managed. If targeting is configured, terraform apply fails with an "approval is required" error — manage targeting through the approval workflow (e.g. with lifecycle { ignore_changes = [included, excluded, rules] }) or disable segment approvals for the environment.
 ---
 
 # launchdarkly_segment (Resource)
@@ -12,6 +13,8 @@ description: |-
 Provides a LaunchDarkly segment resource.
 
 This resource allows you to create and manage segments within your LaunchDarkly organization.
+
+-> **Note:** When [segment approvals](https://docs.launchdarkly.com/home/releases/approvals) are enabled for an environment, segment **targeting** changes (`included`, `excluded`, `rules`, `included_contexts`, `excluded_contexts`) require approval and cannot be applied by Terraform: unlike feature flags, service tokens cannot bypass segment approvals (LaunchDarkly feature request FROPS-190). A segment with no targeting can still be created and managed. If targeting is configured, `terraform apply` fails with an "approval is required" error — manage targeting through the approval workflow (e.g. with `lifecycle { ignore_changes = [included, excluded, rules] }`) or disable segment approvals for the environment.
 
 ## Example Usage
 

--- a/launchdarkly/helper.go
+++ b/launchdarkly/helper.go
@@ -63,6 +63,30 @@ func isTimeoutError(err error) bool {
 	return ok && e.Timeout()
 }
 
+// isApprovalRequiredErr reports whether err is a LaunchDarkly API rejection
+// caused by an approval requirement. When approvals are enabled for a
+// resource, the API rejects direct mutations with HTTP 403 and the body
+// {"code":"forbidden","message":"approval is required"}. Segment approvals
+// gate targeting changes (included / excluded / rules / *_contexts) and,
+// unlike flag approvals, cannot yet be bypassed by a service token
+// (FROPS-190) — so Terraform cannot apply gated segment changes. See issue
+// #370. Keyed on the message rather than the bare 403 so ordinary
+// permission-denied 403s are not misclassified.
+func isApprovalRequiredErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	const marker = "approval is required"
+	// The API client returns the response payload via Body(); err.Error() only
+	// carries the HTTP status line, so check the body first.
+	if swaggerErr, ok := err.(*ldapi.GenericOpenAPIError); ok {
+		if strings.Contains(string(swaggerErr.Body()), marker) {
+			return true
+		}
+	}
+	return strings.Contains(err.Error(), marker)
+}
+
 func isStatusNotFound(response *http.Response) bool {
 	if response != nil && response.StatusCode == http.StatusNotFound {
 		return true

--- a/launchdarkly/helper_test.go
+++ b/launchdarkly/helper_test.go
@@ -1,0 +1,68 @@
+package launchdarkly
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	ldapi "github.com/launchdarkly/api-client-go/v22"
+)
+
+func TestIsApprovalRequiredErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain approval message", errors.New(`{"code":"forbidden","message":"approval is required"}`), true},
+		{"wrapped approval message", fmt.Errorf("patch failed: %w", errors.New("approval is required")), true},
+		{"unrelated forbidden", errors.New(`{"code":"forbidden","message":"insufficient permissions"}`), false},
+		{"unrelated error", errors.New("connection reset"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isApprovalRequiredErr(tt.err); got != tt.want {
+				t.Fatalf("isApprovalRequiredErr(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppendSegmentTargetingOps(t *testing.T) {
+	rule := ldapi.UserSegmentRule{}
+	target := ldapi.SegmentTarget{}
+
+	t.Run("all empty yields no ops", func(t *testing.T) {
+		ops := appendSegmentTargetingOps(nil, nil, nil, nil, nil, nil)
+		if len(ops) != 0 {
+			t.Fatalf("expected 0 ops for empty targeting, got %d: %+v", len(ops), ops)
+		}
+	})
+
+	t.Run("only non-empty collections produce ops", func(t *testing.T) {
+		ops := appendSegmentTargetingOps(nil,
+			[]string{"u1"},                // included
+			nil,                           // excluded (empty -> skipped)
+			[]ldapi.UserSegmentRule{rule}, // rules
+			nil,                           // includedContexts (empty -> skipped)
+			[]ldapi.SegmentTarget{target}, // excludedContexts
+		)
+		gotPaths := map[string]bool{}
+		for _, op := range ops {
+			gotPaths[op.Path] = true
+		}
+		want := []string{"/included", "/rules", "/excludedContexts"}
+		if len(ops) != len(want) {
+			t.Fatalf("expected %d ops, got %d: %+v", len(want), len(ops), ops)
+		}
+		for _, p := range want {
+			if !gotPaths[p] {
+				t.Errorf("missing expected op path %q (got %v)", p, gotPaths)
+			}
+		}
+		if gotPaths["/excluded"] || gotPaths["/includedContexts"] {
+			t.Errorf("empty collections should not emit ops, got %v", gotPaths)
+		}
+	})
+}

--- a/launchdarkly/resource_launchdarkly_segment_test.go
+++ b/launchdarkly/resource_launchdarkly_segment_test.go
@@ -2,9 +2,13 @@ package launchdarkly
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -729,4 +733,115 @@ resource "launchdarkly_segment" "test" {
 			},
 		},
 	})
+}
+
+// TestAccSegment_ApprovalRequired covers issue #370: when segment approvals are
+// enabled for an environment, a segment with no targeting must still create
+// (the gated, no-op targeting PATCH is skipped), while a segment that does
+// configure targeting must fail with the actionable "approval is required"
+// error rather than the old opaque failure. Segment approvals are not exposed
+// through the provider schema, so they are toggled out-of-band via the beta
+// approval-settings API in a PreConfig step. Runs serially because it mutates
+// environment-scoped approval settings.
+func TestAccSegment_ApprovalRequired(t *testing.T) {
+	projectKey := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	envKey := "test-env"
+	bareResourceName := "launchdarkly_segment.bare"
+
+	projectOnly := fmt.Sprintf(`
+resource "launchdarkly_project" "test" {
+	key  = "%s"
+	name = "Segment Approvals Test"
+	environments = [{
+		key   = "%s"
+		name  = "Test Environment"
+		color = "010101"
+	}]
+}
+`, projectKey, envKey)
+
+	bareSegment := projectOnly + `
+resource "launchdarkly_segment" "bare" {
+	project_key = launchdarkly_project.test.key
+	env_key     = "test-env"
+	key         = "approval-bare"
+	name        = "bare under approvals"
+	description = "no targeting; must create under approvals"
+}
+`
+
+	withRules := bareSegment + `
+resource "launchdarkly_segment" "rules" {
+	project_key = launchdarkly_project.test.key
+	env_key     = "test-env"
+	key         = "approval-rules"
+	name        = "rules under approvals"
+	rules = [{
+		clauses = [{
+			attribute    = "email"
+			op           = "in"
+			values       = ["a@b.com"]
+			context_kind = "user"
+		}]
+	}]
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckProjectDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: create the project + environment (no segment yet).
+			{
+				Config: projectOnly,
+			},
+			// Step 2: enable segment approvals, then a targeting-free segment
+			// must still create successfully.
+			{
+				PreConfig: func() { enableSegmentApprovalsForTest(t, projectKey, envKey) },
+				Config:    bareSegment,
+				Check:     resource.ComposeTestCheckFunc(testAccCheckSegmentExists(bareResourceName)),
+			},
+			// Step 3: a segment that configures targeting must fail with the
+			// actionable approval error; the partial shell is rolled back.
+			{
+				// Terraform word-wraps diagnostics, so tolerate whitespace
+				// (including newlines) between words.
+				Config:      withRules,
+				ExpectError: regexp.MustCompile(`approval\s+is\s+required`),
+			},
+		},
+	})
+}
+
+// enableSegmentApprovalsForTest turns on segment approvals for the given
+// environment via the beta approval-settings API. Segment approvals are not
+// configurable through the provider schema, so the test toggles them directly.
+func enableSegmentApprovalsForTest(t *testing.T, projectKey, envKey string) {
+	t.Helper()
+	host := os.Getenv(LAUNCHDARKLY_API_HOST)
+	if host == "" {
+		host = DEFAULT_LAUNCHDARKLY_HOST
+	}
+	if !strings.HasPrefix(host, "http://") && !strings.HasPrefix(host, "https://") {
+		host = "https://" + host
+	}
+	body := fmt.Sprintf(`{"environmentKey":%q,"resourceKind":"segment","required":true,"serviceKind":"launchdarkly","minNumApprovals":1}`, envKey)
+	req, err := http.NewRequest(http.MethodPatch, host+"/api/v2/approval-requests/projects/"+projectKey+"/settings", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("build approval-settings request: %s", err)
+	}
+	req.Header.Set("Authorization", os.Getenv(LAUNCHDARKLY_ACCESS_TOKEN))
+	req.Header.Set("LD-API-Version", "beta")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	if err != nil {
+		t.Fatalf("enable segment approvals: %s", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("enable segment approvals for %s/%s returned %d: %s", projectKey, envKey, resp.StatusCode, string(b))
+	}
 }

--- a/launchdarkly/resource_segment_framework.go
+++ b/launchdarkly/resource_segment_framework.go
@@ -69,7 +69,9 @@ func (r *SegmentResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 		Version: 1,
 		Description: `Provides a LaunchDarkly segment resource.
 
-This resource allows you to create and manage segments within your LaunchDarkly organization.`,
+This resource allows you to create and manage segments within your LaunchDarkly organization.
+
+-> **Note:** When [segment approvals](https://docs.launchdarkly.com/home/releases/approvals) are enabled for an environment, segment **targeting** changes (` + "`included`" + `, ` + "`excluded`" + `, ` + "`rules`" + `, ` + "`included_contexts`" + `, ` + "`excluded_contexts`" + `) require approval and cannot be applied by Terraform: unlike feature flags, service tokens cannot bypass segment approvals (LaunchDarkly feature request FROPS-190). A segment with no targeting can still be created and managed. If targeting is configured, ` + "`terraform apply`" + ` fails with an "approval is required" error — manage targeting through the approval workflow (e.g. with ` + "`lifecycle { ignore_changes = [included, excluded, rules] }`" + `) or disable segment approvals for the environment.`,
 		Attributes: segmentSchemaAttributes(),
 	}
 }
@@ -483,33 +485,51 @@ func (r *SegmentResource) applySegmentUpdate(ctx context.Context, plan, state Se
 	}
 
 	comment := "Terraform"
-	patchOps := []ldapi.PatchOperation{
-		patchReplace("/name", plan.Name.ValueString()),
-		patchReplace("/description", desc),
-		patchReplace("/temporary", false),
-		patchReplace("/included", included),
-		patchReplace("/excluded", excluded),
-		patchReplace("/rules", rules),
-		patchReplace("/includedContexts", includedContexts),
-		patchReplace("/excludedContexts", excludedContexts),
-	}
-	tagsChanged := isCreate || !plan.Tags.Equal(state.Tags)
-	if tagsChanged && len(tags) == 0 {
-		patchOps = append(patchOps, patchRemove("/tags"))
+	var patchOps []ldapi.PatchOperation
+	if isCreate {
+		// The shell created by PostSegment / createSegmentWithViewKeys already
+		// carries name, description, tags and unbounded settings, so a create
+		// only needs to PATCH targeting. We deliberately omit the no-op
+		// targeting replaces (and the legacy "/temporary" op, which targets a
+		// field segments don't have): when segment approvals are enabled those
+		// ops are themselves gated, so sending them would make even a
+		// targeting-free segment fail to create (issue #370). A segment with no
+		// targeting therefore needs no PATCH at all and is created by the shell
+		// POST alone.
+		patchOps = appendSegmentTargetingOps(nil, included, excluded, rules, includedContexts, excludedContexts)
 	} else {
-		patchOps = append(patchOps, patchReplace("/tags", tags))
+		patchOps = []ldapi.PatchOperation{
+			patchReplace("/name", plan.Name.ValueString()),
+			patchReplace("/description", desc),
+			patchReplace("/included", included),
+			patchReplace("/excluded", excluded),
+			patchReplace("/rules", rules),
+			patchReplace("/includedContexts", includedContexts),
+			patchReplace("/excludedContexts", excludedContexts),
+		}
+		if !plan.Tags.Equal(state.Tags) && len(tags) == 0 {
+			patchOps = append(patchOps, patchRemove("/tags"))
+		} else {
+			patchOps = append(patchOps, patchReplace("/tags", tags))
+		}
 	}
 
-	err := r.client.withConcurrency(r.client.ctx, func() error {
-		_, _, e := r.client.ld.SegmentsApi.PatchSegment(r.client.ctx, projectKey, envKey, key).PatchWithComment(ldapi.PatchWithComment{
-			Comment: &comment,
-			Patch:   patchOps,
-		}).Execute()
-		return e
-	})
-	if err != nil {
-		diags.AddError(fmt.Sprintf("failed to update segment %q in project %q: %s", key, projectKey, handleLdapiErr(err).Error()), "")
-		return diags
+	if len(patchOps) > 0 {
+		err := r.client.withConcurrency(r.client.ctx, func() error {
+			_, _, e := r.client.ld.SegmentsApi.PatchSegment(r.client.ctx, projectKey, envKey, key).PatchWithComment(ldapi.PatchWithComment{
+				Comment: &comment,
+				Patch:   patchOps,
+			}).Execute()
+			return e
+		})
+		if err != nil {
+			if isApprovalRequiredErr(err) {
+				diags.Append(r.segmentApprovalRequiredDiag(isCreate, projectKey, envKey, key))
+				return diags
+			}
+			diags.AddError(fmt.Sprintf("failed to update segment %q in project %q: %s", key, projectKey, handleLdapiErr(err).Error()), "")
+			return diags
+		}
 	}
 
 	// View association reconciliation.
@@ -580,6 +600,62 @@ func (r *SegmentResource) applySegmentUpdate(ctx context.Context, plan, state Se
 		}
 	}
 	return diags
+}
+
+// appendSegmentTargetingOps appends a replace op for each segment targeting
+// collection that is non-empty. Empty collections are skipped because a
+// freshly created segment shell already has them empty, and replacing them
+// with an empty value is gated when segment approvals are enabled (issue
+// #370) — sending such no-op replaces would needlessly fail an otherwise
+// targeting-free create.
+func appendSegmentTargetingOps(ops []ldapi.PatchOperation, included, excluded []string, rules []ldapi.UserSegmentRule, includedContexts, excludedContexts []ldapi.SegmentTarget) []ldapi.PatchOperation {
+	if len(included) > 0 {
+		ops = append(ops, patchReplace("/included", included))
+	}
+	if len(excluded) > 0 {
+		ops = append(ops, patchReplace("/excluded", excluded))
+	}
+	if len(rules) > 0 {
+		ops = append(ops, patchReplace("/rules", rules))
+	}
+	if len(includedContexts) > 0 {
+		ops = append(ops, patchReplace("/includedContexts", includedContexts))
+	}
+	if len(excludedContexts) > 0 {
+		ops = append(ops, patchReplace("/excludedContexts", excludedContexts))
+	}
+	return ops
+}
+
+// segmentApprovalRequiredDiag builds the diagnostic returned when a segment
+// PATCH is rejected because segment approvals are enabled for the environment.
+// Segment targeting changes require approval and, unlike feature flags,
+// service tokens cannot bypass segment approvals yet (FROPS-190), so Terraform
+// — which applies changes non-interactively — cannot satisfy the inline
+// approval. On create the function also rolls back the shell that PostSegment
+// created (DELETE is not gated by approvals) so a retry does not collide with
+// an orphaned segment. See issue #370.
+func (r *SegmentResource) segmentApprovalRequiredDiag(isCreate bool, projectKey, envKey, key string) diag.Diagnostic {
+	verb := "updated"
+	remediation := "Remove the targeting attributes (included / excluded / rules / included_contexts / excluded_contexts) from this resource, or disable segment approvals for this environment."
+	rollback := ""
+	if isCreate {
+		verb = "created"
+		remediation = "Remove the targeting attributes (included / excluded / rules / included_contexts / excluded_contexts) so Terraform creates only the segment shell and you manage targeting through the approval workflow, or disable segment approvals for this environment."
+		delErr := r.client.withConcurrency(r.client.ctx, func() error {
+			_, e := r.client.ld.SegmentsApi.DeleteSegment(r.client.ctx, projectKey, envKey, key).Execute()
+			return e
+		})
+		if delErr == nil {
+			rollback = " The partially created segment was rolled back to keep Terraform state consistent."
+		} else {
+			rollback = fmt.Sprintf(" Note: the partially created segment %q could not be removed automatically (%s); delete it manually before retrying.", key, handleLdapiErr(delErr).Error())
+		}
+	}
+	return diag.NewErrorDiagnostic(
+		fmt.Sprintf("segment %q cannot be %s in project %q: segment approvals are enabled for environment %q", key, verb, projectKey, envKey),
+		fmt.Sprintf("LaunchDarkly rejected the segment targeting change with \"approval is required\" (HTTP 403). Segment approvals gate targeting changes in this environment, and unlike feature flags, service tokens cannot bypass segment approvals yet (LaunchDarkly feature request FROPS-190). Because Terraform applies changes non-interactively, it cannot satisfy an inline approval.%s\n\n%s", rollback, remediation),
+	)
 }
 
 func (r *SegmentResource) readIntoModel(ctx context.Context, data *SegmentResourceModel, diags *diag.Diagnostics) {


### PR DESCRIPTION
## Summary

Fixes #370 — `launchdarkly_segment` create fails when **segment approvals** are enabled (reported by Netskope on `2.25.3`; this fixes the v3/framework path).

### Root cause (reproduced against a real account)
Segment `Create` does `PostSegment` (creates the shell — **succeeds with 201 even under approvals**) and then an **always-sent** `PatchSegment`. Under segment approvals the targeting ops (`/included`, `/excluded`, `/rules`, `/includedContexts`, `/excludedContexts`) **and** a legacy `/temporary` op — a field `UserSegment` doesn't even have (cruft copied from flags) — are gated, so the atomic PATCH returns:

```
403 {"code":"forbidden","message":"approval is required"}
```

Because `/temporary` and the empty-array targeting replaces are gated **even when empty**, *every* segment create failed — including bare segments with no targeting — and the dead PATCH left the shell **orphaned** in LaunchDarkly (absent from state → 409 on the next apply). Unlike feature flags, service tokens cannot bypass segment approvals yet (**FROPS-190**, still open), so an admin token does not help.

### What changed
- **Skip the no-op create PATCH.** The shell POST already sets name/description/tags/unbounded, so create now sends a **targeting-only** PATCH built from non-empty collections, and skips it entirely when there's no targeting. → **a segment with no targeting now creates cleanly under approvals.**
- **Drop the `/temporary` op** (nonexistent field; was itself gated).
- **Clear, actionable error** when targeting *is* configured under approvals (`isApprovalRequiredErr` + `segmentApprovalRequiredDiag`) citing FROPS-190 and remediation.
- **Roll back the orphaned shell** on create failure (DELETE is not gated) so state stays consistent.
- **Docs** note on the segment resource + **unit tests** for the new helpers.

> This is graceful degradation, not a full fix — segments *with* targeting still cannot be applied under approvals until FROPS-190 ships. Documented as such.

## Test plan
- `make build`, `make fmtcheck`, `go vet` — clean.
- New unit tests pass (`TestIsApprovalRequiredErr`, `TestAppendSegmentTargetingOps`); full package run shows **no new failures** vs base.
- **Live end-to-end** against a real account with segment approvals enabled on the env:
  - bare segment → **created** ✓
  - segment with `rules` → fails with the clear error, partial shell **rolled back** (GET → 404) ✓
  - destroy + cleanup ✓

## Notes
- Targets `preview-v3` (this branch is based on the v3 framework line, not `main`).
- Does **not** touch `integration_configs_generated.go` — `make generate` drift there is account-specific manifest noise, unrelated to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes segment create/update PATCH behavior and error handling for a core resource; behavior under approvals is improved but segments with targeting still cannot be fully managed until FROPS-190.
> 
> **Overview**
> Fixes **#370** so `launchdarkly_segment` works when **segment approvals** are on for an environment.
> 
> **Create path:** After `PostSegment`, create no longer always PATCHes name/description/tags and empty targeting (or the invalid `/temporary` op). It only PATCHes **non-empty** targeting fields via `appendSegmentTargetingOps`, and skips PATCH entirely when there is no targeting—so shell-only segments succeed under approvals.
> 
> **Errors:** `isApprovalRequiredErr` detects API `"approval is required"` responses; `segmentApprovalRequiredDiag` returns remediation (FROPS-190, `ignore_changes`, etc.) and **deletes the partial segment** on failed create when rollback succeeds.
> 
> **Docs:** Segment resource schema/docs note that targeting cannot be applied via Terraform when approvals are enabled.
> 
> **Tests:** Unit tests for the helpers; acceptance test `TestAccSegment_ApprovalRequired` enables approvals via the beta API and asserts bare create succeeds vs targeting create fails with the expected message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee8a9c4df84e1216beda9b6d082f1287d004e14b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/terraform-provider-launchdarkly/pull/463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->