### PR TITLE
fix(release): ship migrate-tf-syntax binaries in preview releases

### DIFF
--- a/.goreleaser-canary-v3.yml
+++ b/.goreleaser-canary-v3.yml
@@ -9,7 +9,8 @@ before:
     # this is just an example and not a requirement for provider building/publishing
     - go mod tidy
 builds:
-  - env:
+  - id: provider
+    env:
       # goreleaser does not work with CGO, it could also complicate
       # usage by users in CI/CD systems like Terraform Cloud where
       # they are unable to install libraries.
@@ -33,9 +34,38 @@ builds:
       - goos: darwin
         goarch: "386"
     binary: "{{ .ProjectName }}_v{{ .Version }}"
+  # Companion CLI that rewrites customer HCL between v2 block syntax and v3
+  # nested-attribute syntax. Shipped as separate release assets. The Terraform
+  # Registry only ingests assets matching the provider naming pattern, so
+  # these archives do not affect registry ingestion. Kept in sync with
+  # .goreleaser.yml so the migration guide's download step works on preview
+  # releases too.
+  - id: migrate-tf-syntax
+    dir: scripts/migrate-tf-syntax
+    binary: migrate-tf-syntax
+    env:
+      - CGO_ENABLED=0
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - "-s -w"
+    goos:
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
 archives:
-  - format: zip
+  - id: provider
+    ids: [provider]
+    formats: [zip]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - id: migrate-tf-syntax
+    ids: [migrate-tf-syntax]
+    formats: [zip]
+    name_template: "migrate-tf-syntax_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
   extra_files:
     - glob: 'terraform-registry-manifest.json'


### PR DESCRIPTION
The preview-v3 release workflow uses `.goreleaser-canary-v3.yml`, which never gained the `migrate-tf-syntax` build/archive blocks that `.goreleaser.yml` on `main` has (#448). Result: `v3.0.0-beta.4` and `beta.5` ship **zero tool binaries**, so the migration guide's "download the `migrate-tf-syntax` archive from the provider release assets" step is broken for preview users (the `go run …@<tag>` path still works).

This ports the two blocks verbatim from `.goreleaser.yml` and gives the provider build/archive explicit `id`s to pair them — the canary config now matches main's shape, with the canary-only `prerelease: auto` release setting untouched.

Validation:
- `goreleaser check --config .goreleaser-canary-v3.yml` — 1 configuration file validated
- `goreleaser build --single-target --id migrate-tf-syntax --snapshot` — build succeeds (4.1M darwin_arm64 binary)

Registry note: the Terraform Registry only ingests assets matching the provider naming pattern, so the extra archives do not affect ingestion (same comment as on main's config, where this has shipped since #448).

Found during the v3 RC readiness review. The next preview cut (beta.6, release PR #489 pending) will validate the full asset set end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release packaging only; no provider or migration tool source changes, and non-provider asset names remain outside Terraform Registry ingestion.
> 
> **Overview**
> Preview v3 releases (`.goreleaser-canary-v3.yml`) previously omitted the **`migrate-tf-syntax`** build and zip archive that main’s `.goreleaser.yml` already ships, so beta preview tags had no downloadable migration CLI and the migration guide’s release-asset step failed.
> 
> This change **adds** the companion `migrate-tf-syntax` build (from `scripts/migrate-tf-syntax`) and matching archives, and gives the provider build/archive explicit **`id: provider`** so they pair with the new archive entries—the same layout as main, without touching canary-only release settings like `prerelease: auto`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2602488b1be42532eda2986a2960af4e4b285cc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->