### PR TITLE
ci: update GitHub Actions to Node 24-compatible versions (REL-14074)

### DIFF
--- a/.github/workflows/drift-report.yml
+++ b/.github/workflows/drift-report.yml
@@ -37,13 +37,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # All autogen work targets the v3 line. Without this pin a dispatch
           # from main would enumerate the v2 (SDKv2) provider against the spec
           # and report garbage drift. Drop the pin when v3 becomes `main`.
           ref: preview-v3
-      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
           cache: true

--- a/.github/workflows/generate_integration_config_pr.yml
+++ b/.github/workflows/generate_integration_config_pr.yml
@@ -8,21 +8,21 @@ jobs:
   generate-manifest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: scripts/codegen/go.mod
           cache: true
           cache-dependency-path: |
             scripts/codegen/go.sum
             go.sum
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
       - run: make generate
         env:
           LAUNCHDARKLY_ACCESS_TOKEN: ${{secrets.LAUNCHDARKLY_ACCESS_TOKEN}}
 
       - name: Create Pull request
-        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.2
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: regenerate-integration-configs/patch
           delete-branch: true

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -16,6 +16,6 @@ jobs:
     name: Validate Semantic PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       release-created: ${{ steps.release.outputs.release_created }}
       upload-tag-name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
 
   goreleaser:
@@ -21,7 +21,7 @@ jobs:
       contents: write
     if: ${{ needs.release-please.outputs.upload-tag-name != ''}}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Allow goreleaser to access older tag information.
           fetch-depth: 0
@@ -29,17 +29,17 @@ jobs:
         run: | 
           git tag ${{ needs.release-please.outputs.upload-tag-name }} 
           git push origin ${{ needs.release-please.outputs.upload-tag-name }}
-      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
           cache: true
-      - uses: crazy-max/ghaction-import-gpg@cb9bde2e2525e640591a934b1fd28eef1dcaf5e5 # v6.2.0
+      - uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         name: Import GPG key
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
-      - uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0
+      - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         name: Run GoReleaser
         with:
           args: release --clean

--- a/.github/workflows/scaffold-resource.yml
+++ b/.github/workflows/scaffold-resource.yml
@@ -78,11 +78,11 @@ jobs:
         run: |
           echo "::error::'operations' is required when 'resource_name' is set (scoped mode needs the comma-separated operationId list)."
           exit 1
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: preview-v3 # scaffolds always target the v3 line
           fetch-depth: 0
-      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
           cache: true
@@ -90,7 +90,7 @@ jobs:
       # both need a real terraform binary on PATH so the agent can regenerate
       # docs/. No LD token here — doc generation introspects the provider schema
       # offline; the token-needing integration-configs codegen is NOT run.
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_wrapper: false
       - name: Extract endpoint-family context

--- a/.github/workflows/test-fork-pr.yml
+++ b/.github/workflows/test-fork-pr.yml
@@ -31,10 +31,10 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
+      - uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           audience: https://github.com/launchdarkly
           aws-region: us-east-1
@@ -45,11 +45,11 @@ jobs:
         with:
           parameterPairs: |
             /global/services/github/terraform-provider/launchdarkly-access-token = LAUNCHDARKLY_ACCESS_TOKEN
-      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
           cache: false
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_wrapper: false
       - run: make generate
@@ -102,10 +102,10 @@ jobs:
           - TestAccView
           - TestAccWebhook
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
+      - uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           audience: https://github.com/launchdarkly
           aws-region: us-east-1
@@ -116,12 +116,12 @@ jobs:
         with:
           parameterPairs: |
             /global/services/github/terraform-provider/launchdarkly-access-token = LAUNCHDARKLY_ACCESS_TOKEN
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
           cache: false
       - run: go mod download
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_wrapper: false
       - name: Set Terraform path for acceptance tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,19 +19,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha}}
-      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
           cache: true
       - run: go mod download
       - run: go build -v .
       - name: Run linters
-        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v1.64.8
+          version: v2.12.2
           install-mode: goinstall
   
   generate:
@@ -42,10 +42,10 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
+      - uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           audience: https://github.com/launchdarkly
           aws-region: us-east-1
@@ -56,12 +56,12 @@ jobs:
         with:
           parameterPairs: |
             /global/services/github/terraform-provider/launchdarkly-access-token = LAUNCHDARKLY_ACCESS_TOKEN
-      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
           cache: true
       # We need the latest version of Terraform for our documentation generation to use
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_wrapper: false
       - run: make generate
@@ -113,10 +113,10 @@ jobs:
           - TestAccView
           - TestAccWebhook
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
+      - uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           audience: https://github.com/launchdarkly
           aws-region: us-east-1
@@ -127,11 +127,11 @@ jobs:
         with:
           parameterPairs: |
             /global/services/github/terraform-provider/launchdarkly-access-token = LAUNCHDARKLY_ACCESS_TOKEN
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
       - run: go mod download
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_wrapper: false
       - name: Set Terraform path for acceptance tests
@@ -168,7 +168,7 @@ jobs:
     steps:
       - name: Send GitHub trigger payload to Slack Workflow Builder
         id: slack
-        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           payload-delimiter: "_"
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/verify-reusable.yml
+++ b/.github/workflows/verify-reusable.yml
@@ -121,7 +121,7 @@ jobs:
             echo "pr_title=$title"
           } >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ steps.pr.outputs.head_branch }}
           fetch-depth: 0
@@ -207,7 +207,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Composed verification prompt ($(wc -c < "$pf") bytes)."
 
-      - uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0
+      - uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           audience: https://github.com/launchdarkly
           aws-region: us-east-1
@@ -223,12 +223,12 @@ jobs:
 
       # setup-go AFTER checkout so go-version-file reads the PR branch's go.mod
       # (the v3 line pins a newer Go than main).
-      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
           cache: true
       - run: go mod download
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_wrapper: false
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,20 @@
+# golangci-lint v2 configuration.
+#
+# Added alongside the golangci-lint-action v6 -> v9 bump (REL-14074, Node 24
+# migration). golangci-lint-action only ships a Node 24 runtime from v9.0.0,
+# which requires the golangci-lint v2 binary.
+#
+# golangci-lint v1 implicitly applied a set of default issue exclusions
+# (the old `issues.exclude-use-default: true`, which hid e.g. unchecked
+# `resp.Body.Close()` errcheck findings). v2 no longer applies those unless a
+# config opts in. The exclusion presets below reproduce the v1 defaults so the
+# lint job's behavior is unchanged by the version bump.
+version: "2"
+
+linters:
+  exclusions:
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling


### PR DESCRIPTION
RUBBER STAMP

## Why

GitHub is deprecating the **Node 20** Actions runtime in favor of **Node 24**; actions declaring `using: node20` now emit deprecation warnings across this repo's workflows.

## What

Bumped every action pinned to a `node20` build → its latest **Node 24** release that is **at least 7 days old** (internal stability constraint). All pins remain full-SHA + version comment.

| Action | From | To |
|---|---|---|
| actions/checkout | v4.2.2 | **v6.0.3** |
| actions/setup-go | v5.1.0 & v5.5.0 | **v6.4.0** (unified) |
| hashicorp/setup-terraform | v3.1.2 | **v4.0.1** |
| peter-evans/create-pull-request | v7.0.2 | **v8.1.1** |
| amannn/action-semantic-pull-request | v5.5.3 | **v6.1.1** |
| googleapis/release-please-action | v4.1.3 | **v5.0.0** |
| crazy-max/ghaction-import-gpg | v6.2.0 | **v7.0.0** |
| goreleaser/goreleaser-action | v6.1.0 | **v7.2.2** |
| aws-actions/configure-aws-credentials | v4.2.0 | **v6.2.0** |
| slackapi/slack-github-action | v2.0.0 | **v3.0.3** |
| golangci/golangci-lint-action | v6.1.1 | **v9.2.1** |

### golangci-lint v1 → v2 (coupled to the action bump)
`golangci-lint-action` ships a Node 24 runtime **only from v9**, which dropped golangci-lint v1 and requires the **v2 binary** — so `version:` is bumped `v1.64.8 → v2.12.2`. golangci-lint v2 no longer applies v1's implicit default exclusions, which surfaced 3 pre-existing `errcheck` findings (unchecked `resp.Body.Close()`). Added a minimal **`.golangci.yml`** (`version: "2"`) with the standard exclusion presets to reproduce v1's defaults, so lint behavior is unchanged. Verified locally: `golangci-lint v2.12.2 run ./...` → **0 issues**.

## Left unchanged (deliberate)

- **dkershner6/aws-ssm-getparameters-action** — no Node 24 release exists upstream (newest `v2.0.3` and `main` are both `node20`; unmaintained since Jan 2024). Widely used across LD repos. One node20 warning will persist until a replacement is chosen.
- **anthropics/claude-code-action** — `composite` action (no node runtime → no deprecation warning); its only nested action (`oven-sh/setup-bun`) is already `node24`. Already Node 24-clean.

## Validation

- Confirmed each target's `action.yml` declares `using: node24`; current pins were all `node20`.
- Target tags resolved to commit SHAs via the GitHub API (annotated tags dereferenced).
- YAML parses clean on all workflows.
- Input compatibility checked for every major bump (create-pull-request, configure-aws-credentials, import-gpg, goreleaser, slack v3 payload inputs, release-please manifest-mode outputs).
- golangci-lint v9.2.1 confirmed to still accept the `version` + `install-mode` inputs the workflow uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release, AWS OIDC, and the main test/lint pipeline; golangci v2 is a major linter bump, though behavior is meant to be preserved via config presets.
> 
> **Overview**
> Updates CI so workflows stop using deprecated **Node 20** action runtimes ahead of GitHub’s migration to **Node 24**. Every affected workflow keeps **full-SHA pins**; only the referenced versions change (e.g. `actions/checkout` **v4 → v6**, `actions/setup-go` unified to **v6.4.0**, `hashicorp/setup-terraform` **v3 → v4**, `aws-actions/configure-aws-credentials` **v4 → v6**, plus bumps for release, PR bots, semantic PR title, GPG import, GoReleaser, and Slack notify).
> 
> The **build** job in `test.yml` also moves **`golangci/golangci-lint-action` v6 → v9** and **`golangci-lint` v1.64.8 → v2.12.2**, because v9+ requires the v2 linter binary on Node 24. A new **`.golangci.yml`** opts into v2’s standard exclusion presets so results match v1’s implicit defaults (avoiding new `errcheck` noise without changing application code).
> 
> **`dkershner6/aws-ssm-getparameters-action`** is intentionally not bumped in this diff (no Node 24 release upstream).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23e18bfdef45f9bfe81051c7340461fcb2989e71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->