### PR TITLE
docs: align skills and guides with the v3.0.0-beta.4 release

### DIFF
--- a/.claude/skills/terraform-provider-block-to-nested-attrs/SKILL.md
+++ b/.claude/skills/terraform-provider-block-to-nested-attrs/SKILL.md
@@ -12,7 +12,7 @@ metadata:
 The LaunchDarkly Terraform provider v3.0.0 finished the migration from `terraform-plugin-sdk/v2` to `terraform-plugin-framework`. Every former `schema.Block` is now a nested attribute. HCL that worked against v2.x using block syntax (`name { ... }`) fails to parse against v3 with `Unsupported block type` or `Missing required argument`. The fix is mechanical, but the target syntax depends on the attribute's cardinality:
 
 - **List/Set nested attributes** (genuinely plural, e.g. `variations`, `rules`, `statements`) → `name = [{ ... }]`.
-- **Single nested attributes** (genuinely one object — `client_side_availability`, `defaults`, `default_client_side_availability`, `fallthrough`, `approval_settings`, `segment_approval_settings`, `instructions`, `boolean_defaults`) → `name = { ... }`. These were modeled as max-1 lists through `3.0.0-beta.3` and switched to single objects in `3.0.0-beta.4` (REL-14237), so the bracketless object form is the correct syntax from `3.0.0-beta.4` on, including GA. **Only on `3.0.0-beta.1`–`beta.3` use the list form `= [{ ... }]` instead.**
+- **Single nested attributes** (genuinely one object — `client_side_availability`, `defaults`, `default_client_side_availability`, `fallthrough`, `approval_settings`, `segment_approval_settings`, `instructions`, `boolean_defaults`) → `name = { ... }`. The bracketless object form is the correct v3 syntax (REL-14237).
 - **Map nested attributes** (keyed by a natural key — `launchdarkly_project.environments` by env `key`, `launchdarkly_feature_flag.custom_properties` by property `key`, `launchdarkly_ai_agent_graph.edges` by edge `key`) → `name = { "<key>" = { ... } }`. Each block's `key` value becomes the map key; the `key` attribute is also **kept inside** the object (Optional+Computed in v3, equals the map key) so `.environments["x"].key` references keep working (REL-14236). Reordering/adding/removing one entry no longer churns the others.
 - **Plain map attribute** (`role_attributes` on `launchdarkly_team` / `launchdarkly_team_member`) → `role_attributes = { "<key>" = ["<values>", ...] }`. The `{key, values}` object collapses entirely: the map key is the role attribute key and the value is the string list, matching `launchdarkly_team_role_mapping`.
 
@@ -81,32 +81,32 @@ Every attribute that changed from block → nested attribute in v3. The **Type**
 | `launchdarkly_custom_role` | `policy` | Set | Deprecated; prefer `policy_statements`. |
 | `launchdarkly_custom_role` | `policy_statements` | List | |
 | `launchdarkly_relay_proxy_configuration` | `policy` | List | Required. |
-| `launchdarkly_project` | `default_client_side_availability` | **Object** | v3.0.0 GA: `= { ... }`. Was List (max 1) through `3.0.0-beta.3`. |
-| `launchdarkly_project` | `environments` | **Map** | Keyed by env `key`: `= { "<key>" = { key = "<key>", ... } }`. The `key` stays inside the object (Optional+Computed, equals the map key). Required, at least one entry; authoritative (an env removed from the map is deleted). Use `lifecycle { ignore_changes = [environments] }` to manage environments outside Terraform. Was an ordered List through `3.0.0-beta.3` (REL-14236); map from `3.0.0-beta.4`. |
-| `launchdarkly_project.environments["<key>"]` | `approval_settings` | **Object** | Nested inside each environment map value. v3.0.0 GA: `= { ... }`. Was List (max 1) through `3.0.0-beta.3`. |
-| `launchdarkly_environment` | `approval_settings` | **Object** | Same shape as inline-in-project. v3.0.0 GA: `= { ... }`. |
+| `launchdarkly_project` | `default_client_side_availability` | **Object** | `= { ... }`. |
+| `launchdarkly_project` | `environments` | **Map** | Keyed by env `key`: `= { "<key>" = { key = "<key>", ... } }`. The `key` stays inside the object (Optional+Computed, equals the map key). Required, at least one entry; authoritative (an env removed from the map is deleted). Use `lifecycle { ignore_changes = [environments] }` to manage environments outside Terraform. (REL-14236) |
+| `launchdarkly_project.environments["<key>"]` | `approval_settings` | **Object** | Nested inside each environment map value. `= { ... }`. |
+| `launchdarkly_environment` | `approval_settings` | **Object** | Same shape as inline-in-project. `= { ... }`. |
 | `launchdarkly_environment` | `segment_approval_settings` | **Object** | Net-new in v3 (beta approvals API). `= { ... }`. |
 | `launchdarkly_segment` | `included_contexts` | List | |
 | `launchdarkly_segment` | `excluded_contexts` | List | |
 | `launchdarkly_segment` | `rules` | List | |
 | `launchdarkly_segment.rules[*]` | `clauses` | List | Nested inside each rule. |
-| `launchdarkly_flag_trigger` | `instructions` | **Object** | Required. v3.0.0 GA: `= { kind = "..." }`. Was List (max 1) through `3.0.0-beta.3`. |
+| `launchdarkly_flag_trigger` | `instructions` | **Object** | Required. `= { kind = "..." }`. |
 | `launchdarkly_view_links` | `segments` | Set | Wrap `environment_id` values in `nonsensitive()` to avoid set-hash churn — see `view.tf` in `local-testing/full-account-v2.29.original` for an example. |
 | `launchdarkly_metric` | `urls` | List | |
-| `launchdarkly_team` | `role_attributes` | **Plain map** | `= { "<key>" = ["<values>"] }` — the `{key, values}` object collapses to a map entry. Was Set through `3.0.0-beta.3`. |
+| `launchdarkly_team` | `role_attributes` | **Plain map** | `= { "<key>" = ["<values>"] }` — the `{key, values}` object collapses to a map entry. |
 | `launchdarkly_team_member` | `role_attributes` | **Plain map** | Same shape as on `launchdarkly_team`. |
 | `launchdarkly_ai_config_variation` | `messages` | List | |
-| `launchdarkly_flag_templates` | `boolean_defaults` | **Object** | Required. v3.0.0 GA: `= { ... }`. Was List (max 1) through `3.0.0-beta.3`. |
+| `launchdarkly_flag_templates` | `boolean_defaults` | **Object** | Required. `= { ... }`. |
 | `launchdarkly_feature_flag_environment` | `prerequisites` | List | |
 | `launchdarkly_feature_flag_environment` | `targets` | Set | |
 | `launchdarkly_feature_flag_environment` | `context_targets` | Set | |
 | `launchdarkly_feature_flag_environment` | `rules` | List | |
 | `launchdarkly_feature_flag_environment.rules[*]` | `clauses` | List | Nested inside each rule. |
-| `launchdarkly_feature_flag_environment` | `fallthrough` | **Object** | Required. v3.0.0 GA: `= { ... }`. Was List (max 1) through `3.0.0-beta.3`. |
-| `launchdarkly_feature_flag` | `client_side_availability` | **Object** | v3.0.0 GA: `= { ... }`. Was List (max 1) through `3.0.0-beta.3`. |
+| `launchdarkly_feature_flag_environment` | `fallthrough` | **Object** | Required. `= { ... }`. |
+| `launchdarkly_feature_flag` | `client_side_availability` | **Object** | `= { ... }`. |
 | `launchdarkly_feature_flag` | `variations` | List | **Required (min 1) in v3, including for boolean flags.** See gotcha §1. |
-| `launchdarkly_feature_flag` | `custom_properties` | **Map** | Keyed by property `key`: `= { "<key>" = { name = ..., value = [...] } }`. The `key` stays inside the object (Optional+Computed, equals the map key). Was Set through `3.0.0-beta.3`. |
-| `launchdarkly_feature_flag` | `defaults` | **Object** | v3.0.0 GA: `= { ... }`. Was List (max 1) through `3.0.0-beta.3`. |
+| `launchdarkly_feature_flag` | `custom_properties` | **Map** | Keyed by property `key`: `= { "<key>" = { name = ..., value = [...] } }`. The `key` stays inside the object (Optional+Computed, equals the map key). |
+| `launchdarkly_feature_flag` | `defaults` | **Object** | `= { ... }`. |
 | `launchdarkly_ai_agent_graph` | `edges` | **Map** | Net-new in v3. Keyed by edge `key`: `= { "<key>" = { source_config = ..., target_config = ... } }`. |
 
 If an attribute on a `launchdarkly_*` resource is not listed here, it was either already a primitive (no migration needed) or it was a `config` map (which uses `= { ... }` map syntax — not list-of-objects — and stayed the same across versions).
@@ -127,7 +127,7 @@ If an attribute on a `launchdarkly_*` resource is not listed here, it was either
 3. **`launchdarkly_view_links.segments` uses set semantics.** If `environment_id` is sourced from a data source field marked `Sensitive` (e.g. `data.launchdarkly_environment.x.client_side_id`), the set hash will be unstable across plans. Wrap the value in `nonsensitive(...)` to stabilize the hash. Without this you get perpetual "segments updated" drift.
 
 4. **Single-object vs map.** Several shapes use brace-ish syntax — don't confuse them:
-   - **Single objects** (no brackets, `= { ... }`): `client_side_availability`, `defaults` (feature_flag), `default_client_side_availability` (project), `fallthrough` (flag_environment), `approval_settings` (environment + project envs), `segment_approval_settings` (environment), `instructions` (flag_trigger), `boolean_defaults` (flag_templates). These are `SingleNestedAttribute` in v3.0.0 GA. A bracketed list here fails with a type error. (Through the `3.0.0-beta` pre-releases they were max-1 lists — if you target a beta pre-release, use brackets.)
+   - **Single objects** (no brackets, `= { ... }`): `client_side_availability`, `defaults` (feature_flag), `default_client_side_availability` (project), `fallthrough` (flag_environment), `approval_settings` (environment + project envs), `segment_approval_settings` (environment), `instructions` (flag_trigger), `boolean_defaults` (flag_templates). These are `SingleNestedAttribute` in v3. A bracketed list here fails with a type error.
    - **Maps of objects** (keyed object, `= { "<key>" = { ... } }`): `launchdarkly_project.environments`, `launchdarkly_feature_flag.custom_properties`, `launchdarkly_ai_agent_graph.edges`. The top-level keys are entry keys, each mapping to an object. A list `= [{ ... }]` here fails with `map of object required`. Reference elements as `environments["<key>"]`, never `environments[0]`.
    - **Plain maps** (`= { "<key>" = [ ... ] }`): `role_attributes` on team / team_member — the value is the string list directly, no inner object.
 

--- a/.claude/skills/terraform-provider-block-to-nested-attrs/SKILL.md
+++ b/.claude/skills/terraform-provider-block-to-nested-attrs/SKILL.md
@@ -12,7 +12,7 @@ metadata:
 The LaunchDarkly Terraform provider v3.0.0 finished the migration from `terraform-plugin-sdk/v2` to `terraform-plugin-framework`. Every former `schema.Block` is now a nested attribute. HCL that worked against v2.x using block syntax (`name { ... }`) fails to parse against v3 with `Unsupported block type` or `Missing required argument`. The fix is mechanical, but the target syntax depends on the attribute's cardinality:
 
 - **List/Set nested attributes** (genuinely plural, e.g. `variations`, `rules`, `statements`) → `name = [{ ... }]`.
-- **Single nested attributes** (genuinely one object — `client_side_availability`, `defaults`, `default_client_side_availability`, `fallthrough`, `approval_settings`, `segment_approval_settings`, `instructions`, `boolean_defaults`) → `name = { ... }`. These were modeled as max-1 lists through the `3.0.0-beta` pre-releases and switched to single objects for GA (REL-14237), so the bracketless object form is the correct v3.0.0 syntax. **If you are on a `3.0.0-beta.N` pre-release, use the list form `= [{ ... }]` instead** — the object form is GA-only.
+- **Single nested attributes** (genuinely one object — `client_side_availability`, `defaults`, `default_client_side_availability`, `fallthrough`, `approval_settings`, `segment_approval_settings`, `instructions`, `boolean_defaults`) → `name = { ... }`. These were modeled as max-1 lists through `3.0.0-beta.3` and switched to single objects in `3.0.0-beta.4` (REL-14237), so the bracketless object form is the correct syntax from `3.0.0-beta.4` on, including GA. **Only on `3.0.0-beta.1`–`beta.3` use the list form `= [{ ... }]` instead.**
 - **Map nested attributes** (keyed by a natural key — `launchdarkly_project.environments` by env `key`, `launchdarkly_feature_flag.custom_properties` by property `key`, `launchdarkly_ai_agent_graph.edges` by edge `key`) → `name = { "<key>" = { ... } }`. Each block's `key` value becomes the map key; the `key` attribute is also **kept inside** the object (Optional+Computed in v3, equals the map key) so `.environments["x"].key` references keep working (REL-14236). Reordering/adding/removing one entry no longer churns the others.
 - **Plain map attribute** (`role_attributes` on `launchdarkly_team` / `launchdarkly_team_member`) → `role_attributes = { "<key>" = ["<values>", ...] }`. The `{key, values}` object collapses entirely: the map key is the role attribute key and the value is the string list, matching `launchdarkly_team_role_mapping`.
 
@@ -82,21 +82,21 @@ Every attribute that changed from block → nested attribute in v3. The **Type**
 | `launchdarkly_custom_role` | `policy_statements` | List | |
 | `launchdarkly_relay_proxy_configuration` | `policy` | List | Required. |
 | `launchdarkly_project` | `default_client_side_availability` | **Object** | v3.0.0 GA: `= { ... }`. Was List (max 1) through `3.0.0-beta.3`. |
-| `launchdarkly_project` | `environments` | **Map** | Keyed by env `key`: `= { "<key>" = { key = "<key>", ... } }`. The `key` stays inside the object (Optional+Computed, equals the map key). Required, at least one entry; authoritative (an env removed from the map is deleted). Use `lifecycle { ignore_changes = [environments] }` to manage environments outside Terraform. Was an ordered List through the early v3 preview (REL-14236). |
-| `launchdarkly_project.environments["<key>"]` | `approval_settings` | **Object** | Nested inside each environment map value. v3.0.0 GA: `= { ... }`. Was List (max 1) through the betas. |
+| `launchdarkly_project` | `environments` | **Map** | Keyed by env `key`: `= { "<key>" = { key = "<key>", ... } }`. The `key` stays inside the object (Optional+Computed, equals the map key). Required, at least one entry; authoritative (an env removed from the map is deleted). Use `lifecycle { ignore_changes = [environments] }` to manage environments outside Terraform. Was an ordered List through `3.0.0-beta.3` (REL-14236); map from `3.0.0-beta.4`. |
+| `launchdarkly_project.environments["<key>"]` | `approval_settings` | **Object** | Nested inside each environment map value. v3.0.0 GA: `= { ... }`. Was List (max 1) through `3.0.0-beta.3`. |
 | `launchdarkly_environment` | `approval_settings` | **Object** | Same shape as inline-in-project. v3.0.0 GA: `= { ... }`. |
 | `launchdarkly_environment` | `segment_approval_settings` | **Object** | Net-new in v3 (beta approvals API). `= { ... }`. |
 | `launchdarkly_segment` | `included_contexts` | List | |
 | `launchdarkly_segment` | `excluded_contexts` | List | |
 | `launchdarkly_segment` | `rules` | List | |
 | `launchdarkly_segment.rules[*]` | `clauses` | List | Nested inside each rule. |
-| `launchdarkly_flag_trigger` | `instructions` | **Object** | Required. v3.0.0 GA: `= { kind = "..." }`. Was List (max 1) through the betas. |
+| `launchdarkly_flag_trigger` | `instructions` | **Object** | Required. v3.0.0 GA: `= { kind = "..." }`. Was List (max 1) through `3.0.0-beta.3`. |
 | `launchdarkly_view_links` | `segments` | Set | Wrap `environment_id` values in `nonsensitive()` to avoid set-hash churn — see `view.tf` in `local-testing/full-account-v2.29.original` for an example. |
 | `launchdarkly_metric` | `urls` | List | |
-| `launchdarkly_team` | `role_attributes` | **Plain map** | `= { "<key>" = ["<values>"] }` — the `{key, values}` object collapses to a map entry. Was Set through the betas. |
+| `launchdarkly_team` | `role_attributes` | **Plain map** | `= { "<key>" = ["<values>"] }` — the `{key, values}` object collapses to a map entry. Was Set through `3.0.0-beta.3`. |
 | `launchdarkly_team_member` | `role_attributes` | **Plain map** | Same shape as on `launchdarkly_team`. |
 | `launchdarkly_ai_config_variation` | `messages` | List | |
-| `launchdarkly_flag_templates` | `boolean_defaults` | **Object** | Required. v3.0.0 GA: `= { ... }`. Was List (max 1) through the betas. |
+| `launchdarkly_flag_templates` | `boolean_defaults` | **Object** | Required. v3.0.0 GA: `= { ... }`. Was List (max 1) through `3.0.0-beta.3`. |
 | `launchdarkly_feature_flag_environment` | `prerequisites` | List | |
 | `launchdarkly_feature_flag_environment` | `targets` | Set | |
 | `launchdarkly_feature_flag_environment` | `context_targets` | Set | |
@@ -105,7 +105,7 @@ Every attribute that changed from block → nested attribute in v3. The **Type**
 | `launchdarkly_feature_flag_environment` | `fallthrough` | **Object** | Required. v3.0.0 GA: `= { ... }`. Was List (max 1) through `3.0.0-beta.3`. |
 | `launchdarkly_feature_flag` | `client_side_availability` | **Object** | v3.0.0 GA: `= { ... }`. Was List (max 1) through `3.0.0-beta.3`. |
 | `launchdarkly_feature_flag` | `variations` | List | **Required (min 1) in v3, including for boolean flags.** See gotcha §1. |
-| `launchdarkly_feature_flag` | `custom_properties` | **Map** | Keyed by property `key`: `= { "<key>" = { name = ..., value = [...] } }`. The `key` stays inside the object (Optional+Computed, equals the map key). Was Set through the betas. |
+| `launchdarkly_feature_flag` | `custom_properties` | **Map** | Keyed by property `key`: `= { "<key>" = { name = ..., value = [...] } }`. The `key` stays inside the object (Optional+Computed, equals the map key). Was Set through `3.0.0-beta.3`. |
 | `launchdarkly_feature_flag` | `defaults` | **Object** | v3.0.0 GA: `= { ... }`. Was List (max 1) through `3.0.0-beta.3`. |
 | `launchdarkly_ai_agent_graph` | `edges` | **Map** | Net-new in v3. Keyed by edge `key`: `= { "<key>" = { source_config = ..., target_config = ... } }`. |
 

--- a/.claude/skills/terraform-provider-v3-migration/SKILL.md
+++ b/.claude/skills/terraform-provider-v3-migration/SKILL.md
@@ -5,8 +5,8 @@ description: >
   new resources against a real LaunchDarkly account. Use when the user wants to (1) upgrade an entire
   v2.x configuration to v3 — run migrate-tf-syntax, fix the manual follow-ups, build the v3 provider,
   apply, and confirm an idempotent state upgrade with zero forced replacements; or (2) exercise and
-  validate the new v3 resources (context_kind, announcement, oauth_client, metric_group, release_policy,
-  big_segment_store_integration, flag_import_configuration, integration_delivery_configuration) with
+  validate the new v3 resources (context_kind, announcement, oauth_client, ai_agent_graph, metric_group,
+  release_policy, big_segment_store_integration, flag_import_configuration, integration_delivery_configuration) with
   create/read/update/delete and idempotency checks before calling them GA. Triggers: "migrate a full v2
   setup", "end-to-end v3 upgrade", "verify the new v3 resources", "test the scaffolded resources",
   "validate v3 before GA", "exercise the beta resources".
@@ -123,7 +123,7 @@ The inverse appends reversed blocks at the end of each body, so attribute order 
 
 ## Workflow B — Try and verify the new v3 resources
 
-The net-new v3 resources are listed with their stability, scope, example path, and known gotchas in [references/new-resources.md](references/new-resources.md). Seven of the eight resources were added as autogen scaffolds after the `v3.0.0-beta.2` preview and have not been exercised in a tagged release, so this workflow is the gate before treating them as GA.
+The net-new v3 resources are listed with their stability, scope, example path, and known gotchas in [references/new-resources.md](references/new-resources.md). All nine ship in a tagged release as of `v3.0.0-beta.4` and passed full CRUD + data-source verification on 2026-07-02; re-run this workflow when a resource schema changes or before promoting the beta-API resources to stable.
 
 ### B1. Stand up a scratch project
 
@@ -145,11 +145,10 @@ For each resource in the matrix:
 
 Several beta resources integrate with external systems or gated account features:
 
-- `big_segment_store_integration` needs reachable store credentials, for example a Redis or DynamoDB store.
-- `flag_import_configuration` and `integration_delivery_configuration` need valid third-party credentials for the chosen integration, for example Split or Fastly.
+- `big_segment_store_integration`, `flag_import_configuration`, and `integration_delivery_configuration` accept dummy third-party credentials for CRUD verification: the LaunchDarkly API persists `config` without validating connectivity, so placeholder values with `on = false` exercise the full create/read/update/delete path (verified 2026-07-02). Live credentials only matter for verifying the integration functions end to end, which is out of scope here.
 - Any beta resource may require an account entitlement that the test account lacks.
 
-When the only blocker is a missing credential or entitlement, classify the resource **BLOCKED**, not **FAIL**. Record exactly what is missing so it can be retried on an entitled account.
+When the only blocker is a missing entitlement, classify the resource **BLOCKED**, not **FAIL**. Record exactly what is missing so it can be retried on an entitled account.
 
 ### Result classification
 

--- a/.claude/skills/terraform-provider-v3-migration/SKILL.md
+++ b/.claude/skills/terraform-provider-v3-migration/SKILL.md
@@ -61,7 +61,7 @@ The goal is a clean upgrade: the first v3 plan shows only cosmetic drift, the ap
 ### A1. Prepare the v2 configuration
 
 - For a customer setup, copy their `.tf` files into a scratch directory under `local-testing/`.
-- For an internal end-to-end test, the genuine v2.29 **block-syntax** setup is in the backup archive `local-testing/full-account-v2.29-backup-*.zip`. Extract it to a scratch dir and use that as the v2 source. The on-disk `local-testing/full-account-v2.29/` and `full-account-v2.29.original/` dirs are **both already v3 nested syntax** (last applied with provider 3.0.0-beta.1) — they are not v2-block sources. To regenerate a block-syntax config from a v3 one, run the tool with `-direction v3-to-v2` first.
+- For an internal end-to-end test, the genuine v2.29 **block-syntax** setup is in the backup archive `local-testing/full-account-v2.29-backup-*.zip`. Extract it to a scratch dir and use that as the v2 source. The on-disk `local-testing/full-account-v2.29/` and `full-account-v2.29.original/` dirs are **both already v3 nested syntax** — they are not v2-block sources. To regenerate a block-syntax config from a v3 one, run the tool with `-direction v3-to-v2` first.
 - Establish a clean baseline. Against the v2 provider, `terraform apply` until the plan is empty. The migration starts from a state with no pending changes.
 
 ### A2. Convert the syntax with migrate-tf-syntax
@@ -85,7 +85,7 @@ terraform -chdir="$DIR" fmt
 
 The tool converts block syntax to nested-attribute syntax, drops `expire` and `is_active`, renames `policy_statements` to `inline_roles`, converts `policy` to `policy_statements`, rewrites `include_in_snippet` into the matching client-side-availability attribute, and updates data-source references such as `client_side_availability` on the `launchdarkly_project` data source.
 
-This also covers upgrades from an **early v3 preview to a later v3 build** (for example 3.0.0-beta.1 to GA). A preview config has no block syntax to convert, but it may still set an attribute that a later v3 removed (for example `policy` on `launchdarkly_custom_role`), which fails `terraform plan` with `Unsupported argument`. The tool drops or renames those on already-nested input too, so run it for preview-to-GA upgrades as well.
+The tool also accepts input that is already in nested-attribute syntax: it drops or renames attributes that v3 removed (for example `policy` on `launchdarkly_custom_role`, which otherwise fails `terraform plan` with `Unsupported argument`).
 
 ### A3. Finish the follow-ups the tool cannot do
 
@@ -123,7 +123,7 @@ The inverse appends reversed blocks at the end of each body, so attribute order 
 
 ## Workflow B — Try and verify the new v3 resources
 
-The net-new v3 resources are listed with their stability, scope, example path, and known gotchas in [references/new-resources.md](references/new-resources.md). All nine ship in a tagged release as of `v3.0.0-beta.4` and passed full CRUD + data-source verification on 2026-07-02; re-run this workflow when a resource schema changes or before promoting the beta-API resources to stable.
+The net-new v3 resources are listed with their stability, scope, example path, and known gotchas in [references/new-resources.md](references/new-resources.md). All nine ship in the current v3 release and passed full CRUD + data-source verification on 2026-07-02; re-run this workflow when a resource schema changes or before promoting the beta-API resources to stable.
 
 ### B1. Stand up a scratch project
 

--- a/.claude/skills/terraform-provider-v3-migration/references/new-resources.md
+++ b/.claude/skills/terraform-provider-v3-migration/references/new-resources.md
@@ -2,11 +2,11 @@
 
 These are the resources and data sources that v3 adds over the latest v2 line. v3 removes none. Use this matrix with Workflow B in the parent `SKILL.md`.
 
-All nine resources ship in a tagged release as of `v3.0.0-beta.4`, and all nine passed a full CRUD + data-source verification on a real account on 2026-07-02 (see the status table). Re-run Workflow B when a resource schema changes or before promoting the beta-API resources to stable. The canonical config for each is `examples/resources/launchdarkly_<name>/resource.tf` — read it at verification time rather than trusting the summaries below, since scaffolds can change.
+All nine resources ship in the current v3 release, and all nine passed a full CRUD + data-source verification on a real account on 2026-07-02 (see the status table). Re-run Workflow B when a resource schema changes or before promoting the beta-API resources to stable. The canonical config for each is `examples/resources/launchdarkly_<name>/resource.tf` — read it at verification time rather than trusting the summaries below, since scaffolds can change.
 
 | Resource | Data source | Stability | Scope | Origin |
 |---|---|---|---|---|
-| `launchdarkly_context_kind` | yes | Stable API | Project | beta.2 |
+| `launchdarkly_context_kind` | yes | Stable API | Project | core v3 line |
 | `launchdarkly_announcement` | no | Stable API | Account | scaffold #460 |
 | `launchdarkly_oauth_client` | yes | Stable API | Account | scaffold #466 |
 | `launchdarkly_ai_agent_graph` | yes | Beta API | Project | scaffold #475 |

--- a/.claude/skills/terraform-provider-v3-migration/references/new-resources.md
+++ b/.claude/skills/terraform-provider-v3-migration/references/new-resources.md
@@ -2,13 +2,14 @@
 
 These are the resources and data sources that v3 adds over the latest v2 line. v3 removes none. Use this matrix with Workflow B in the parent `SKILL.md`.
 
-Only `launchdarkly_context_kind` shipped in a tagged preview (`v3.0.0-beta.2`). The other seven resources were added as autogen scaffolds after `beta.2`, so this matrix and Workflow B are the gate before treating them as GA. The canonical config for each is `examples/resources/launchdarkly_<name>/resource.tf` — read it at verification time rather than trusting the summaries below, since scaffolds can change.
+All nine resources ship in a tagged release as of `v3.0.0-beta.4`, and all nine passed a full CRUD + data-source verification on a real account on 2026-07-02 (see the status table). Re-run Workflow B when a resource schema changes or before promoting the beta-API resources to stable. The canonical config for each is `examples/resources/launchdarkly_<name>/resource.tf` — read it at verification time rather than trusting the summaries below, since scaffolds can change.
 
 | Resource | Data source | Stability | Scope | Origin |
 |---|---|---|---|---|
 | `launchdarkly_context_kind` | yes | Stable API | Project | beta.2 |
 | `launchdarkly_announcement` | no | Stable API | Account | scaffold #460 |
 | `launchdarkly_oauth_client` | yes | Stable API | Account | scaffold #466 |
+| `launchdarkly_ai_agent_graph` | yes | Beta API | Project | scaffold #475 |
 | `launchdarkly_metric_group` | yes | Beta API | Project | scaffold #453 |
 | `launchdarkly_release_policy` | yes | Beta API | Project | scaffold #471 |
 | `launchdarkly_big_segment_store_integration` | yes | Beta API | Project + environment | scaffold #468 |
@@ -40,7 +41,7 @@ The three integration resources do NOT need live third-party credentials for CRU
 ### launchdarkly_context_kind — Stable, project scoped
 
 - Required: `project_key`, `key`, `name`. Optional: `description`.
-- Simplest of the set and the only one validated in a tagged preview. Use it as the smoke test that the dev-override build is wired up correctly.
+- Simplest of the set. Use it as the smoke test that the dev-override build is wired up correctly.
 - Verification: expect a clean create, an empty follow-up plan, an update on `name` or `description`, and a clean delete.
 
 ### launchdarkly_announcement — Stable, account scoped, singleton
@@ -54,6 +55,12 @@ The three integration resources do NOT need live third-party credentials for CRU
 - Required: `name`, `redirect_uri`. Optional: `description`.
 - The API likely returns a client secret on create. Confirm any secret field is marked sensitive and is not echoed in plan output. Treat a secret that is settable but not returned on read as write-only, and confirm the provider does not blank it on refresh.
 - May require an Admin or Owner role on the account. A permissions error is BLOCKED.
+
+### launchdarkly_ai_agent_graph — Beta, project scoped
+
+- Required: `project_key`, `key`, `name`, `root_config_key`, and an `edges` map keyed by edge key (each edge: `source_config`, `target_config`, optional `handoff` JSON).
+- **Every node must be an agent-mode AI config.** Create the referenced `launchdarkly_ai_config` resources with `mode = "agent"` — the API rejects the default `completion` mode with `400 invalid_request` ("not allowed as an agent graph node"). Note `mode` is immutable on `launchdarkly_ai_config`; changing it plans a replace.
+- Destroy + recreate at the same graph key can transiently return `400 "could not fetch Agent Graph flag"` (beta-API delete propagation). Retry once after ~30s before calling it a defect.
 
 ### launchdarkly_metric_group — Beta, project scoped
 

--- a/docs/guides/v3-release-notes.md
+++ b/docs/guides/v3-release-notes.md
@@ -97,7 +97,7 @@ resource "launchdarkly_feature_flag" "example" {
 
 The `migrate-tf-syntax` tool emits this object form automatically. When you read these attributes from a data source, drop the list index too: `data.launchdarkly_feature_flag.x.client_side_availability.using_environment_id`, not `...client_side_availability[0].using_environment_id`.
 
-> **Upgrading from a `3.0.0-beta` pre-release?** These attributes were modeled as single-element lists through the `3.0.0-beta` pre-releases (`= [{ ... }]`). The switch to object syntax landed for GA. The pre-release → GA jump is not state-compatible for them — update the configuration to the object form; the provider's state upgraders convert pre-release state in place. Upgrades from v2 are handled automatically by the state upgrade and the `migrate-tf-syntax` tool.
+> **Upgrading from a `3.0.0-beta` pre-release?** These attributes were modeled as single-element lists through `3.0.0-beta.3` (`= [{ ... }]`). The switch to object syntax landed in `v3.0.0-beta.4`. The jump from an earlier pre-release is not state-compatible for them — update the configuration to the object form; the provider's state upgraders convert pre-release state in place. Upgrades from v2 are handled automatically by the state upgrade and the `migrate-tf-syntax` tool.
 
 ### Keyed collections become maps
 
@@ -130,7 +130,7 @@ Reference environments by key, not index: `environments["production"].client_sid
 
 `custom_properties` follows the same object-map pattern (`custom_properties = { "my.key" = { name = ..., value = [...] } }`). `role_attributes` collapses further to a plain map of string lists — `role_attributes = { myAttribute = ["value1", "value2"] }` — matching both the LaunchDarkly API shape and the `launchdarkly_team_role_mapping` resource.
 
-> **Upgrading from a `3.0.0-beta` pre-release?** These collections were lists or sets through the `3.0.0-beta` pre-releases. Update the configuration to the map form; the provider's state upgraders convert both v2 and pre-release state in place (except `launchdarkly_project.environments` state from `3.0.0-beta.1`–`beta.3`, which pre-dates the map and must be re-imported).
+> **Upgrading from a `3.0.0-beta` pre-release?** These collections were lists or sets through `3.0.0-beta.3`; the map shapes landed in `v3.0.0-beta.4`. Update the configuration to the map form; the provider's state upgraders convert both v2 and pre-release state in place (except `launchdarkly_project.environments` state from `3.0.0-beta.1`–`beta.3`, which pre-dates the map and must be re-imported).
 
 ### Removed attributes
 

--- a/docs/guides/v3-release-notes.md
+++ b/docs/guides/v3-release-notes.md
@@ -6,7 +6,7 @@ description: |-
 
 # LaunchDarkly Terraform provider v3.0.0 release notes
 
-Version 3.0.0 completes the provider's migration to the HashiCorp Terraform Plugin Framework. The provider now serves the protocol version 6 plugin API, expresses every nested structure as a nested attribute instead of a configuration block, and removes the attributes that v2 deprecated. v3 also adds new resources, data sources, and a provider setting, and it ships a command-line tool that rewrites v2 configurations into v3 syntax. v3.0.0 follows a series of preview releases (v3.0.0-beta.1 through v3.0.0-beta.4).
+Version 3.0.0 completes the provider's migration to the HashiCorp Terraform Plugin Framework. The provider now serves the protocol version 6 plugin API, expresses every nested structure as a nested attribute instead of a configuration block, and removes the attributes that v2 deprecated. v3 also adds new resources, data sources, and a provider setting, and it ships a command-line tool that rewrites v2 configurations into v3 syntax.
 
 > **Before you upgrade:** your v2 configurations do not parse against v3 until you rewrite them from block syntax to nested attribute syntax. To convert them, read the [migration guide](https://registry.terraform.io/providers/launchdarkly/launchdarkly/latest/docs/guides/migrating-to-v3) and run the `migrate-tf-syntax` tool that ships with this release.
 
@@ -97,8 +97,6 @@ resource "launchdarkly_feature_flag" "example" {
 
 The `migrate-tf-syntax` tool emits this object form automatically. When you read these attributes from a data source, drop the list index too: `data.launchdarkly_feature_flag.x.client_side_availability.using_environment_id`, not `...client_side_availability[0].using_environment_id`.
 
-> **Upgrading from a `3.0.0-beta` pre-release?** These attributes were modeled as single-element lists through `3.0.0-beta.3` (`= [{ ... }]`). The switch to object syntax landed in `v3.0.0-beta.4`. The jump from an earlier pre-release is not state-compatible for them — update the configuration to the object form; the provider's state upgraders convert pre-release state in place. Upgrades from v2 are handled automatically by the state upgrade and the `migrate-tf-syntax` tool.
-
 ### Keyed collections become maps
 
 Four collections whose elements have a natural unique key are maps in v3, so adding, removing, or reordering one entry no longer forces a diff (or a destructive plan) on its siblings:
@@ -129,8 +127,6 @@ The map is **authoritative**: an environment removed from the map is deleted on 
 Reference environments by key, not index: `environments["production"].client_side_id`, never `environments[0].client_side_id`. The `migrate-tf-syntax` tool rewrites the blocks and warns on each positional reference with the exact replacement.
 
 `custom_properties` follows the same object-map pattern (`custom_properties = { "my.key" = { name = ..., value = [...] } }`). `role_attributes` collapses further to a plain map of string lists — `role_attributes = { myAttribute = ["value1", "value2"] }` — matching both the LaunchDarkly API shape and the `launchdarkly_team_role_mapping` resource.
-
-> **Upgrading from a `3.0.0-beta` pre-release?** These collections were lists or sets through `3.0.0-beta.3`; the map shapes landed in `v3.0.0-beta.4`. Update the configuration to the map form; the provider's state upgraders convert both v2 and pre-release state in place (except `launchdarkly_project.environments` state from `3.0.0-beta.1`–`beta.3`, which pre-dates the map and must be re-imported).
 
 ### Removed attributes
 

--- a/templates/guides/v3-release-notes.md.tmpl
+++ b/templates/guides/v3-release-notes.md.tmpl
@@ -97,7 +97,7 @@ resource "launchdarkly_feature_flag" "example" {
 
 The `migrate-tf-syntax` tool emits this object form automatically. When you read these attributes from a data source, drop the list index too: `data.launchdarkly_feature_flag.x.client_side_availability.using_environment_id`, not `...client_side_availability[0].using_environment_id`.
 
-> **Upgrading from a `3.0.0-beta` pre-release?** These attributes were modeled as single-element lists through the `3.0.0-beta` pre-releases (`= [{ ... }]`). The switch to object syntax landed for GA. The pre-release → GA jump is not state-compatible for them — update the configuration to the object form; the provider's state upgraders convert pre-release state in place. Upgrades from v2 are handled automatically by the state upgrade and the `migrate-tf-syntax` tool.
+> **Upgrading from a `3.0.0-beta` pre-release?** These attributes were modeled as single-element lists through `3.0.0-beta.3` (`= [{ ... }]`). The switch to object syntax landed in `v3.0.0-beta.4`. The jump from an earlier pre-release is not state-compatible for them — update the configuration to the object form; the provider's state upgraders convert pre-release state in place. Upgrades from v2 are handled automatically by the state upgrade and the `migrate-tf-syntax` tool.
 
 ### Keyed collections become maps
 
@@ -130,7 +130,7 @@ Reference environments by key, not index: `environments["production"].client_sid
 
 `custom_properties` follows the same object-map pattern (`custom_properties = { "my.key" = { name = ..., value = [...] } }`). `role_attributes` collapses further to a plain map of string lists — `role_attributes = { myAttribute = ["value1", "value2"] }` — matching both the LaunchDarkly API shape and the `launchdarkly_team_role_mapping` resource.
 
-> **Upgrading from a `3.0.0-beta` pre-release?** These collections were lists or sets through the `3.0.0-beta` pre-releases. Update the configuration to the map form; the provider's state upgraders convert both v2 and pre-release state in place (except `launchdarkly_project.environments` state from `3.0.0-beta.1`–`beta.3`, which pre-dates the map and must be re-imported).
+> **Upgrading from a `3.0.0-beta` pre-release?** These collections were lists or sets through `3.0.0-beta.3`; the map shapes landed in `v3.0.0-beta.4`. Update the configuration to the map form; the provider's state upgraders convert both v2 and pre-release state in place (except `launchdarkly_project.environments` state from `3.0.0-beta.1`–`beta.3`, which pre-dates the map and must be re-imported).
 
 ### Removed attributes
 

--- a/templates/guides/v3-release-notes.md.tmpl
+++ b/templates/guides/v3-release-notes.md.tmpl
@@ -6,7 +6,7 @@ description: |-
 
 # LaunchDarkly Terraform provider v3.0.0 release notes
 
-Version 3.0.0 completes the provider's migration to the HashiCorp Terraform Plugin Framework. The provider now serves the protocol version 6 plugin API, expresses every nested structure as a nested attribute instead of a configuration block, and removes the attributes that v2 deprecated. v3 also adds new resources, data sources, and a provider setting, and it ships a command-line tool that rewrites v2 configurations into v3 syntax. v3.0.0 follows a series of preview releases (v3.0.0-beta.1 through v3.0.0-beta.4).
+Version 3.0.0 completes the provider's migration to the HashiCorp Terraform Plugin Framework. The provider now serves the protocol version 6 plugin API, expresses every nested structure as a nested attribute instead of a configuration block, and removes the attributes that v2 deprecated. v3 also adds new resources, data sources, and a provider setting, and it ships a command-line tool that rewrites v2 configurations into v3 syntax.
 
 > **Before you upgrade:** your v2 configurations do not parse against v3 until you rewrite them from block syntax to nested attribute syntax. To convert them, read the [migration guide](https://registry.terraform.io/providers/launchdarkly/launchdarkly/latest/docs/guides/migrating-to-v3) and run the `migrate-tf-syntax` tool that ships with this release.
 
@@ -97,8 +97,6 @@ resource "launchdarkly_feature_flag" "example" {
 
 The `migrate-tf-syntax` tool emits this object form automatically. When you read these attributes from a data source, drop the list index too: `data.launchdarkly_feature_flag.x.client_side_availability.using_environment_id`, not `...client_side_availability[0].using_environment_id`.
 
-> **Upgrading from a `3.0.0-beta` pre-release?** These attributes were modeled as single-element lists through `3.0.0-beta.3` (`= [{ ... }]`). The switch to object syntax landed in `v3.0.0-beta.4`. The jump from an earlier pre-release is not state-compatible for them — update the configuration to the object form; the provider's state upgraders convert pre-release state in place. Upgrades from v2 are handled automatically by the state upgrade and the `migrate-tf-syntax` tool.
-
 ### Keyed collections become maps
 
 Four collections whose elements have a natural unique key are maps in v3, so adding, removing, or reordering one entry no longer forces a diff (or a destructive plan) on its siblings:
@@ -129,8 +127,6 @@ The map is **authoritative**: an environment removed from the map is deleted on 
 Reference environments by key, not index: `environments["production"].client_side_id`, never `environments[0].client_side_id`. The `migrate-tf-syntax` tool rewrites the blocks and warns on each positional reference with the exact replacement.
 
 `custom_properties` follows the same object-map pattern (`custom_properties = { "my.key" = { name = ..., value = [...] } }`). `role_attributes` collapses further to a plain map of string lists — `role_attributes = { myAttribute = ["value1", "value2"] }` — matching both the LaunchDarkly API shape and the `launchdarkly_team_role_mapping` resource.
-
-> **Upgrading from a `3.0.0-beta` pre-release?** These collections were lists or sets through `3.0.0-beta.3`; the map shapes landed in `v3.0.0-beta.4`. Update the configuration to the map form; the provider's state upgraders convert both v2 and pre-release state in place (except `launchdarkly_project.environments` state from `3.0.0-beta.1`–`beta.3`, which pre-dates the map and must be re-imported).
 
 ### Removed attributes
 


### PR DESCRIPTION
Post-release staleness sweep after cutting `v3.0.0-beta.4` (which now carries the RC-prep object/map conversions and all nine net-new resources):

- **block-to-nested-attrs skill** — object/map forms apply from `v3.0.0-beta.4` onward (previously framed as "GA-only"); list/set shapes ended at `beta.3`.
- **v3 release notes (guide + template)** — the object-syntax and map-shape switches landed in `beta.4`, not "for GA". The `beta.1`–`beta.3` environments re-import exception is unchanged.
- **v3-migration skill** — retires the "not exercised in a tagged release" gate framing: all nine net-new resources passed full CRUD + data-source verification on a real account on 2026-07-02. The three integration resources (`big_segment_store_integration`, `flag_import_configuration`, `integration_delivery_configuration`) accept dummy credentials for CRUD verification, so only entitlement gaps classify as BLOCKED.
- **new-resources matrix** — adds the previously missing `launchdarkly_ai_agent_graph` row and per-resource notes (nodes must be `mode = "agent"` AI configs, `mode` is immutable, transient delete-propagation 400 retry).

Docs-only; no provider code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Claude skills only; no runtime or schema changes.
> 
> **Overview**
> **Docs-only** refresh after `v3.0.0-beta.4` and real-account verification—no provider code changes.
> 
> The **block-to-nested-attrs** skill now describes single-object and map shapes as standard **v3** syntax (`= { ... }` / keyed maps) without GA-vs-beta branching or “use list form on beta” caveats; mapping table notes are shortened accordingly.
> 
> The **v3-migration** skill and **new-resources** matrix drop the “not exercised in a tagged release” gate: all **nine** net-new resources (including **`launchdarkly_ai_agent_graph`**) are documented as shipping in the current v3 line with full CRUD + data-source verification on 2026-07-02. Workflow B notes that the three integration resources can use **dummy credentials** for provider CRUD; **BLOCKED** applies mainly to missing **entitlements**. `ai_agent_graph` per-resource notes cover `mode = "agent"`, immutability, and transient delete 400 retries.
> 
> **v3 release notes** (rendered guide + template) remove the preview-release sentence and the two **“Upgrading from 3.0.0-beta”** callouts under object syntax and keyed maps; core breaking-change content is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 378835e3701e6484f2e5b18fc3881e00b5bdd94a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->