### PR TITLE
ci(driftreport): surface triage families as one-click scaffold links

### DIFF
--- a/.github/workflows/drift-report.yml
+++ b/.github/workflows/drift-report.yml
@@ -75,10 +75,16 @@ jobs:
           # the notify step also fires when any exist. Count only — names are roadmap.
           triage="$(jq '.triage_families | length' drift-report.json 2>/dev/null || echo 0)"
           echo "triage=$triage" >> "$GITHUB_OUTPUT"
-          # PUBLIC-REPO SAFETY: this run's logs/summary are world-readable, so
-          # only the yes/no fact lands here. Detail goes to the private channel.
+          # PUBLIC-REPO SAFETY: this run's logs/summary are world-readable, so only
+          # the yes/no drift fact + the triage-family COUNT land here (the count is
+          # already derivable from the public mapping.yaml). The roadmap — family
+          # names/paths/operationIds — goes only to the private Slack channel. The
+          # triage branch mirrors the drift branch's "detail sent to Slack" note so a
+          # green "no drift" run that still posted (triage families) isn't a surprise.
           if [ "$drift" = "true" ]; then
             echo "Drift detected — detail sent to the private Slack channel." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$triage" != "0" ]; then
+            echo "No drift detected. $triage family(ies) pending triage — detail sent to the private Slack channel." >> "$GITHUB_STEP_SUMMARY"
           else
             echo "No drift detected." >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/drift-report.yml
+++ b/.github/workflows/drift-report.yml
@@ -12,7 +12,12 @@
 #   2. one message per NEW endpoint family, each carrying the family's paths and
 #      a one-click link + CLI to dispatch the stage-2 scaffold workflow for it,
 #   3. one message per partial family with UNCLAIMED operations (informational —
-#      stage 2 only scaffolds NEW resources, so these need a manual PR).
+#      stage 2 only scaffolds NEW resources, so these need a manual PR),
+#   4. one message per TRIAGE family (status: triage — acknowledged but the
+#      coverage decision is still pending). NOT drift; these carry a scaffold
+#      link too (whole-family mode accepts any spec tag) but the wording keeps
+#      the "decide scope FIRST" human gate explicit. The notify step therefore
+#      runs when there is drift OR any triage family — not on drift alone.
 # Messages are POSTed individually to a SINGLE generic Slack Workflow Builder
 # webhook trigger. That trigger must declare exactly two Text variables —
 # `title` and `body` — and a "Send a message" step into the private channel.
@@ -66,6 +71,10 @@ jobs:
           fi
           drift=$([ "$code" -eq 2 ] && echo true || echo false)
           echo "drift=$drift" >> "$GITHUB_OUTPUT"
+          # Triage families (status: triage) are NOT drift but ARE dispatchable, so
+          # the notify step also fires when any exist. Count only — names are roadmap.
+          triage="$(jq '.triage_families | length' drift-report.json 2>/dev/null || echo 0)"
+          echo "triage=$triage" >> "$GITHUB_OUTPUT"
           # PUBLIC-REPO SAFETY: this run's logs/summary are world-readable, so
           # only the yes/no fact lands here. Detail goes to the private channel.
           if [ "$drift" = "true" ]; then
@@ -77,8 +86,8 @@ jobs:
       # Each POST carries {title, body}; the Workflow Builder trigger renders
       # them. PUBLIC-REPO SAFETY: family names / paths / operationIds are the
       # internal roadmap — they are passed only to curl, NEVER echoed to the log.
-      - name: Notify Slack on drift
-        if: steps.drift.outputs.drift == 'true'
+      - name: Notify Slack (drift + triage backlog)
+        if: steps.drift.outputs.drift == 'true' || steps.drift.outputs.triage != '0'
         shell: bash
         env:
           WEBHOOK: ${{ secrets.SLACK_DRIFT_WEBHOOK_URL }}
@@ -117,13 +126,16 @@ jobs:
                lbl(.stale_families | length;         "stale family";         "stale families"),
                lbl(.stale_operations | length;       "stale op claim";       "stale op claims"),
                lbl(.unmapped_resources | length;     "unmapped resource";    "unmapped resources"),
-               lbl(.registered_candidates | length;  "miscurated candidate"; "miscurated candidates")
+               lbl(.registered_candidates | length;  "miscurated candidate"; "miscurated candidates"),
+               lbl(.triage_families | length;        "triage family";        "triage families")
              ] | join(" · ")) +
             (([.new_families[].tag] + [.scaffoldable_resources[].name]) as $s
              | if ($s | length) > 0 then "\nScaffoldable: " + ($s | join(", ")) else "" end) +
+            (.triage_families as $t
+             | if ($t | length) > 0 then "\nTriage backlog (decide scope, then dispatch): " + ($t | join(", ")) else "" end) +
             "\n<\($run)|drift run>"
           ' "$JSON")"
-          post_slack "🔎 API coverage drift" "$summary_body"
+          post_slack "🔎 API coverage report" "$summary_body"
 
           # 2) One message per NEW family — scaffoldable via stage 2. Paths inline,
           # scaffold link + CLI on one line.
@@ -161,5 +173,25 @@ jobs:
             body="$(printf 'Modeled, but lagging these ops — extend the existing resource via a manual PR:\n%s' "$ops")"
             post_slack "⚠️ Coverage gap: $tag" "$body"
           done < <(jq -r '[.unclaimed_operations[].tag] | unique | .[]' "$JSON")
+
+          # 4) One message per TRIAGE family (status: triage) — acknowledged but the
+          # coverage decision is still pending, so NOT drift. These never surfaced here
+          # before (the notify step used to gate on drift alone). They ARE dispatchable:
+          # scaffold-resource.yml whole-family mode accepts any spec tag and pulls the
+          # slice itself. The wording keeps the "decide scope FIRST" human gate explicit
+          # so a parked family isn't mistaken for a decided/ready one. The report carries
+          # no paths for triage families (they have no resources/operations block), so
+          # the body links to the family's spec endpoints via the dispatch, not inline.
+          # FUTURE CRON: when a weekly schedule lands (see the `on:` block), gate THIS
+          # loop behind `[ "$GITHUB_EVENT_NAME" = workflow_dispatch ]` so the static
+          # triage backlog isn't re-posted every week — only genuine drift should alert
+          # on a cron. (Harmless today: workflow_dispatch is the only trigger.)
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            # shellcheck disable=SC2016  # backticks are literal Slack mrkdwn, not command subst
+            body="$(printf 'Acknowledged but undecided — decide whether it belongs in Terraform BEFORE dispatching. If yes:\n<%s|▶ Scaffold it> · `gh workflow run scaffold-resource.yml -f family='"'"'%s'"'"'`' \
+              "$ACTIONS_URL" "$tag")"
+            post_slack "⚠️ Triage family: $tag" "$body"
+          done < <(jq -r '.triage_families[]' "$JSON")
 
           echo "Posted $sent Slack message(s)."


### PR DESCRIPTION
## Human Summary

Ensure that the "auto-dispatch" flow covers partially resource-covered features in our API, not just completely untouched ones.

## What

Adds a **block 4** to the drift report's Slack notify step (`drift-report.yml`): one message per `status: triage` family, each carrying a pre-filled `gh workflow run scaffold-resource.yml -f family='<tag>'` command + a one-click ▶ Scaffold link.

## Why

The notify step gated on drift alone (`if: drift == 'true'`). But `status: triage` families — the bulk of the V3 coverage gap (Release Management, Experimentation, the beta `Other` cluster, ~13 families) — are **not drift**: they're acknowledged-but-pending. So they never surfaced in Slack and had **no trigger path** at all, even though `scaffold-resource.yml` whole-family mode already accepts any spec tag and can build them.

This closes the gap between "the drift tool knows about a parked family" and "an operator can dispatch a scaffold for it in one click" — without changing the family's `triage` status or the human scope-decision gate.

## Changes (one file, +37/−5)

- New `triage` output on the drift step (count of `triage_families`).
- Notify step now runs on **drift OR any triage family**; renamed to `Notify Slack (drift + triage backlog)`.
- Summary message gains a triage tally + a `Triage backlog (decide scope, then dispatch): …` line; title generalized to `🔎 API coverage report` (accurate when there's no drift).
- Block 4 posts one `⚠️ Triage family: <tag>` message each, wording keeps **"decide whether it belongs in Terraform BEFORE dispatching"** explicit.

## Deliberately scoped out

- **`triage_operations`** (AgentControl optimizations / restricted models / targeting): can't be one-click scaffolded — scoped mode needs a resource-name + operations split decided first. Left for a mapping promotion (`triage_operations` → `new_resource_candidates`), which then flows through the existing `scaffoldable_resources` link path.
- **Future cron**: when a weekly schedule lands, gate block 4 behind `workflow_dispatch` so the static backlog isn't re-posted weekly (noted inline; harmless today — dispatch is the only trigger).

## Validation

- `python3 yaml.safe_load` — parses.
- Ran the exact summary `jq` + block-4 `jq` against a synthetic report: correct tally, backlog line, and per-family iteration.
- Verified `gh` command quoting for a tag with spaces/parens (`-f family='Release pipelines (beta)'`) and that `jq -nc --arg` JSON-encodes the payload safely (no injection).
- No provider/Go code touched.

## Note on target branch

This workflow lives on `main` (dispatch must register on the default branch) and pins `preview-v3` for the tool checkout — so this change targets `main` directly, like the rest of the autogen pipeline YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow and private Slack messaging only; no provider, auth, or runtime behavior changes.
> 
> **Overview**
> Extends the API drift report workflow so **acknowledged-but-undecided** `status: triage` families get the same private Slack operator path as real drift, without treating them as drift.
> 
> The drift step now exports a **`triage` count** from `triage_families` in the JSON report. **Notify Slack** runs when **drift is true OR triage &gt; 0** (renamed from drift-only). The GitHub step summary explains when a green “no drift” run still posted because of triage backlog.
> 
> The Slack summary adds a **triage family** tally, a **Triage backlog** line, and the headline becomes **API coverage report**. **Block 4** posts one `⚠️ Triage family` message per tag with scaffold workflow link/CLI, with copy that **scope must be decided before dispatch**. Comments note gating block 4 on `workflow_dispatch` when a future cron is added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 396dd272f232bb340a88438ac5cf6eca527e4d12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->