### PR TITLE
fix(lint): lowercase capitalized error strings in team_member_helper (ST1005)

### DIFF
--- a/launchdarkly/team_member_helper.go
+++ b/launchdarkly/team_member_helper.go
@@ -16,10 +16,10 @@ func getTeamMemberByEmail(client *Client, memberEmail string) (*ldapi.Member, er
 	expand := "roleAttributes"
 	members, err := getMembersPaginated(client, &emailFilter, &expand, nil, 1, nil)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get team member %q: %v", memberEmail, handleLdapiErr(err))
+		return nil, fmt.Errorf("failed to get team member %q: %v", memberEmail, handleLdapiErr(err))
 	}
 	if len(members) < 1 {
-		return nil, fmt.Errorf("No member found with email %q", memberEmail)
+		return nil, fmt.Errorf("no member found with email %q", memberEmail)
 	}
 	return &members[0], nil
 }


### PR DESCRIPTION
## What
Lowercase two capitalized `fmt.Errorf` strings in `getTeamMemberByEmail` (`team_member_helper.go`) to satisfy staticcheck **ST1005** ("error strings should not be capitalized").

```diff
- fmt.Errorf("Failed to get team member %q: %v", ...)
+ fmt.Errorf("failed to get team member %q: %v", ...)
- fmt.Errorf("No member found with email %q", memberEmail)
+ fmt.Errorf("no member found with email %q", memberEmail)
```

## Why
preview-v3 lints with **golangci-lint v2 defaults** (it lacks the `.golangci.yml` that `main` carries from REL-14074). Those defaults enforce ST1005. The two strings — added in #436 (prep v3 preview) — fail the **Build** job, turning **preview-v3 itself red** and blocking every open PR against it (e.g. **#475** agent-graph, which otherwise passes all 30+ acceptance tests).

`main`'s exclusion presets (`comments`, `common-false-positives`, `legacy`, `std-error-handling`) do **not** cover ST1005, so this is a real, correct fix — not something a config merge would paper over.

## Scope
- 2 lines, no behavior change. `diags.AddError("Failed to get team member", …)` (a diagnostic *summary*/title, not an `error` value) is intentionally left capitalized — ST1005 doesn't apply to it.
- Verified: `go build ./launchdarkly/...` OK, `gofmt` clean, no test asserts the old message text.

## Follow-up (separate)
preview-v3 should also pick up `main`'s `.golangci.yml` for lint-config parity — that arrives via the planned main→preview-v3 merge, independent of this ST1005 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-line string-only change in error messages with no logic or API impact.
> 
> **Overview**
> Fixes **staticcheck ST1005** by lowercasing two `fmt.Errorf` messages in `getTeamMemberByEmail`: `"Failed to get team member..."` → `"failed to get team member..."` and `"No member found with email..."` → `"no member found with email..."`.
> 
> No runtime behavior change—only error string casing so golangci-lint (v2 defaults on preview-v3) passes the Build job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9db3c11822b3b14643b1747a66f661803e242da1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->