### PR TITLE
fix: [REL-14260] add note about global vs custom configs to AI model config documentation

### DIFF
--- a/docs/resources/model_config.md
+++ b/docs/resources/model_config.md
@@ -4,8 +4,7 @@ page_title: "launchdarkly_model_config Resource - launchdarkly"
 subcategory: ""
 description: |-
   Provides a LaunchDarkly custom model config resource.
-  This resource allows you to create and manage custom AI model configurations within your LaunchDarkly project. If you wish to use global model configurations in Terraform, you can import them using the launchdarkly_model_config data source.
-  Since the API does not support updates, any field change will force recreation of the resource.
+  This resource allows you to create and manage custom AI model configurations within your LaunchDarkly project. Since the API does not support updates, any field change will force recreation of the resource.
   ~> Important: If an launchdarkly_ai_config_variation references this model config via model_config_key, use a Terraform resource reference (e.g. launchdarkly_model_config.example.key) so Terraform can order destruction correctly. A literal string key will cause the delete to fail because the API rejects deleting a model config that is still in use.
 ---
 
@@ -13,9 +12,7 @@ description: |-
 
 Provides a LaunchDarkly custom model config resource.
 
-This resource allows you to create and manage custom AI model configurations within your LaunchDarkly project. If you wish to use global model configurations in Terraform, you can import them using the `launchdarkly_model_config` data source. 
-
-Since the API does not support updates, any field change will force recreation of the resource.
+This resource allows you to create and manage custom AI model configurations within your LaunchDarkly project. Since the API does not support updates, any field change will force recreation of the resource.
 
 ~> **Important:** If an `launchdarkly_ai_config_variation` references this model config via `model_config_key`, use a Terraform resource reference (e.g. `launchdarkly_model_config.example.key`) so Terraform can order destruction correctly. A literal string key will cause the delete to fail because the API rejects deleting a model config that is still in use.
 

--- a/docs/resources/model_config.md
+++ b/docs/resources/model_config.md
@@ -3,16 +3,19 @@
 page_title: "launchdarkly_model_config Resource - launchdarkly"
 subcategory: ""
 description: |-
-  Provides a LaunchDarkly model config resource.
-  This resource allows you to create and manage AI model configurations within your LaunchDarkly project. Since the API does not support updates, any field change will force recreation of the resource.
+  Provides a LaunchDarkly custom model config resource.
+  This resource allows you to create and manage custom AI model configurations within your LaunchDarkly project. If you wish to use global model configurations in Terraform, you can import them using the launchdarkly_model_config data source.
+  Since the API does not support updates, any field change will force recreation of the resource.
   ~> Important: If an launchdarkly_ai_config_variation references this model config via model_config_key, use a Terraform resource reference (e.g. launchdarkly_model_config.example.key) so Terraform can order destruction correctly. A literal string key will cause the delete to fail because the API rejects deleting a model config that is still in use.
 ---
 
 # launchdarkly_model_config (Resource)
 
-Provides a LaunchDarkly model config resource.
+Provides a LaunchDarkly custom model config resource.
 
-This resource allows you to create and manage AI model configurations within your LaunchDarkly project. Since the API does not support updates, any field change will force recreation of the resource.
+This resource allows you to create and manage custom AI model configurations within your LaunchDarkly project. If you wish to use global model configurations in Terraform, you can import them using the `launchdarkly_model_config` data source. 
+
+Since the API does not support updates, any field change will force recreation of the resource.
 
 ~> **Important:** If an `launchdarkly_ai_config_variation` references this model config via `model_config_key`, use a Terraform resource reference (e.g. `launchdarkly_model_config.example.key`) so Terraform can order destruction correctly. A literal string key will cause the delete to fail because the API rejects deleting a model config that is still in use.
 

--- a/launchdarkly/resource_launchdarkly_model_config.go
+++ b/launchdarkly/resource_launchdarkly_model_config.go
@@ -24,9 +24,7 @@ func resourceModelConfig() *schema.Resource {
 
 		Description: `Provides a LaunchDarkly custom model config resource.
 
-This resource allows you to create and manage custom AI model configurations within your LaunchDarkly project. If you wish to use global model configurations in Terraform, you can import them using the ` + "`launchdarkly_model_config`" + ` data source. 
-
-Since the API does not support updates, any field change will force recreation of the resource.
+This resource allows you to create and manage custom AI model configurations within your LaunchDarkly project. Since the API does not support updates, any field change will force recreation of the resource.
 
 ~> **Important:** If an ` + "`launchdarkly_ai_config_variation`" + ` references this model config via ` + "`model_config_key`" + `, use a Terraform resource reference (e.g. ` + "`launchdarkly_model_config.example.key`" + `) so Terraform can order destruction correctly. A literal string key will cause the delete to fail because the API rejects deleting a model config that is still in use.`,
 

--- a/launchdarkly/resource_launchdarkly_model_config.go
+++ b/launchdarkly/resource_launchdarkly_model_config.go
@@ -22,9 +22,11 @@ func resourceModelConfig() *schema.Resource {
 			StateContext: resourceModelConfigImport,
 		},
 
-		Description: `Provides a LaunchDarkly model config resource.
+		Description: `Provides a LaunchDarkly custom model config resource.
 
-This resource allows you to create and manage AI model configurations within your LaunchDarkly project. Since the API does not support updates, any field change will force recreation of the resource.
+This resource allows you to create and manage custom AI model configurations within your LaunchDarkly project. If you wish to use global model configurations in Terraform, you can import them using the ` + "`launchdarkly_model_config`" + ` data source. 
+
+Since the API does not support updates, any field change will force recreation of the resource.
 
 ~> **Important:** If an ` + "`launchdarkly_ai_config_variation`" + ` references this model config via ` + "`model_config_key`" + `, use a Terraform resource reference (e.g. ` + "`launchdarkly_model_config.example.key`" + `) so Terraform can order destruction correctly. A literal string key will cause the delete to fail because the API rejects deleting a model config that is still in use.`,
 


### PR DESCRIPTION
Following some reported confusion, just a quick note to the AI model config resource doc to specify that it is specifically for custom model configs (not global).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording updates with no runtime or API impact.
> 
> **Overview**
> Clarifies in **`launchdarkly_model_config`** docs that the resource manages **custom** AI model configurations (not LaunchDarkly **global** model configs).
> 
> The same wording is updated in **`docs/resources/model_config.md`** and the resource **`Description`** in **`resource_launchdarkly_model_config.go`** so generated registry docs stay aligned. No schema, API, or behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db818a0b373429f26b54aabbdbcaddc5eabdf505. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->