### PR TITLE
ci(driftreport): plain-text gh command + bare URLs for Workflow Builder

### DIFF
--- a/.github/workflows/drift-report.yml
+++ b/.github/workflows/drift-report.yml
@@ -121,6 +121,18 @@ jobs:
             sent=$((sent + 1))
           }
 
+          # scaffold_cmd <family> [resource_name] [operations]: prints the ready-to-run
+          # gh dispatch command (multi-line). Workflow Builder renders NO code blocks, so
+          # this goes out as plain text — verified paste-and-run. No backticks (WB would
+          # show them literally). Quotes survive WB un-mangled (verified).
+          scaffold_cmd() {
+            local fam="$1" name="${2:-}" ops="${3:-}"
+            printf 'gh workflow run scaffold-resource.yml \\\n  --repo %s --ref main \\\n  -f family="%s"' "$REPO" "$fam"
+            if [ -n "$name" ]; then
+              printf ' \\\n  -f resource_name="%s" \\\n  -f operations="%s"' "$name" "$ops"
+            fi
+          }
+
           # 1) Summary — one tally line (zero categories dropped) + scaffoldable
           # families + run link. The title carries the headline, so the body
           # doesn't restate it.
@@ -139,7 +151,7 @@ jobs:
              | if ($s | length) > 0 then "\nScaffoldable: " + ($s | join(", ")) else "" end) +
             (.triage_families as $t
              | if ($t | length) > 0 then "\nTriage backlog (decide scope, then dispatch): " + ($t | join(", ")) else "" end) +
-            "\n<\($run)|drift run>"
+            "\nDrift run: \($run)"
           ' "$JSON")"
           post_slack "🔎 API coverage report" "$summary_body"
 
@@ -148,10 +160,9 @@ jobs:
           while IFS= read -r fam; do
             [ -n "$fam" ] || continue
             tag="$(printf '%s' "$fam" | jq -r '.tag')"
-            paths="$(printf '%s' "$fam" | jq -r '[.paths[] | "`" + . + "`"] | join(" · ")')"
-            # shellcheck disable=SC2016  # backticks are literal Slack mrkdwn, not command subst
-            body="$(printf 'No provider resource yet. Paths: %s\n<%s|▶ Scaffold it> · `gh workflow run scaffold-resource.yml -f family='"'"'%s'"'"'`' \
-              "$paths" "$ACTIONS_URL" "$tag")"
+            paths="$(printf '%s' "$fam" | jq -r '[.paths[]] | join(" · ")')"
+            body="$(printf 'No provider resource yet.\nPaths: %s\n\nRun:\n%s\n\nActions page: %s' \
+              "$paths" "$(scaffold_cmd "$tag")" "$ACTIONS_URL")"
             post_slack "🆕 New API family: $tag" "$body"
           done < <(jq -c '.new_families[]' "$JSON")
 
@@ -163,10 +174,9 @@ jobs:
             tag="$(printf '%s' "$sr" | jq -r '.tag')"
             name="$(printf '%s' "$sr" | jq -r '.name')"
             opids="$(printf '%s' "$sr" | jq -r '[.operations[].operation_id] | join(",")')"
-            oplist="$(printf '%s' "$sr" | jq -r '[.operations[] | "• `\(.method) \(.path)`"] | join("\n")')"
-            # shellcheck disable=SC2016  # backticks are literal Slack mrkdwn, not command subst
-            body="$(printf 'Net-new resource in the `%s` family (existing resources untouched):\n%s\n<%s|▶ Scaffold it> · `gh workflow run scaffold-resource.yml -f family='"'"'%s'"'"' -f resource_name='"'"'%s'"'"' -f operations='"'"'%s'"'"'`' \
-              "$tag" "$oplist" "$ACTIONS_URL" "$tag" "$name" "$opids")"
+            oplist="$(printf '%s' "$sr" | jq -r '[.operations[] | "• \(.method) \(.path)"] | join("\n")')"
+            body="$(printf 'Net-new resource in the %s family (existing resources untouched).\nOperations:\n%s\n\nRun:\n%s\n\nActions page: %s' \
+              "$tag" "$oplist" "$(scaffold_cmd "$tag" "$name" "$opids")" "$ACTIONS_URL")"
             post_slack "🆕 New resource: $name" "$body"
           done < <(jq -c '.scaffoldable_resources[]' "$JSON")
 
@@ -174,8 +184,7 @@ jobs:
           # (stage 2 only scaffolds NEW resources, so no dispatch link).
           while IFS= read -r tag; do
             [ -n "$tag" ] || continue
-            ops="$(jq -r --arg t "$tag" '.unclaimed_operations[] | select(.tag == $t) | "• `\(.method) \(.path)` (`\(.operation_id)`)"' "$JSON")"
-            # shellcheck disable=SC2016  # backticks are literal Slack mrkdwn, not command subst
+            ops="$(jq -r --arg t "$tag" '.unclaimed_operations[] | select(.tag == $t) | "• \(.method) \(.path) (\(.operation_id))"' "$JSON")"
             body="$(printf 'Modeled, but lagging these ops — extend the existing resource via a manual PR:\n%s' "$ops")"
             post_slack "⚠️ Coverage gap: $tag" "$body"
           done < <(jq -r '[.unclaimed_operations[].tag] | unique | .[]' "$JSON")
@@ -194,9 +203,8 @@ jobs:
           # on a cron. (Harmless today: workflow_dispatch is the only trigger.)
           while IFS= read -r tag; do
             [ -n "$tag" ] || continue
-            # shellcheck disable=SC2016  # backticks are literal Slack mrkdwn, not command subst
-            body="$(printf 'Acknowledged but undecided — decide whether it belongs in Terraform BEFORE dispatching. If yes:\n<%s|▶ Scaffold it> · `gh workflow run scaffold-resource.yml -f family='"'"'%s'"'"'`' \
-              "$ACTIONS_URL" "$tag")"
+            body="$(printf 'Acknowledged but undecided — decide whether it belongs in Terraform before dispatching.\n\nRun:\n%s\n\nActions page: %s' \
+              "$(scaffold_cmd "$tag")" "$ACTIONS_URL")"
             post_slack "⚠️ Triage family: $tag" "$body"
           done < <(jq -r '.triage_families[]' "$JSON")
 

--- a/.github/workflows/verify-reusable.yml
+++ b/.github/workflows/verify-reusable.yml
@@ -320,13 +320,12 @@ jobs:
             project="$(jq -r '.project_key // ""' "$RESULT")"
             if [ "$status" = "pass" ]; then icon="✅"; else icon="⚠️"; fi
             title="$icon Scaffold PR #$PR_NUMBER verified ($status)"
-            # shellcheck disable=SC2016  # backticks are literal Slack mrkdwn, not command subst
-            body="$(printf '%s\nRetained in `%s`: <%s|open in LaunchDarkly> · <%s|PR #%s>' \
-              "$summary" "$project" "$ld_url" "$PR_URL" "$PR_NUMBER")"
+            body="$(printf '%s\nRetained in project %s\nLaunchDarkly: %s\nPR #%s: %s' \
+              "$summary" "$project" "$ld_url" "$PR_NUMBER" "$PR_URL")"
           else
             title="❌ Scaffold PR #$PR_NUMBER verification did not complete"
-            body="$(printf 'Stage-3 verification produced no result file — the run likely errored. See the <%s|workflow run> and <%s|PR #%s>.' \
-              "$RUN_URL" "$PR_URL" "$PR_NUMBER")"
+            body="$(printf 'Stage-3 verification produced no result file — the run likely errored.\nWorkflow run: %s\nPR #%s: %s' \
+              "$RUN_URL" "$PR_NUMBER" "$PR_URL")"
           fi
           payload="$(jq -nc --arg title "$title" --arg body "$body" '{title: $title, body: $body}')"
           curl -sS -f --retry 3 --retry-connrefused --retry-delay 2 \


### PR DESCRIPTION
## What
Reformat the drift-report + verify Slack message bodies to what the **Workflow Builder** webhook can actually render. No interactive buttons (Slack app deferred), no new infra.

## Why
The notifications post via a WB "Send a message" step, which renders variables as **escaped plain text** — it does *not* interpret Slack mrkdwn `<url|label>` links or fenced code blocks. **Verified against the channel:**
- `<url|▶ Scaffold it>` came through as mangled `&lt;…&gt;|…&gt;` text (broken links).
- ```` ``` ```` code blocks rendered as literal backticks, non-monospace.
- **Bare URLs render as clickable links** ✓, and straight quotes survive un-mangled ✓.

## Changes
- New `scaffold_cmd` helper → emits a multi-line, **fully pre-filled** `gh workflow run` command (`--repo`/`--ref` + scoped `resource_name`/`operations`) as plain text. Better than a link button, which can't pre-fill `workflow_dispatch` inputs.
- Every `<url|label>` → bare URL (drift-run link, Actions-page link, verify LD/PR links).
- Stripped backticks WB shows literally (paths, op lists).
- Same bare-URL fix in `verify-reusable.yml` pass/fail messages.

## Verification
- Both files parse (`yaml.safe_load`).
- Simulated the bash: triage + scoped bodies render clean multi-line commands; families with spaces/parens quote correctly (`family="Release pipelines (beta)"`); `jq -nc --arg` JSON-encodes valid (`\\`, `\n`, `\"`).
- Earlier live WB test (manual webhook fire) confirmed bare URLs link + code blocks don't — this PR is the response to that.

## Ground-truth test after merge
WB rendering can only be fully confirmed by a real run: dispatch `drift-report.yml` once merged and eyeball the channel.

## Deferred / follow-ups
- Slack app + Block Kit (real code blocks w/ copy buttons + interactive buttons) — deferred; needs admin approval + (for buttons) an inbound endpoint.
- Factoring the two near-identical `post_slack`/notify blocks into one shared snippet — left for a separate refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI notification formatting only; no runtime, auth, or provider behavior changes.
> 
> **Overview**
> Reformats **drift-report** and **verify-reusable** Slack notification bodies so they render correctly through the **Workflow Builder** webhook (plain text only—no mrkdwn links or backticks).
> 
> In **drift-report.yml**, adds a **`scaffold_cmd`** helper that emits a multi-line, pre-filled `gh workflow run scaffold-resource.yml` command (`--repo`, `--ref`, and optional `resource_name` / `operations`). New-family, net-new-resource, and triage messages now use **Run:** + that command and **Actions page:** with a bare URL instead of `<url|label>` links and inline one-liner `gh` snippets. Summary drift-run links, path/op listings, and unclaimed-op bullets drop backticks for plain text.
> 
> In **verify-reusable.yml**, pass/fail Slack bodies replace mrkdwn links with labeled lines (**LaunchDarkly**, **PR #**, **Workflow run**) using bare URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82b5cfe7cd76666eee379981f473dc9407028e6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->