### PR TITLE
fix(driftreport): repair mapping.yaml so the drift report parses

### DIFF
--- a/scripts/driftreport/mapping.yaml
+++ b/scripts/driftreport/mapping.yaml
@@ -299,7 +299,7 @@ families:
     status: covered
     resources:
       - launchdarkly_integration_delivery_configuration
-    notes: Beta family scaffolded by the autogen pipeline (stage 2). Persistent feature store delivery configurations scoped per project/environment/integration; wraps the IntegrationDeliveryConfigurationsBetaApi via a beta client (LD-API-Version: beta). The validate endpoint is an imperative action, not modeled as a resource.
+    notes: "Beta family scaffolded by the autogen pipeline (stage 2). Persistent feature store delivery configurations scoped per project/environment/integration; wraps the IntegrationDeliveryConfigurationsBetaApi via a beta client (LD-API-Version: beta). The validate endpoint is an imperative action, not modeled as a resource."
 
   - tag: Integrations (beta)
     status: triage
@@ -341,10 +341,7 @@ families:
     status: covered
     resources:
       - launchdarkly_big_segment_store_integration
-    ignored_operations:
-      - id: getBigSegmentStoreIntegrations
-        reason: Account-wide list/index endpoint; the singular get covers declarative reads.
-    notes: Environment-scoped big-segment (persistent) store integrations backed by Redis or DynamoDB. Scaffolded by the autogen pipeline (stage 2) against the PersistentStoreIntegrationsBetaApi (LD-API-Version beta). config carries credentials and is modeled as a sensitive JSON string.
+    notes: "Environment-scoped big-segment (persistent) store integrations backed by Redis or DynamoDB. Scaffolded by the autogen pipeline (stage 2) against the PersistentStoreIntegrationsBetaApi (LD-API-Version beta). config carries credentials and is modeled as a sensitive JSON string. The account-wide list endpoint getBigSegmentStoreIntegrations is not modeled (the singular get covers declarative reads)."
 
   - tag: Projects
     status: covered


### PR DESCRIPTION
## What

Fixes two bugs in `scripts/driftreport/mapping.yaml` that made the drift report (autogen stage 1) fail with `exit 1`, which silently disabled the Foreman, the scaffolder, and the (incoming) triager — all of which parse this mapping at runtime.

## Bugs

1. **Invalid YAML (`Integration delivery configurations (beta)`).** The `notes:` value was unquoted and contained `LD-API-Version: beta`; the inner `: ` made the parser read it as a nested mapping — `yaml: mapping values are not allowed in this context`. Quoted the value.
2. **Invalid mapping (`Persistent store integrations (beta)`).** A `covered` family carried an `ignored_operations` list, which the tool only allows on `partial` families — `ignored_operations set but family status is "covered"`. Removed the list and folded its rationale (the account-wide list endpoint is not modeled) into `notes`.

Both were introduced by recent stage-2 scaffold commits (the scaffolder edits this mapping, and nothing lints it).

## Validation

`go build -o /tmp/driftreport ./scripts/driftreport && /tmp/driftreport -format json -out /tmp/d.json` now exits `0` (was `1`) — the mapping parses and validates.

## Follow-up

Worth adding a `mapping.yaml` lint to CI (and to the scaffolder's own post-step) so a future agent-written note can't silently break the pipeline again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only mapping edits with no runtime provider or API behavior changes; low blast radius aside from re-enabling the drift/autogen pipeline.
> 
> **Overview**
> Restores **`scripts/driftreport/mapping.yaml`** so stage-1 drift report and downstream autogen tools can load it again.
> 
> For **Integration delivery configurations (beta)**, the family `notes` value is now **double-quoted** so text like `LD-API-Version: beta` is not parsed as nested YAML.
> 
> For **Persistent store integrations (beta)**, **`ignored_operations`** is removed from this **`covered`** family (the validator only allows that block on **`partial`** entries). The reason the account-wide list op is not modeled is folded into **`notes`** instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 726db49946f1e35bea8dc92c6aa512c514e36c97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->