### PR TITLE
feat(feature_flag_environment): make off_variation optional to model "Not set" (#482)

### DIFF
--- a/docs/data-sources/feature_flag_environment.md
+++ b/docs/data-sources/feature_flag_environment.md
@@ -35,7 +35,7 @@ data "launchdarkly_feature_flag_environment" "example" {
 - `context_targets` (Attributes Set) Individual context-kind targets per variation. (see [below for nested schema](#nestedatt--context_targets))
 - `fallthrough` (Attributes) Default variation served when no other targeting applies. (see [below for nested schema](#nestedatt--fallthrough))
 - `id` (String) Composite ID `project_key/env_key/flag_key`.
-- `off_variation` (Number) Variation index to serve when targeting is disabled.
+- `off_variation` (Number) The index of the variation to serve when targeting is off. This is null when the environment has no off variation set (the UI's "Not set" state), which is distinct from a value of `0`.
 - `on` (Boolean) Whether targeting is enabled.
 - `prerequisites` (Attributes List) Prerequisite flag rules. (see [below for nested schema](#nestedatt--prerequisites))
 - `rules` (Attributes List) Logical targeting rules. (see [below for nested schema](#nestedatt--rules))

--- a/docs/guides/v3-release-notes.md
+++ b/docs/guides/v3-release-notes.md
@@ -139,6 +139,7 @@ This table lists the new resources, their data sources, and their API stability:
 
 - `launchdarkly_environment` gains a `segment_approval_settings` attribute. This attribute configures approval requirements for segment changes.
 - `launchdarkly_feature_flag` validates prerequisite-flag removals at plan time. If you remove a flag that another flag depends on, the provider surfaces a warning during plan instead of failing at apply.
+- `launchdarkly_feature_flag_environment` makes `off_variation` optional. In v2 it was required. Omitting it now leaves the off variation unset, matching the LaunchDarkly UI's "Not set" state, and removing a previously configured value clears it. Note the behavior change: when the off variation is unset and targeting is off, LaunchDarkly serves no variation, so SDKs return the application-provided default value and the evaluation carries a null variation index (which affects Data Export and Experimentation). Setting `off_variation = 0` remains a distinct, valid configuration. This resolves issue #482.
 
 ## Bug fixes
 

--- a/docs/resources/feature_flag_environment.md
+++ b/docs/resources/feature_flag_environment.md
@@ -197,11 +197,11 @@ resource "launchdarkly_feature_flag_environment" "big_flag_environment" {
 - `env_key` (String) The environment key. A change in this field will force the destruction of the existing resource and the creation of a new one.
 - `fallthrough` (Attributes) The default variation to serve if no `prerequisites`, `target`, or `rules` apply. (see [below for nested schema](#nestedatt--fallthrough))
 - `flag_id` (String) The feature flag's unique `id` in the format `project_key/flag_key`. A change in this field will force the destruction of the existing resource and the creation of a new one.
-- `off_variation` (Number) The index of the variation to serve if targeting is disabled.
 
 ### Optional
 
 - `context_targets` (Attributes Set) Individual targets for non-user context kinds for each variation. (see [below for nested schema](#nestedatt--context_targets))
+- `off_variation` (Number) The index of the variation to serve when targeting is off. Omitting this attribute leaves the off variation unset (the UI's "Not set" state), which is distinct from setting it to `0`. When it is unset and targeting is off, LaunchDarkly serves no variation: SDKs return the application-provided default value and the evaluation carries a null variation index, which affects Data Export and Experimentation.
 - `on` (Boolean) Whether targeting is enabled. Defaults to `false` if not set.
 - `prerequisites` (Attributes List) Prerequisite feature flag rules. (see [below for nested schema](#nestedatt--prerequisites))
 - `rules` (Attributes List) List of logical targeting rules. (see [below for nested schema](#nestedatt--rules))

--- a/launchdarkly/data_source_feature_flag_environment_framework.go
+++ b/launchdarkly/data_source_feature_flag_environment_framework.go
@@ -82,7 +82,7 @@ func (d *FeatureFlagEnvironmentDataSource) Schema(_ context.Context, _ datasourc
 			TRACK_EVENTS: schema.BoolAttribute{Computed: true, Description: "Whether to send event data back to LaunchDarkly."},
 			OFF_VARIATION: schema.Int64Attribute{
 				Computed:    true,
-				Description: "Variation index to serve when targeting is disabled.",
+				Description: "The index of the variation to serve when targeting is off. This is null when the environment has no off variation set (the UI's \"Not set\" state), which is distinct from a value of `0`.",
 			},
 			TARGETS: schema.SetNestedAttribute{
 				Computed:    true,
@@ -218,7 +218,9 @@ func (d *FeatureFlagEnvironmentDataSource) Read(ctx context.Context, req datasou
 	if environment.OffVariation != nil {
 		data.OffVariation = types.Int64Value(int64(*environment.OffVariation))
 	} else {
-		data.OffVariation = types.Int64Value(0)
+		// No offVariation on the environment ("Not set") — report null rather
+		// than a misleading literal index 0.
+		data.OffVariation = types.Int64Null()
 	}
 
 	// targets / context_targets

--- a/launchdarkly/feature_flag_environment_patches_test.go
+++ b/launchdarkly/feature_flag_environment_patches_test.go
@@ -1,0 +1,100 @@
+package launchdarkly
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+// ffeTestBaselineModel returns a minimal, valid FeatureFlagEnvironmentResourceModel
+// with all collection attributes null and a concrete fallthrough, so
+// buildFFEPatches can run without error. Individual tests override
+// OffVariation.
+func ffeTestBaselineModel(t *testing.T) FeatureFlagEnvironmentResourceModel {
+	t.Helper()
+	fallthrough_, d := types.ObjectValue(ffeFallthroughAttrTypes, map[string]attr.Value{
+		VARIATION:       types.Int64Value(0),
+		BUCKET_BY:       types.StringNull(),
+		CONTEXT_KIND:    types.StringNull(),
+		ROLLOUT_WEIGHTS: types.ListNull(types.Int64Type),
+	})
+	require.False(t, d.HasError(), "failed to build baseline fallthrough object: %v", d)
+	return FeatureFlagEnvironmentResourceModel{
+		On:             types.BoolValue(false),
+		TrackEvents:    types.BoolValue(false),
+		Rules:          types.ListNull(types.ObjectType{AttrTypes: ffeRuleAttrTypes}),
+		Prerequisites:  types.ListNull(types.ObjectType{AttrTypes: ffePrerequisiteAttrTypes}),
+		Targets:        types.SetNull(types.ObjectType{AttrTypes: ffeTargetAttrTypes}),
+		ContextTargets: types.SetNull(types.ObjectType{AttrTypes: ffeTargetAttrTypes}),
+		Fallthrough:    fallthrough_,
+	}
+}
+
+// TestBuildFFEPatches_OffVariation locks in the issue #482 behavior, in
+// particular that a null off_variation only produces a JSON Patch remove when
+// the live environment actually has an offVariation — LaunchDarkly returns 400
+// invalid_patch on a remove of an absent path (Cursor Bugbot finding on PR
+// #483).
+func TestBuildFFEPatches_OffVariation(t *testing.T) {
+	const envKey = "test"
+	offPath := ffePatchPath(envKey, "offVariation")
+
+	// find returns the op of the offVariation patch, or "" if absent.
+	find := func(t *testing.T, plan, state FeatureFlagEnvironmentResourceModel, isCreate, live bool) string {
+		t.Helper()
+		patches, d := buildFFEPatches(context.Background(), envKey, plan, state, isCreate, live)
+		require.False(t, d.HasError(), "buildFFEPatches errored: %v", d)
+		for _, p := range patches {
+			if p.Path == offPath {
+				return p.Op
+			}
+		}
+		return ""
+	}
+
+	t.Run("create, value set -> replace", func(t *testing.T) {
+		plan := ffeTestBaselineModel(t)
+		plan.OffVariation = types.Int64Value(1)
+		require.Equal(t, "replace", find(t, plan, FeatureFlagEnvironmentResourceModel{}, true, false))
+	})
+
+	t.Run("create, null, live default present -> remove", func(t *testing.T) {
+		plan := ffeTestBaselineModel(t)
+		plan.OffVariation = types.Int64Null()
+		require.Equal(t, "remove", find(t, plan, FeatureFlagEnvironmentResourceModel{}, true, true))
+	})
+
+	t.Run("create, null, env already Not set -> no patch", func(t *testing.T) {
+		plan := ffeTestBaselineModel(t)
+		plan.OffVariation = types.Int64Null()
+		// live=false: a remove here would 400 invalid_patch.
+		require.Equal(t, "", find(t, plan, FeatureFlagEnvironmentResourceModel{}, true, false))
+	})
+
+	t.Run("update, set -> null with prior value -> remove", func(t *testing.T) {
+		plan := ffeTestBaselineModel(t)
+		plan.OffVariation = types.Int64Null()
+		state := ffeTestBaselineModel(t)
+		state.OffVariation = types.Int64Value(2)
+		require.Equal(t, "remove", find(t, plan, state, false, true))
+	})
+
+	t.Run("update, null -> null (already unset) -> no patch", func(t *testing.T) {
+		plan := ffeTestBaselineModel(t)
+		plan.OffVariation = types.Int64Null()
+		state := ffeTestBaselineModel(t)
+		state.OffVariation = types.Int64Null()
+		require.Equal(t, "", find(t, plan, state, false, false))
+	})
+
+	t.Run("update, null -> 0 sets a valid, distinct value -> replace", func(t *testing.T) {
+		plan := ffeTestBaselineModel(t)
+		plan.OffVariation = types.Int64Value(0)
+		state := ffeTestBaselineModel(t)
+		state.OffVariation = types.Int64Null()
+		require.Equal(t, "replace", find(t, plan, state, false, false))
+	})
+}

--- a/launchdarkly/resource_feature_flag_environment_framework.go
+++ b/launchdarkly/resource_feature_flag_environment_framework.go
@@ -96,9 +96,9 @@ func featureFlagEnvironmentSchemaAttributes() map[string]schema.Attribute {
 			Description: "Whether to send event data back to LaunchDarkly. Defaults to `false` if not set.",
 		},
 		OFF_VARIATION: schema.Int64Attribute{
-			Required:    true,
+			Optional:    true,
 			Validators:  []validator.Int64{int64validator.AtLeast(0)},
-			Description: "The index of the variation to serve if targeting is disabled.",
+			Description: "The index of the variation to serve when targeting is off. Omitting this attribute leaves the off variation unset (the UI's \"Not set\" state), which is distinct from setting it to `0`. When it is unset and targeting is off, LaunchDarkly serves no variation: SDKs return the application-provided default value and the evaluation carries a null variation index, which affects Data Export and Experimentation.",
 		},
 		TARGETS: schema.SetNestedAttribute{
 			Optional:    true,
@@ -547,7 +547,9 @@ func (r *FeatureFlagEnvironmentResource) readIntoModel(ctx context.Context, proj
 	if environment.OffVariation != nil {
 		data.OffVariation = types.Int64Value(int64(*environment.OffVariation))
 	} else {
-		data.OffVariation = types.Int64Value(0)
+		// No offVariation on the environment ("Not set") — model as null so
+		// it round-trips instead of collapsing to a literal index 0.
+		data.OffVariation = types.Int64Null()
 	}
 
 	noopDiags := noopDiagSink{}
@@ -712,9 +714,18 @@ func buildFFEPatches(ctx context.Context, envKey string, plan, state FeatureFlag
 	if isCreate || !plan.On.Equal(state.On) {
 		patches = append(patches, patchReplace(ffePatchPath(envKey, "on"), plan.On.ValueBool()))
 	}
-	if isCreate {
-		patches = append(patches, patchReplace(ffePatchPath(envKey, "offVariation"), int32(plan.OffVariation.ValueInt64())))
-	} else if !plan.OffVariation.Equal(state.OffVariation) {
+	// off_variation is optional: a null value models LD's "Not set" state
+	// (no offVariation field on the environment). LaunchDarkly initialises
+	// every environment's offVariation to the flag's default when the flag
+	// is created, so to honour a null we must emit a JSON Patch remove —
+	// merely omitting the patch would leave the default in place and trip
+	// the "inconsistent result after apply" check. On update we only remove
+	// when a value was previously set (removing an absent path errors).
+	if plan.OffVariation.IsNull() {
+		if isCreate || !state.OffVariation.IsNull() {
+			patches = append(patches, patchRemove(ffePatchPath(envKey, "offVariation")))
+		}
+	} else if isCreate || !plan.OffVariation.Equal(state.OffVariation) {
 		patches = append(patches, patchReplace(ffePatchPath(envKey, "offVariation"), int32(plan.OffVariation.ValueInt64())))
 	}
 	if isCreate || !plan.TrackEvents.Equal(state.TrackEvents) {

--- a/launchdarkly/resource_feature_flag_environment_framework.go
+++ b/launchdarkly/resource_feature_flag_environment_framework.go
@@ -311,7 +311,25 @@ func (r *FeatureFlagEnvironmentResource) Create(ctx context.Context, req resourc
 		return
 	}
 
-	patches, d := buildFFEPatches(ctx, envKey, plan, FeatureFlagEnvironmentResourceModel{}, true)
+	// When off_variation is omitted we may need to remove the offVariation LD
+	// seeded from the flag default. Determine whether one is actually present
+	// first — a remove of an absent path returns 400 invalid_patch, which
+	// would otherwise block create for an environment already in "Not set".
+	offVariationLiveSet := false
+	if plan.OffVariation.IsNull() {
+		flag, _, gerr := getFeatureFlagEnvironment(r.client, projectKey, flagKey, envKey)
+		if gerr != nil {
+			resp.Diagnostics.AddError(fmt.Sprintf("failed to read flag %q of project %q before create: %s", flagKey, projectKey, handleLdapiErr(gerr).Error()), "")
+			return
+		}
+		if flag.Environments != nil {
+			if env, ok := (*flag.Environments)[envKey]; ok && env.OffVariation != nil {
+				offVariationLiveSet = true
+			}
+		}
+	}
+
+	patches, d := buildFFEPatches(ctx, envKey, plan, FeatureFlagEnvironmentResourceModel{}, true, offVariationLiveSet)
 	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -398,7 +416,9 @@ func (r *FeatureFlagEnvironmentResource) Update(ctx context.Context, req resourc
 		return
 	}
 
-	patches, d := buildFFEPatches(ctx, envKey, plan, state, false)
+	// state is post-refresh, so its off_variation presence mirrors the live
+	// environment — a safe basis for deciding whether a remove is valid.
+	patches, d := buildFFEPatches(ctx, envKey, plan, state, false, !state.OffVariation.IsNull())
 	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -707,7 +727,11 @@ type ffeFallthroughPayload struct {
 // buildFFEPatches assembles the JSON-Patch document applied at
 // Create/Update. Each attribute is patched only when it differs from
 // state (or unconditionally on create).
-func buildFFEPatches(ctx context.Context, envKey string, plan, state FeatureFlagEnvironmentResourceModel, isCreate bool) ([]ldapi.PatchOperation, diag.Diagnostics) {
+// offVariationLiveSet reports whether the live environment currently has an
+// offVariation. The caller supplies it because a JSON Patch remove of an
+// absent path returns 400 invalid_patch from LaunchDarkly: Update derives it
+// from the post-refresh state, Create reads it from the API.
+func buildFFEPatches(ctx context.Context, envKey string, plan, state FeatureFlagEnvironmentResourceModel, isCreate, offVariationLiveSet bool) ([]ldapi.PatchOperation, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	patches := make([]ldapi.PatchOperation, 0)
 
@@ -717,12 +741,13 @@ func buildFFEPatches(ctx context.Context, envKey string, plan, state FeatureFlag
 	// off_variation is optional: a null value models LD's "Not set" state
 	// (no offVariation field on the environment). LaunchDarkly initialises
 	// every environment's offVariation to the flag's default when the flag
-	// is created, so to honour a null we must emit a JSON Patch remove —
-	// merely omitting the patch would leave the default in place and trip
-	// the "inconsistent result after apply" check. On update we only remove
-	// when a value was previously set (removing an absent path errors).
+	// is created, so honouring a null generally means emitting a JSON Patch
+	// remove — merely omitting the patch would leave the default in place and
+	// trip the "inconsistent result after apply" check. We only remove when
+	// the live environment actually has an offVariation, because a remove of
+	// an absent path returns 400 invalid_patch.
 	if plan.OffVariation.IsNull() {
-		if isCreate || !state.OffVariation.IsNull() {
+		if offVariationLiveSet {
 			patches = append(patches, patchRemove(ffePatchPath(envKey, "offVariation")))
 		}
 	} else if isCreate || !plan.OffVariation.Equal(state.OffVariation) {

--- a/launchdarkly/resource_launchdarkly_feature_flag_environment_test.go
+++ b/launchdarkly/resource_launchdarkly_feature_flag_environment_test.go
@@ -69,7 +69,34 @@ resource "launchdarkly_feature_flag_environment" "basic" {
 }
 `
 
-	testAccFeatureFlagEnvironmentUpdate = `	
+	// off_variation is omitted entirely. LaunchDarkly initialises the env's
+	// offVariation to the flag default (2) on flag creation, so the provider
+	// must actively remove it to model the UI's "Not set" state (issue #482).
+	testAccFeatureFlagEnvironmentNoOffVariation = `
+resource "launchdarkly_feature_flag" "basic" {
+	project_key = launchdarkly_project.test.key
+	key = "basic-flag"
+	name = "Basic feature flag"
+	variation_type = "number"
+	variations = [{
+		value = 10
+	}, {
+		value = 20
+	}, {
+		value = 30
+	}]
+}
+
+resource "launchdarkly_feature_flag_environment" "basic" {
+	flag_id 		  = launchdarkly_feature_flag.basic.id
+	env_key 		  = "test"
+	fallthrough = {
+		variation = 0
+	}
+}
+`
+
+	testAccFeatureFlagEnvironmentUpdate = `
 resource "launchdarkly_feature_flag" "basic" {
 	project_key = launchdarkly_project.test.key
 	key = "basic-flag"
@@ -712,6 +739,53 @@ func TestAccFeatureFlagEnvironment_Empty(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccFeatureFlagEnvironment_OffVariationUnset exercises issue #482:
+// off_variation must be omittable (modelling LD's "Not set" state) and
+// round-trip cleanly through create (remove flag default), set, and
+// remove-again (set->null) without a perpetual diff.
+func TestAccFeatureFlagEnvironment_OffVariationUnset(t *testing.T) {
+	projectKey := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resourceName := "launchdarkly_feature_flag_environment.basic"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with off_variation omitted -> "Not set" (null, not 0).
+			{
+				Config: withRandomProject(projectKey, testAccFeatureFlagEnvironmentNoOffVariation),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFeatureFlagEnvironmentExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, ON, "false"),
+					resource.TestCheckNoResourceAttr(resourceName, OFF_VARIATION),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Set a concrete value -> patchReplace.
+			{
+				Config: withRandomProject(projectKey, testAccFeatureFlagEnvironmentEmpty),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFeatureFlagEnvironmentExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, OFF_VARIATION, "2"),
+				),
+			},
+			// Remove again -> patchRemove, back to null.
+			{
+				Config: withRandomProject(projectKey, testAccFeatureFlagEnvironmentNoOffVariation),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFeatureFlagEnvironmentExists(resourceName),
+					resource.TestCheckNoResourceAttr(resourceName, OFF_VARIATION),
+				),
 			},
 		},
 	})

--- a/templates/guides/v3-release-notes.md.tmpl
+++ b/templates/guides/v3-release-notes.md.tmpl
@@ -139,6 +139,7 @@ This table lists the new resources, their data sources, and their API stability:
 
 - `launchdarkly_environment` gains a `segment_approval_settings` attribute. This attribute configures approval requirements for segment changes.
 - `launchdarkly_feature_flag` validates prerequisite-flag removals at plan time. If you remove a flag that another flag depends on, the provider surfaces a warning during plan instead of failing at apply.
+- `launchdarkly_feature_flag_environment` makes `off_variation` optional. In v2 it was required. Omitting it now leaves the off variation unset, matching the LaunchDarkly UI's "Not set" state, and removing a previously configured value clears it. Note the behavior change: when the off variation is unset and targeting is off, LaunchDarkly serves no variation, so SDKs return the application-provided default value and the evaluation carries a null variation index (which affects Data Export and Experimentation). Setting `off_variation = 0` remains a distinct, valid configuration. This resolves issue #482.
 
 ## Bug fixes
 


### PR DESCRIPTION
## What

Makes `off_variation` **optional** on `launchdarkly_feature_flag_environment` (and reports it faithfully on the data source), so a config can model the LaunchDarkly UI's **"Not set"** state — an environment with no `offVariation`. 

Before: `off_variation` was `Required`, so users had to supply a concrete index even though the API/UI support "no off variation".

## How

- **Schema** — `Required` → `Optional`.
- **Create/Update** (`buildFFEPatches`) — when the plan value is null, emit a JSON Patch **remove**. LaunchDarkly initialises every environment's `offVariation` to the flag default at flag creation, so a bare omit would leave that default in place and trip the framework's *"inconsistent result after apply"* check. Update only removes when a value was previously set (removing an absent path errors). Otherwise `replace` as before.
- **Read** — a nil API `offVariation` maps to `null` instead of a literal `0`, so `0` stays distinct from unset. Data source read does the same.
- Docs regenerated; added a note to the v3 release-notes guide.

## Evaluation semantics (why the doc note matters)

Traced end-to-end (engine `go-server-sdk-evaluation` + client `go-server-sdk`): when the off variation is **unset** and targeting is off, the evaluator returns no value / no variation index / reason `OFF`, and the SDK client substitutes the **application-provided default**. Consequences, now documented on the attribute and in the release notes:

- The off value is no longer LD-controlled — each call site's code default decides it.
- Evaluations carry a **null variation index**, which affects Data Export and Experimentation.

This is intentional, documented LD behavior; the provider now exposes it. `off_variation = 0` remains a distinct, valid configuration.

## Testing

Adds acceptance test `TestAccFeatureFlagEnvironment_OffVariationUnset` (create-omit → set → remove).

Verified against a real account via local `plan`/`apply`:

| Scenario | Result |
|---|---|
| Create, `off_variation` omitted | env `offVariation` absent (flag default removed), state null, no perpetual diff |
| Set `= 1` | API `offVariation = 1` |
| Remove (set → null) | API `offVariation` absent |
| External drift (`= 2` via API) | plan reverts to config |
| Explicit `= 0` | API `offVariation = 0` present, distinct from absent |

`make build`, `go vet`, `gofmtcheck`, and the new acceptance test all pass.

## Notes

- Base branch is `preview-v3` (v3 is where the fix lands; v2 SDKv2 cannot round-trip a null int cleanly).
- `Required` → `Optional` is backward compatible for existing configs. The behavior change to call out: omitting `off_variation` now means "Not set", not "keep current" — surfaced in the release-notes guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes flag evaluation when `off_variation` is omitted (SDK defaults vs LD-controlled off value) and alters create/update API patching; existing configs that set a value are unchanged.
> 
> **Overview**
> Makes **`off_variation` optional** on `launchdarkly_feature_flag_environment` and aligns the data source so unset maps to **null**, not index `0`, matching LaunchDarkly’s **“Not set”** UI.
> 
> **Patching:** When the plan omits or clears `off_variation`, `buildFFEPatches` emits a JSON Patch **remove** only if the live env already has `offVariation` (avoids API `400 invalid_patch`). Create probes the API when needed; update uses refreshed state. Explicit values still use **replace**, including `off_variation = 0`.
> 
> **Docs:** Resource/data source schema text and v3 release notes describe unset vs `0` and SDK evaluation when targeting is off.
> 
> **Tests:** Unit tests for patch ops plus acceptance `TestAccFeatureFlagEnvironment_OffVariationUnset` (omit → set → clear).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5341c9c4b5704af747c42978117b83075f0ff744. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->