### PR TITLE
chore(deps): upgrade api-client-go from v22.0.0 to v23.0.0

### DIFF
--- a/.github/agent-prompts/scaffold-instructions.md
+++ b/.github/agent-prompts/scaffold-instructions.md
@@ -29,7 +29,7 @@ Inputs:
   ValidateConfig key==map-key, ModifyPlan pinMapKeysToMapKey); {key, values}
   pairs collapse to a plain MapAttribute. Acceptance tests for map attributes
   must include an update step that ADDS an entry.
-- Use the generated API client (github.com/launchdarkly/api-client-go/v22) for
+- Use the generated API client (github.com/launchdarkly/api-client-go/v23) for
   all API calls. If the client lacks this surface, stop and report that instead
   of hand-rolling HTTP.
 - If the resource is an account-scoped SINGLETON (the API allows only one per

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 
 require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
-	github.com/launchdarkly/api-client-go/v22 v22.0.0
+	github.com/launchdarkly/api-client-go/v23 v23.0.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/sync v0.20.0
 )

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/kulti/thelper v0.5.0/go.mod h1:vMu2Cizjy/grP+jmsvOFDx1kYP6+PD1lqg4Yu5
 github.com/kunwardeep/paralleltest v1.0.3/go.mod h1:vLydzomDFpk7yu5UX02RmP0H8QfRPOV/oFhWN85Mjb4=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/kyoh86/exportloopref v0.1.8/go.mod h1:1tUcJeiioIs7VWe5gcOObrux3lb66+sBqGZrRkMwPgg=
-github.com/launchdarkly/api-client-go/v22 v22.0.0 h1:UeWfl/JDVD5oDVto2NQvho+edAJs9478drZH8L1A1Ws=
-github.com/launchdarkly/api-client-go/v22 v22.0.0/go.mod h1:gwKiCZMJeT/x7inYaswt/Z8h5lr+tdHRcRCI4qTZEyM=
+github.com/launchdarkly/api-client-go/v23 v23.0.0 h1:iRpZGH1OlfjfdL8/B90BmfGsmwOGnUkaekgUxJp5aQw=
+github.com/launchdarkly/api-client-go/v23 v23.0.0/go.mod h1:+hoUijyl2J83GwZf/gQryNXFSscnc4aSxVtr9P9oGiY=
 github.com/ldez/gomoddirectives v0.2.2/go.mod h1:cpgBogWITnCfRq2qGoDkKMEVSaarhdBr6g8G04uz6d0=
 github.com/ldez/tagliatelle v0.3.0/go.mod h1:8s6WJQwEYHbKZDsp/LjArytKOG8qaMrKQQ3mFukHs88=
 github.com/leonklingele/grouper v1.1.0/go.mod h1:uk3I3uDfi9B6PeUjsCKi6ndcf63Uy7snXgR4yDYQVDY=

--- a/launchdarkly/ai_agent_graph_helper.go
+++ b/launchdarkly/ai_agent_graph_helper.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 // agentGraphBetaVersion is the LD-API-Version the agent graph endpoints

--- a/launchdarkly/ai_agent_graph_helper_test.go
+++ b/launchdarkly/ai_agent_graph_helper_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/launchdarkly/approvals_framework.go
+++ b/launchdarkly/approvals_framework.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 // frameworkApprovalSettingsObjectAttrTypes is the attribute-type map

--- a/launchdarkly/big_segment_store_integration_helper.go
+++ b/launchdarkly/big_segment_store_integration_helper.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strings"
 
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 // Big segment (persistent) store integration keys. These select the backing

--- a/launchdarkly/clauses_framework.go
+++ b/launchdarkly/clauses_framework.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var frameworkClauseAttrTypes = map[string]attr.Type{

--- a/launchdarkly/config.go
+++ b/launchdarkly/config.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 //nolint:staticcheck // The version string gets updated at build time using -ldflags

--- a/launchdarkly/context_kind_helper.go
+++ b/launchdarkly/context_kind_helper.go
@@ -2,7 +2,7 @@ package launchdarkly
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 // findContextKindByKey scans a context-kind list response for an item matching the given key.

--- a/launchdarkly/data_source_ai_agent_graph_framework.go
+++ b/launchdarkly/data_source_ai_agent_graph_framework.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &AIAgentGraphDataSource{}
@@ -96,7 +96,7 @@ func (d *AIAgentGraphDataSource) Read(ctx context.Context, req datasource.ReadRe
 	}
 	var graph *ldapi.AgentGraph
 	err = beta.withConcurrency(beta.ctx, func() error {
-		graph, _, err = beta.ld.AIConfigsApi.GetAgentGraph(beta.ctx, projectKey, graphKey).LDAPIVersion(agentGraphBetaVersion).Execute()
+		graph, _, err = beta.ld.AgentControlApi.GetAgentGraph(beta.ctx, projectKey, graphKey).LDAPIVersion(agentGraphBetaVersion).Execute()
 		return err
 	})
 	if err != nil {

--- a/launchdarkly/data_source_ai_config_framework.go
+++ b/launchdarkly/data_source_ai_config_framework.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &AIConfigDataSource{}
@@ -104,7 +104,7 @@ func (d *AIConfigDataSource) Read(ctx context.Context, req datasource.ReadReques
 	var aiConfig *ldapi.AIConfig
 	var err error
 	err = d.client.withConcurrency(d.client.ctx, func() error {
-		aiConfig, _, err = d.client.ld.AIConfigsApi.GetAIConfig(d.client.ctx, projectKey, key).Execute()
+		aiConfig, _, err = d.client.ld.AgentControlApi.GetAIConfig(d.client.ctx, projectKey, key).Execute()
 		return err
 	})
 	if err != nil {

--- a/launchdarkly/data_source_ai_config_variation_framework.go
+++ b/launchdarkly/data_source_ai_config_variation_framework.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &AIConfigVariationDataSource{}
@@ -109,7 +109,7 @@ func (d *AIConfigVariationDataSource) Read(ctx context.Context, req datasource.R
 	var variationsResp *ldapi.AIConfigVariationsResponse
 	var err error
 	err = d.client.withConcurrency(d.client.ctx, func() error {
-		variationsResp, _, err = d.client.ld.AIConfigsApi.GetAIConfigVariation(d.client.ctx, projectKey, configKey, variationKey).Execute()
+		variationsResp, _, err = d.client.ld.AgentControlApi.GetAIConfigVariation(d.client.ctx, projectKey, configKey, variationKey).Execute()
 		return err
 	})
 	if err != nil {

--- a/launchdarkly/data_source_ai_tool_framework.go
+++ b/launchdarkly/data_source_ai_tool_framework.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &AIToolDataSource{}
@@ -79,7 +79,7 @@ func (d *AIToolDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	var tool *ldapi.AITool
 	var err error
 	err = d.client.withConcurrency(d.client.ctx, func() error {
-		tool, _, err = d.client.ld.AIConfigsApi.GetAITool(d.client.ctx, projectKey, key).Execute()
+		tool, _, err = d.client.ld.AgentControlApi.GetAITool(d.client.ctx, projectKey, key).Execute()
 		return err
 	})
 	if err != nil {

--- a/launchdarkly/data_source_audit_log_subscription_framework.go
+++ b/launchdarkly/data_source_audit_log_subscription_framework.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	strcase "github.com/stoewer/go-strcase"
 )
 

--- a/launchdarkly/data_source_big_segment_store_integration_framework.go
+++ b/launchdarkly/data_source_big_segment_store_integration_framework.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &BigSegmentStoreIntegrationDataSource{}

--- a/launchdarkly/data_source_context_kind_framework.go
+++ b/launchdarkly/data_source_context_kind_framework.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/data_source_environment_framework.go
+++ b/launchdarkly/data_source_environment_framework.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &EnvironmentDataSource{}

--- a/launchdarkly/data_source_feature_flag_environment_framework.go
+++ b/launchdarkly/data_source_feature_flag_environment_framework.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &FeatureFlagEnvironmentDataSource{}

--- a/launchdarkly/data_source_feature_flag_framework.go
+++ b/launchdarkly/data_source_feature_flag_framework.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &FeatureFlagDataSource{}

--- a/launchdarkly/data_source_flag_import_configuration_framework.go
+++ b/launchdarkly/data_source_flag_import_configuration_framework.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &FlagImportConfigurationDataSource{}

--- a/launchdarkly/data_source_flag_templates_framework.go
+++ b/launchdarkly/data_source_flag_templates_framework.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &FlagTemplatesDataSource{}

--- a/launchdarkly/data_source_flag_trigger_framework.go
+++ b/launchdarkly/data_source_flag_trigger_framework.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &FlagTriggerDataSource{}

--- a/launchdarkly/data_source_integration_delivery_configuration_framework.go
+++ b/launchdarkly/data_source_integration_delivery_configuration_framework.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &IntegrationDeliveryConfigurationDataSource{}

--- a/launchdarkly/data_source_launchdarkly_audit_log_subscription_test.go
+++ b/launchdarkly/data_source_launchdarkly_audit_log_subscription_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/data_source_launchdarkly_environment_test.go
+++ b/launchdarkly/data_source_launchdarkly_environment_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/data_source_launchdarkly_feature_flag_environment_test.go
+++ b/launchdarkly/data_source_launchdarkly_feature_flag_environment_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/launchdarkly/data_source_launchdarkly_feature_flag_test.go
+++ b/launchdarkly/data_source_launchdarkly_feature_flag_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/data_source_launchdarkly_flag_import_configuration_test.go
+++ b/launchdarkly/data_source_launchdarkly_flag_import_configuration_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/data_source_launchdarkly_flag_templates_test.go
+++ b/launchdarkly/data_source_launchdarkly_flag_templates_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/data_source_launchdarkly_flag_trigger_test.go
+++ b/launchdarkly/data_source_launchdarkly_flag_trigger_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/data_source_launchdarkly_integration_delivery_configuration_test.go
+++ b/launchdarkly/data_source_launchdarkly_integration_delivery_configuration_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/data_source_launchdarkly_metric_group_test.go
+++ b/launchdarkly/data_source_launchdarkly_metric_group_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/data_source_launchdarkly_metric_test.go
+++ b/launchdarkly/data_source_launchdarkly_metric_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/data_source_launchdarkly_oauth_client_test.go
+++ b/launchdarkly/data_source_launchdarkly_oauth_client_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/data_source_launchdarkly_project_test.go
+++ b/launchdarkly/data_source_launchdarkly_project_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/data_source_launchdarkly_relay_proxy_configuration_test.go
+++ b/launchdarkly/data_source_launchdarkly_relay_proxy_configuration_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/data_source_launchdarkly_release_policy_test.go
+++ b/launchdarkly/data_source_launchdarkly_release_policy_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/data_source_launchdarkly_segment_test.go
+++ b/launchdarkly/data_source_launchdarkly_segment_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/data_source_launchdarkly_team_member_test.go
+++ b/launchdarkly/data_source_launchdarkly_team_member_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/data_source_launchdarkly_team_members_test.go
+++ b/launchdarkly/data_source_launchdarkly_team_members_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/data_source_launchdarkly_team_test.go
+++ b/launchdarkly/data_source_launchdarkly_team_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/data_source_launchdarkly_webhook_test.go
+++ b/launchdarkly/data_source_launchdarkly_webhook_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/data_source_metric_framework.go
+++ b/launchdarkly/data_source_metric_framework.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &MetricDataSource{}

--- a/launchdarkly/data_source_metric_group_framework.go
+++ b/launchdarkly/data_source_metric_group_framework.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &MetricGroupDataSource{}

--- a/launchdarkly/data_source_model_config_framework.go
+++ b/launchdarkly/data_source_model_config_framework.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &ModelConfigDataSource{}
@@ -134,7 +134,7 @@ func (d *ModelConfigDataSource) Read(ctx context.Context, req datasource.ReadReq
 	var modelConfig *ldapi.ModelConfig
 	var err error
 	err = d.client.withConcurrency(d.client.ctx, func() error {
-		modelConfig, _, err = d.client.ld.AIConfigsApi.GetModelConfig(d.client.ctx, projectKey, key).Execute()
+		modelConfig, _, err = d.client.ld.AgentControlApi.GetModelConfig(d.client.ctx, projectKey, key).Execute()
 		return err
 	})
 	if err != nil {

--- a/launchdarkly/data_source_oauth_client_framework.go
+++ b/launchdarkly/data_source_oauth_client_framework.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &OAuthClientDataSource{}

--- a/launchdarkly/data_source_relay_proxy_configuration_framework.go
+++ b/launchdarkly/data_source_relay_proxy_configuration_framework.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &RelayProxyConfigurationDataSource{}

--- a/launchdarkly/data_source_release_policy_framework.go
+++ b/launchdarkly/data_source_release_policy_framework.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &ReleasePolicyDataSource{}

--- a/launchdarkly/data_source_segment_framework.go
+++ b/launchdarkly/data_source_segment_framework.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &SegmentDataSource{}

--- a/launchdarkly/data_source_team_framework.go
+++ b/launchdarkly/data_source_team_framework.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &TeamDataSource{}

--- a/launchdarkly/data_source_team_members_framework.go
+++ b/launchdarkly/data_source_team_members_framework.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &TeamMembersDataSource{}

--- a/launchdarkly/data_source_webhook_framework.go
+++ b/launchdarkly/data_source_webhook_framework.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var _ datasource.DataSource = &WebhookDataSource{}

--- a/launchdarkly/environments_framework.go
+++ b/launchdarkly/environments_framework.go
@@ -33,7 +33,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 // environmentModel matches the nested-environments element shape used in

--- a/launchdarkly/feature_flag_environment_helpers.go
+++ b/launchdarkly/feature_flag_environment_helpers.go
@@ -3,7 +3,7 @@ package launchdarkly
 import (
 	"net/http"
 
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 // rule is the patch payload shape used by acceptance tests that patch

--- a/launchdarkly/feature_flag_helpers.go
+++ b/launchdarkly/feature_flag_helpers.go
@@ -15,7 +15,7 @@ import (
 	"strconv"
 	"strings"
 
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 // Variation type identifiers.

--- a/launchdarkly/flag_import_configuration_helper.go
+++ b/launchdarkly/flag_import_configuration_helper.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 // betaVersionRoundTripper forces every request through it to carry exactly

--- a/launchdarkly/flag_templates_helper.go
+++ b/launchdarkly/flag_templates_helper.go
@@ -1,7 +1,7 @@
 package launchdarkly
 
 import (
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 // getCurrentCSA reads the current default_client_side_availability from the API

--- a/launchdarkly/helper.go
+++ b/launchdarkly/helper.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 // getRandomSleepDuration returns a duration between [0, maxDuration)

--- a/launchdarkly/helper_test.go
+++ b/launchdarkly/helper_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 func TestIsApprovalRequiredErr(t *testing.T) {

--- a/launchdarkly/metric_group_helper.go
+++ b/launchdarkly/metric_group_helper.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 // Metric group kinds. A funnel metric group orders its metrics into a
@@ -47,18 +47,13 @@ func newMetricGroupBetaClient(c *Client) (*Client, error) {
 }
 
 // metricGroupMaintainerID extracts the maintainer's member ID from the API
-// representation. The beta API returns maintainer as {key, kind, _member}, a
-// shape the v22 MaintainerRep model ({member, team}) predates — the member ID
-// arrives in AdditionalProperties["key"]. The typed read stays first so a
-// future client regen takes over transparently.
+// representation. The API returns maintainer as {key, kind, _member} where
+// key holds the member ID (or team key when kind is "team").
 func metricGroupMaintainerID(m ldapi.MaintainerRep) string {
 	if m.Member != nil && m.Member.GetId() != "" {
 		return m.Member.GetId()
 	}
-	if k, ok := m.AdditionalProperties["key"].(string); ok {
-		return k
-	}
-	return ""
+	return m.GetKey()
 }
 
 // metricGroupIdToKeys splits a composite metric group ID into its project key

--- a/launchdarkly/metric_group_helper_test.go
+++ b/launchdarkly/metric_group_helper_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/launchdarkly/policy_statements_framework.go
+++ b/launchdarkly/policy_statements_framework.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 // frameworkPolicyStatementsObjectAttrTypes is the attribute-type map

--- a/launchdarkly/policy_statements_helper.go
+++ b/launchdarkly/policy_statements_helper.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 // The relay proxy config api requires a statementRep in the POST body

--- a/launchdarkly/policy_statements_helper_test.go
+++ b/launchdarkly/policy_statements_helper_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/launchdarkly/project_helper.go
+++ b/launchdarkly/project_helper.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"net/url"
 
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 // buildProjectURL constructs a properly formatted URL for the projects API endpoint.

--- a/launchdarkly/release_policy_helper.go
+++ b/launchdarkly/release_policy_helper.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 // Release methods supported by a release policy. A guarded release rolls out

--- a/launchdarkly/release_policy_helper_test.go
+++ b/launchdarkly/release_policy_helper_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/launchdarkly/resource_access_token_framework.go
+++ b/launchdarkly/resource_access_token_framework.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_ai_agent_graph_framework.go
+++ b/launchdarkly/resource_ai_agent_graph_framework.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (
@@ -395,7 +395,7 @@ func (r *AIAgentGraphResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 	err = beta.withConcurrency(beta.ctx, func() error {
-		_, _, err := beta.ld.AIConfigsApi.PostAgentGraph(beta.ctx, projectKey).LDAPIVersion(agentGraphBetaVersion).AgentGraphPost(*post).Execute()
+		_, _, err := beta.ld.AgentControlApi.PostAgentGraph(beta.ctx, projectKey).LDAPIVersion(agentGraphBetaVersion).AgentGraphPost(*post).Execute()
 		return err
 	})
 	if err != nil {
@@ -496,7 +496,7 @@ func (r *AIAgentGraphResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 	err = beta.withConcurrency(beta.ctx, func() error {
-		_, _, err := beta.ld.AIConfigsApi.PatchAgentGraph(beta.ctx, projectKey, graphKey).LDAPIVersion(agentGraphBetaVersion).AgentGraphPatch(*patch).Execute()
+		_, _, err := beta.ld.AgentControlApi.PatchAgentGraph(beta.ctx, projectKey, graphKey).LDAPIVersion(agentGraphBetaVersion).AgentGraphPatch(*patch).Execute()
 		return err
 	})
 	if err != nil {
@@ -527,7 +527,7 @@ func (r *AIAgentGraphResource) Delete(ctx context.Context, req resource.DeleteRe
 	var res *http.Response
 	err = beta.withConcurrency(beta.ctx, func() error {
 		var e error
-		res, e = beta.ld.AIConfigsApi.DeleteAgentGraph(beta.ctx, projectKey, graphKey).LDAPIVersion(agentGraphBetaVersion).Execute()
+		res, e = beta.ld.AgentControlApi.DeleteAgentGraph(beta.ctx, projectKey, graphKey).LDAPIVersion(agentGraphBetaVersion).Execute()
 		return e
 	})
 	if err != nil {
@@ -567,7 +567,7 @@ func (r *AIAgentGraphResource) readIntoModel(
 	var graph *ldapi.AgentGraph
 	var res *http.Response
 	err = beta.withConcurrency(beta.ctx, func() error {
-		graph, res, err = beta.ld.AIConfigsApi.GetAgentGraph(beta.ctx, projectKey, graphKey).LDAPIVersion(agentGraphBetaVersion).Execute()
+		graph, res, err = beta.ld.AgentControlApi.GetAgentGraph(beta.ctx, projectKey, graphKey).LDAPIVersion(agentGraphBetaVersion).Execute()
 		return err
 	})
 	if err != nil {

--- a/launchdarkly/resource_ai_config_framework.go
+++ b/launchdarkly/resource_ai_config_framework.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (
@@ -260,7 +260,7 @@ func (r *AIConfigResource) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	err := r.client.withConcurrency(r.client.ctx, func() error {
-		_, _, e := r.client.ld.AIConfigsApi.PostAIConfig(r.client.ctx, projectKey).AIConfigPost(post).Execute()
+		_, _, e := r.client.ld.AgentControlApi.PostAIConfig(r.client.ctx, projectKey).AIConfigPost(post).Execute()
 		return e
 	})
 	if err != nil {
@@ -350,7 +350,7 @@ func (r *AIConfigResource) Update(ctx context.Context, req resource.UpdateReques
 
 	if hasChanges {
 		err := r.client.withConcurrency(r.client.ctx, func() error {
-			_, _, e := r.client.ld.AIConfigsApi.PatchAIConfig(r.client.ctx, projectKey, configKey).AIConfigPatch(patch).Execute()
+			_, _, e := r.client.ld.AgentControlApi.PatchAIConfig(r.client.ctx, projectKey, configKey).AIConfigPatch(patch).Execute()
 			return e
 		})
 		if err != nil {
@@ -384,7 +384,7 @@ func (r *AIConfigResource) Delete(ctx context.Context, req resource.DeleteReques
 		var res *http.Response
 		err := r.client.withConcurrency(r.client.ctx, func() error {
 			var e error
-			res, e = r.client.ld.AIConfigsApi.DeleteAIConfig(r.client.ctx, projectKey, configKey).Execute()
+			res, e = r.client.ld.AgentControlApi.DeleteAIConfig(r.client.ctx, projectKey, configKey).Execute()
 			return e
 		})
 		if err == nil || isStatusNotFound(res) {
@@ -421,7 +421,7 @@ func (r *AIConfigResource) readIntoModel(
 	var res *http.Response
 	var err error
 	err = r.client.withConcurrency(r.client.ctx, func() error {
-		cfg, res, err = r.client.ld.AIConfigsApi.GetAIConfig(r.client.ctx, projectKey, configKey).Execute()
+		cfg, res, err = r.client.ld.AgentControlApi.GetAIConfig(r.client.ctx, projectKey, configKey).Execute()
 		return err
 	})
 	if err != nil {

--- a/launchdarkly/resource_ai_config_variation_framework.go
+++ b/launchdarkly/resource_ai_config_variation_framework.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (
@@ -292,7 +292,7 @@ func (r *AIConfigVariationResource) Create(ctx context.Context, req resource.Cre
 	}
 
 	err := r.client.withConcurrency(r.client.ctx, func() error {
-		_, _, e := r.client.ld.AIConfigsApi.PostAIConfigVariation(r.client.ctx, projectKey, configKey).AIConfigVariationPost(*post).Execute()
+		_, _, e := r.client.ld.AgentControlApi.PostAIConfigVariation(r.client.ctx, projectKey, configKey).AIConfigVariationPost(*post).Execute()
 		return e
 	})
 	if err != nil {
@@ -382,7 +382,7 @@ func (r *AIConfigVariationResource) Update(ctx context.Context, req resource.Upd
 	}
 
 	err := r.client.withConcurrency(r.client.ctx, func() error {
-		_, _, e := r.client.ld.AIConfigsApi.PatchAIConfigVariation(r.client.ctx, projectKey, configKey, variationKey).AIConfigVariationPatch(*patch).Execute()
+		_, _, e := r.client.ld.AgentControlApi.PatchAIConfigVariation(r.client.ctx, projectKey, configKey, variationKey).AIConfigVariationPatch(*patch).Execute()
 		return e
 	})
 	if err != nil {
@@ -411,7 +411,7 @@ func (r *AIConfigVariationResource) Delete(ctx context.Context, req resource.Del
 	var res *http.Response
 	err := r.client.withConcurrency(r.client.ctx, func() error {
 		var e error
-		res, e = r.client.ld.AIConfigsApi.DeleteAIConfigVariation(r.client.ctx, projectKey, configKey, variationKey).Execute()
+		res, e = r.client.ld.AgentControlApi.DeleteAIConfigVariation(r.client.ctx, projectKey, configKey, variationKey).Execute()
 		return e
 	})
 	if err == nil || isStatusNotFound(res) {
@@ -484,7 +484,7 @@ func (r *AIConfigVariationResource) readIntoModel(
 	var res *http.Response
 	var err error
 	err = r.client.withConcurrency(r.client.ctx, func() error {
-		variationsResp, res, err = r.client.ld.AIConfigsApi.GetAIConfigVariation(r.client.ctx, projectKey, configKey, variationKey).Execute()
+		variationsResp, res, err = r.client.ld.AgentControlApi.GetAIConfigVariation(r.client.ctx, projectKey, configKey, variationKey).Execute()
 		return err
 	})
 	if err != nil {

--- a/launchdarkly/resource_ai_tool_framework.go
+++ b/launchdarkly/resource_ai_tool_framework.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (
@@ -217,7 +217,7 @@ func (r *AIToolResource) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	err = r.client.withConcurrency(r.client.ctx, func() error {
-		_, _, err := r.client.ld.AIConfigsApi.PostAITool(r.client.ctx, projectKey).AIToolPost(*post).Execute()
+		_, _, err := r.client.ld.AgentControlApi.PostAITool(r.client.ctx, projectKey).AIToolPost(*post).Execute()
 		return err
 	})
 	if err != nil {
@@ -298,7 +298,7 @@ func (r *AIToolResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	err := r.client.withConcurrency(r.client.ctx, func() error {
-		_, _, err := r.client.ld.AIConfigsApi.PatchAITool(r.client.ctx, projectKey, toolKey).AIToolPatch(*patch).Execute()
+		_, _, err := r.client.ld.AgentControlApi.PatchAITool(r.client.ctx, projectKey, toolKey).AIToolPatch(*patch).Execute()
 		return err
 	})
 	if err != nil {
@@ -322,7 +322,7 @@ func (r *AIToolResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	projectKey := data.ProjectKey.ValueString()
 	toolKey := data.Key.ValueString()
 	err := r.client.withConcurrency(r.client.ctx, func() error {
-		_, err := r.client.ld.AIConfigsApi.DeleteAITool(r.client.ctx, projectKey, toolKey).Execute()
+		_, err := r.client.ld.AgentControlApi.DeleteAITool(r.client.ctx, projectKey, toolKey).Execute()
 		return err
 	})
 	if err != nil {
@@ -355,7 +355,7 @@ func (r *AIToolResource) readIntoModel(
 	var res *http.Response
 	var err error
 	err = r.client.withConcurrency(r.client.ctx, func() error {
-		tool, res, err = r.client.ld.AIConfigsApi.GetAITool(r.client.ctx, projectKey, toolKey).Execute()
+		tool, res, err = r.client.ld.AgentControlApi.GetAITool(r.client.ctx, projectKey, toolKey).Execute()
 		return err
 	})
 	if err != nil {

--- a/launchdarkly/resource_announcement_framework.go
+++ b/launchdarkly/resource_announcement_framework.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 // announcementSeverities is the set of severities accepted by the

--- a/launchdarkly/resource_audit_log_subscription_framework.go
+++ b/launchdarkly/resource_audit_log_subscription_framework.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	strcase "github.com/stoewer/go-strcase"
 )
 

--- a/launchdarkly/resource_big_segment_store_integration_framework.go
+++ b/launchdarkly/resource_big_segment_store_integration_framework.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_context_kind_framework.go
+++ b/launchdarkly/resource_context_kind_framework.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_custom_role_framework.go
+++ b/launchdarkly/resource_custom_role_framework.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_destination_framework.go
+++ b/launchdarkly/resource_destination_framework.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_environment_framework.go
+++ b/launchdarkly/resource_environment_framework.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_feature_flag_environment_framework.go
+++ b/launchdarkly/resource_feature_flag_environment_framework.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_feature_flag_framework.go
+++ b/launchdarkly/resource_feature_flag_framework.go
@@ -28,7 +28,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_flag_import_configuration_framework.go
+++ b/launchdarkly/resource_flag_import_configuration_framework.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_flag_templates_framework.go
+++ b/launchdarkly/resource_flag_templates_framework.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_flag_trigger_framework.go
+++ b/launchdarkly/resource_flag_trigger_framework.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_integration_delivery_configuration_framework.go
+++ b/launchdarkly/resource_integration_delivery_configuration_framework.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_launchdarkly_ai_agent_graph_test.go
+++ b/launchdarkly/resource_launchdarkly_ai_agent_graph_test.go
@@ -237,7 +237,7 @@ func testAccCheckAIAgentGraphExists(resourceName string) resource.TestCheckFunc 
 		if err != nil {
 			return fmt.Errorf("failed to build beta client: %s", err)
 		}
-		_, _, err = beta.ld.AIConfigsApi.GetAgentGraph(beta.ctx, projectKey, graphKey).LDAPIVersion(agentGraphBetaVersion).Execute()
+		_, _, err = beta.ld.AgentControlApi.GetAgentGraph(beta.ctx, projectKey, graphKey).LDAPIVersion(agentGraphBetaVersion).Execute()
 		if err != nil {
 			return fmt.Errorf("received an error getting agent graph: %s", err)
 		}
@@ -258,7 +258,7 @@ var testAccCheckAIAgentGraphDestroy = func(s *terraform.State) error {
 		projectKey := rs.Primary.Attributes[PROJECT_KEY]
 		graphKey := rs.Primary.Attributes[KEY]
 
-		_, res, err := beta.ld.AIConfigsApi.GetAgentGraph(beta.ctx, projectKey, graphKey).LDAPIVersion(agentGraphBetaVersion).Execute()
+		_, res, err := beta.ld.AgentControlApi.GetAgentGraph(beta.ctx, projectKey, graphKey).LDAPIVersion(agentGraphBetaVersion).Execute()
 		if isStatusNotFound(res) {
 			continue
 		}

--- a/launchdarkly/resource_launchdarkly_ai_config_test.go
+++ b/launchdarkly/resource_launchdarkly_ai_config_test.go
@@ -377,7 +377,7 @@ func testAccCheckAIConfigExists(resourceName string) resource.TestCheckFunc {
 		configKey := rs.Primary.Attributes[KEY]
 
 		client := mustTestAccClient()
-		_, _, err := client.ld.AIConfigsApi.GetAIConfig(client.ctx, projectKey, configKey).Execute()
+		_, _, err := client.ld.AgentControlApi.GetAIConfig(client.ctx, projectKey, configKey).Execute()
 		if err != nil {
 			return fmt.Errorf("received an error getting AI config: %s", err)
 		}
@@ -395,7 +395,7 @@ var testAccCheckAIConfigDestroy = func(s *terraform.State) error {
 		projectKey := rs.Primary.Attributes[PROJECT_KEY]
 		configKey := rs.Primary.Attributes[KEY]
 
-		_, res, err := client.ld.AIConfigsApi.GetAIConfig(client.ctx, projectKey, configKey).Execute()
+		_, res, err := client.ld.AgentControlApi.GetAIConfig(client.ctx, projectKey, configKey).Execute()
 		if isStatusNotFound(res) {
 			continue
 		}

--- a/launchdarkly/resource_launchdarkly_ai_config_variation_test.go
+++ b/launchdarkly/resource_launchdarkly_ai_config_variation_test.go
@@ -364,7 +364,7 @@ func testAccCheckAIConfigVariationExists(resourceName string) resource.TestCheck
 		variationKey := rs.Primary.Attributes[KEY]
 
 		client := mustTestAccClient()
-		_, _, err := client.ld.AIConfigsApi.GetAIConfigVariation(client.ctx, projectKey, configKey, variationKey).Execute()
+		_, _, err := client.ld.AgentControlApi.GetAIConfigVariation(client.ctx, projectKey, configKey, variationKey).Execute()
 		if err != nil {
 			return fmt.Errorf("received an error getting AI config variation: %s", err)
 		}
@@ -383,7 +383,7 @@ var testAccCheckAIConfigVariationDestroy = func(s *terraform.State) error {
 		configKey := rs.Primary.Attributes[AI_CONFIG_KEY]
 		variationKey := rs.Primary.Attributes[KEY]
 
-		_, res, err := client.ld.AIConfigsApi.GetAIConfigVariation(client.ctx, projectKey, configKey, variationKey).Execute()
+		_, res, err := client.ld.AgentControlApi.GetAIConfigVariation(client.ctx, projectKey, configKey, variationKey).Execute()
 		if isStatusNotFound(res) {
 			continue
 		}

--- a/launchdarkly/resource_launchdarkly_ai_tool_test.go
+++ b/launchdarkly/resource_launchdarkly_ai_tool_test.go
@@ -157,7 +157,7 @@ func testAccCheckAIToolExists(resourceName string) resource.TestCheckFunc {
 		toolKey := rs.Primary.Attributes[KEY]
 
 		client := mustTestAccClient()
-		_, _, err := client.ld.AIConfigsApi.GetAITool(client.ctx, projectKey, toolKey).Execute()
+		_, _, err := client.ld.AgentControlApi.GetAITool(client.ctx, projectKey, toolKey).Execute()
 		if err != nil {
 			return fmt.Errorf("received an error getting AI tool: %s", err)
 		}
@@ -175,7 +175,7 @@ var testAccCheckAIToolDestroy = func(s *terraform.State) error {
 		projectKey := rs.Primary.Attributes[PROJECT_KEY]
 		toolKey := rs.Primary.Attributes[KEY]
 
-		_, res, err := client.ld.AIConfigsApi.GetAITool(client.ctx, projectKey, toolKey).Execute()
+		_, res, err := client.ld.AgentControlApi.GetAITool(client.ctx, projectKey, toolKey).Execute()
 		if isStatusNotFound(res) {
 			continue
 		}

--- a/launchdarkly/resource_launchdarkly_feature_flag_environment_test.go
+++ b/launchdarkly/resource_launchdarkly_feature_flag_environment_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/resource_launchdarkly_metric_test.go
+++ b/launchdarkly/resource_launchdarkly_metric_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/resource_launchdarkly_model_config_test.go
+++ b/launchdarkly/resource_launchdarkly_model_config_test.go
@@ -133,7 +133,7 @@ func testAccCheckModelConfigExists(resourceName string) resource.TestCheckFunc {
 		modelConfigKey := rs.Primary.Attributes[KEY]
 
 		client := mustTestAccClient()
-		_, _, err := client.ld.AIConfigsApi.GetModelConfig(client.ctx, projectKey, modelConfigKey).Execute()
+		_, _, err := client.ld.AgentControlApi.GetModelConfig(client.ctx, projectKey, modelConfigKey).Execute()
 		if err != nil {
 			return fmt.Errorf("received an error getting model config: %s", err)
 		}
@@ -151,7 +151,7 @@ var testAccCheckModelConfigDestroy = func(s *terraform.State) error {
 		projectKey := rs.Primary.Attributes[PROJECT_KEY]
 		modelConfigKey := rs.Primary.Attributes[KEY]
 
-		_, res, err := client.ld.AIConfigsApi.GetModelConfig(client.ctx, projectKey, modelConfigKey).Execute()
+		_, res, err := client.ld.AgentControlApi.GetModelConfig(client.ctx, projectKey, modelConfigKey).Execute()
 		if isStatusNotFound(res) {
 			continue
 		}

--- a/launchdarkly/resource_launchdarkly_segment_view_keys_test.go
+++ b/launchdarkly/resource_launchdarkly_segment_view_keys_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 )
 

--- a/launchdarkly/resource_metric_framework.go
+++ b/launchdarkly/resource_metric_framework.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 const CUSTOM_METRIC_DEFAULT_SUCCESS_CRITERIA = "HigherThanBaseline"

--- a/launchdarkly/resource_metric_group_framework.go
+++ b/launchdarkly/resource_metric_group_framework.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_model_config_framework.go
+++ b/launchdarkly/resource_model_config_framework.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (
@@ -258,7 +258,7 @@ func (r *ModelConfigResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	err := r.client.withConcurrency(r.client.ctx, func() error {
-		_, _, err := r.client.ld.AIConfigsApi.PostModelConfig(r.client.ctx, projectKey).ModelConfigPost(post).Execute()
+		_, _, err := r.client.ld.AgentControlApi.PostModelConfig(r.client.ctx, projectKey).ModelConfigPost(post).Execute()
 		return err
 	})
 	if err != nil {
@@ -316,7 +316,7 @@ func (r *ModelConfigResource) Delete(ctx context.Context, req resource.DeleteReq
 	var res *http.Response
 	err := r.client.withConcurrency(r.client.ctx, func() error {
 		var e error
-		res, e = r.client.ld.AIConfigsApi.DeleteModelConfig(r.client.ctx, projectKey, key).Execute()
+		res, e = r.client.ld.AgentControlApi.DeleteModelConfig(r.client.ctx, projectKey, key).Execute()
 		return e
 	})
 	if err != nil {
@@ -364,7 +364,7 @@ func (r *ModelConfigResource) readIntoModel(
 	var res *http.Response
 	var err error
 	err = r.client.withConcurrency(r.client.ctx, func() error {
-		modelConfig, res, err = r.client.ld.AIConfigsApi.GetModelConfig(r.client.ctx, projectKey, key).Execute()
+		modelConfig, res, err = r.client.ld.AgentControlApi.GetModelConfig(r.client.ctx, projectKey, key).Execute()
 		return err
 	})
 	if err != nil {

--- a/launchdarkly/resource_oauth_client_framework.go
+++ b/launchdarkly/resource_oauth_client_framework.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_project_framework.go
+++ b/launchdarkly/resource_project_framework.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_relay_proxy_configuration_framework.go
+++ b/launchdarkly/resource_relay_proxy_configuration_framework.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_release_policy_framework.go
+++ b/launchdarkly/resource_release_policy_framework.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_segment_framework.go
+++ b/launchdarkly/resource_segment_framework.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_team_framework.go
+++ b/launchdarkly/resource_team_framework.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_team_member_framework.go
+++ b/launchdarkly/resource_team_member_framework.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_team_role_mapping.go
+++ b/launchdarkly/resource_team_role_mapping.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/resource_webhook_framework.go
+++ b/launchdarkly/resource_webhook_framework.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 var (

--- a/launchdarkly/role_attributes_framework.go
+++ b/launchdarkly/role_attributes_framework.go
@@ -18,7 +18,7 @@ import (
 	rsschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 const roleAttributesDescription = "A map of role attributes, keyed by the role attribute key with a string array of resource keys as each value. For example, if your policy statement defines the resource `\"proj/$${roleAttribute/testAttribute}\"`, the key would be `testAttribute` and the values the keys of the projects you wanted to assign access to."

--- a/launchdarkly/team_helper.go
+++ b/launchdarkly/team_helper.go
@@ -3,7 +3,7 @@ package launchdarkly
 import (
 	"fmt"
 
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 const (

--- a/launchdarkly/team_helper_test.go
+++ b/launchdarkly/team_helper_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/semaphore"

--- a/launchdarkly/team_member_helper.go
+++ b/launchdarkly/team_member_helper.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strings"
 
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 // getTeamMemberByEmail performs a paginated GetMembers search filtered

--- a/launchdarkly/test_utils.go
+++ b/launchdarkly/test_utils.go
@@ -3,7 +3,7 @@ package launchdarkly
 import (
 	"fmt"
 
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 // testAccProjectScaffoldCreate creates a project with the given project parameters

--- a/launchdarkly/view_helper.go
+++ b/launchdarkly/view_helper.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strings"
 
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 const viewAssociationsPageLimit = int32(100)

--- a/launchdarkly/view_helper_test.go
+++ b/launchdarkly/view_helper_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	ldapi "github.com/launchdarkly/api-client-go/v22"
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/semaphore"
 )
@@ -52,19 +52,20 @@ func TestViewRequestsIncludeUserAgentHeader(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		err := json.NewEncoder(w).Encode(map[string]interface{}{
-			"id":          "view-id",
-			"accountId":   "account-id",
-			"projectId":   "project-id",
-			"projectKey":  projectKey,
-			"key":         viewKey,
-			"name":        "Test View",
-			"description": "",
-			"version":     1,
-			"tags":        []string{},
-			"createdAt":   0,
-			"updatedAt":   0,
-			"archived":    false,
-			"deleted":     false,
+			"id":                 "view-id",
+			"accountId":          "account-id",
+			"_affectsSdkPayload": false,
+			"projectId":          "project-id",
+			"projectKey":         projectKey,
+			"key":                viewKey,
+			"name":               "Test View",
+			"description":        "",
+			"version":            1,
+			"tags":               []string{},
+			"createdAt":          0,
+			"updatedAt":          0,
+			"archived":           false,
+			"deleted":            false,
 		})
 		require.NoError(t, err)
 	}))


### PR DESCRIPTION
## Summary

Upgrades `github.com/launchdarkly/api-client-go` from v22.0.0 to v23.0.0 ([release notes](https://github.com/launchdarkly/api-client-go/releases/tag/v23.0.0)).

Mechanical bump plus the two adaptations v23 forces:

- **`AIConfigsApi` → `AgentControlApi`** — upstream renamed the "AI Configs" API tag to "AgentControl". Method names are unchanged; 34 call sites across the AI config, variation, tool, model config, and agent graph resources/data sources.
- **`MaintainerRep` is now typed as the beta shape** `{key, kind, _member}` with `key` and `kind` required. `metricGroupMaintainerID`'s `AdditionalProperties["key"]` fallback stopped receiving the key (it is a typed field now), so it reads `GetKey()` instead. This closes the beta-model AdditionalProperties gap noted in the metric-group pilot.
- **`View` now requires `_affectsSdkPayload`** — added to the mock response in `view_helper_test.go`. (`generateSdkKeys` is gone from `ViewPost`/`ViewPatch`; the provider never used it.)
- Autogen scaffold instructions now reference the v23 client.

### Removed-surface audit

The provider uses nothing v23 removed: context-instances DELETE, user-search pagination params, databricks/redshift data source enums, `UsersBeta.GetUserAttributeNames`. `randomizationUnits` on metrics is deprecated (→ `analysisUnits`) but still present; migrating is deferred to a follow-up. `LD-API-Version: 20240415` remains the latest documented version, so `APIVersion` is unchanged.

An exhaustive diff of `requiredProperties` blocks across all shared models found only `View` and `MaintainerRep` with strictness changes — both handled above.

### Follow-ups (intentionally not in this PR)

- Migrate `ip_allowlist` raw-HTTP helper to the new typed `IPAllowlistBeta` API
- `randomizationUnits` → `analysisUnits` on metrics (schema surface, needs its own design)
- prompt_snippet scaffold via autogen (unblocked by v23)

## Test plan

- [x] `go build ./...`, `go vet ./...`, `make fmtcheck` clean
- [x] Full unit suite (remaining failures reproduce identically on v22 baseline: local 404-retry timeout math, stale local errcheck binary)
- [x] 41 acceptance tests against a real LaunchDarkly account, 0 failures: full AI/AgentControl family + views (34), metric groups incl. maintainer round-trip (4), core project/flag/segment/environment smoke (3)
- [ ] CI acceptance matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide mechanical dependency bump touching most API call sites; AI/AgentControl and metric-group maintainer reads are the only non-import behavior changes, with acceptance coverage noted in the PR.
> 
> **Overview**
> Upgrades the provider to **`github.com/launchdarkly/api-client-go/v23`** (`go.mod` / `go.sum`) and updates every `ldapi` import plus autogen scaffold instructions to match.
> 
> The main behavioral adaptation is routing **AI / agent control** calls through **`AgentControlApi`** instead of the removed **`AIConfigsApi`** (agent graphs, AI configs, variations, tools, and model configs in resources, data sources, and acceptance checks). Method names are unchanged.
> 
> **`metricGroupMaintainerID`** now reads the maintainer identifier via **`MaintainerRep.GetKey()`** instead of digging through **`AdditionalProperties`**, matching v23’s typed beta maintainer shape. **`view_helper_test`** adds required **`_affectsSdkPayload`** on the mocked View JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa34a716809df7f167befab43bf28d327ac27336. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->