### PR TITLE
feat!: adopt api-client-go v23 typed clients and field renames

### DIFF
--- a/docs/data-sources/metric.md
+++ b/docs/data-sources/metric.md
@@ -33,6 +33,7 @@ data "launchdarkly_metric" "example" {
 ### Read-Only
 
 - `analysis_type` (String) The method for analyzing metric events.
+- `analysis_units` (Set of String) A set of one or more context kinds that this metric can measure events from.
 - `description` (String) The description of the metric's purpose.
 - `event_key` (String) The event key for your metric (if custom metric).
 - `id` (String) The ID in the format `project_key/key`.
@@ -42,7 +43,6 @@ data "launchdarkly_metric" "example" {
 - `maintainer_id` (String) The LaunchDarkly member ID of the maintainer.
 - `name` (String) The human-friendly name for the metric.
 - `percentile_value` (Number) The percentile for the analysis method.
-- `randomization_units` (Set of String) A set of one or more context kinds that this metric can measure events from.
 - `selector` (String) The CSS selector for your metric (if click metric).
 - `success_criteria` (String) The success criteria for your metric (if numeric metric).
 - `tags` (Set of String) Tags associated with the metric.

--- a/docs/guides/migrating-to-v3.md
+++ b/docs/guides/migrating-to-v3.md
@@ -116,7 +116,7 @@ The provider includes a state upgrader for every resource whose state shape chan
 - `launchdarkly_flag_trigger`: converts `instructions` to an object.
 - `launchdarkly_flag_templates`: converts `boolean_defaults` to an object.
 - `launchdarkly_team` and `launchdarkly_team_member`: re-key `role_attributes` into a map of string lists.
-- `launchdarkly_metric`: discards `is_active`.
+- `launchdarkly_metric`: discards `is_active`, and renames `randomization_units` to `analysis_units` (following the LaunchDarkly API's rename).
 
 ## Your first plan after upgrading
 

--- a/docs/guides/v3-release-notes.md
+++ b/docs/guides/v3-release-notes.md
@@ -141,6 +141,7 @@ v3 removes the attributes that v2 marked deprecated. The state upgrade migrates 
 | `launchdarkly_project` resource | `include_in_snippet` | `default_client_side_availability` |
 | `launchdarkly_project` data source | `client_side_availability` | `default_client_side_availability` |
 | `launchdarkly_metric` | `is_active` | None. Remove it from your configuration. |
+| `launchdarkly_metric` resource and data source | `randomization_units` | `analysis_units` |
 
 ### Minimum versions
 

--- a/docs/resources/metric.md
+++ b/docs/resources/metric.md
@@ -46,13 +46,13 @@ resource "launchdarkly_metric" "example" {
 ### Optional
 
 - `analysis_type` (String) The method for analyzing metric events. Available choices are `mean` and `percentile`.
+- `analysis_units` (Set of String) A set of one or more context kinds that this metric can measure events from. Metrics can only use context kinds marked as "Available for experiments." For more information, read [Allocating experiment audiences](https://docs.launchdarkly.com/home/creating-experiments/allocation).
 - `description` (String) The description of the metric's purpose.
 - `event_key` (String) The event key for your metric (if custom metric)
 - `include_units_without_events` (Boolean) Include units that did not send any events and set their value to 0.
 - `is_numeric` (Boolean) Whether a `custom` metric is a numeric metric or not.
 - `maintainer_id` (String) The LaunchDarkly member ID of the member who will maintain the metric. If not set, the API will automatically apply the member associated with your Terraform API key or the most recently-set maintainer
 - `percentile_value` (Number) The percentile for the analysis method. An integer denoting the target percentile between 0 and 100. Required when analysis_type is percentile.
-- `randomization_units` (Set of String) A set of one or more context kinds that this metric can measure events from. Metrics can only use context kinds marked as "Available for experiments." For more information, read [Allocating experiment audiences](https://docs.launchdarkly.com/home/creating-experiments/allocation).
 - `selector` (String) The CSS selector for your metric (if click metric)
 - `success_criteria` (String) The success criteria for your metric (if numeric metric). Available choices are `HigherThanBaseline` and `LowerThanBaseline`.
 - `tags` (Set of String) Tags associated with this resource.

--- a/launchdarkly/data_source_launchdarkly_metric_test.go
+++ b/launchdarkly/data_source_launchdarkly_metric_test.go
@@ -31,8 +31,8 @@ func testAccDataSourceMetricScaffold(client *Client, betaClient *Client, project
 		return nil, err
 	}
 
-	randomizationUnitsInput := make([]ldapi.RandomizationUnitInput, 0, len(metricBody.RandomizationUnits))
-	for _, randomizationUnit := range metricBody.RandomizationUnits {
+	randomizationUnitsInput := make([]ldapi.RandomizationUnitInput, 0, len(metricBody.AnalysisUnits))
+	for _, randomizationUnit := range metricBody.AnalysisUnits {
 		if randomizationUnit == "user" {
 			defaultTrue := true
 			defaultRandomizationUnit := *ldapi.NewRandomizationUnitInput(randomizationUnit)
@@ -125,8 +125,8 @@ func TestAccDataSourceMetric_exists(t *testing.T) {
 			Kind:      &metricUrlKind,
 			Substring: &metricUrlSubstring,
 		}},
-		Description:        ldapi.PtrString("a metric to test the terraform metric data source"),
-		RandomizationUnits: []string{"request", "user"},
+		Description:   ldapi.PtrString("a metric to test the terraform metric data source"),
+		AnalysisUnits: []string{"request", "user"},
 	}
 	metric, err := testAccDataSourceMetricScaffold(client, betaClient, projectKey, metricBody)
 	require.NoError(t, err)
@@ -154,8 +154,8 @@ func TestAccDataSourceMetric_exists(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, DESCRIPTION, *metric.Description),
 					resource.TestCheckResourceAttr(resourceName, ID, projectKey+"/"+metric.Key),
 					resource.TestCheckResourceAttr(resourceName, KIND, metric.Kind),
-					resource.TestCheckResourceAttr(resourceName, RANDOMIZATION_UNITS+".0", metric.RandomizationUnits[0]),
-					resource.TestCheckResourceAttr(resourceName, RANDOMIZATION_UNITS+".1", metric.RandomizationUnits[1]),
+					resource.TestCheckResourceAttr(resourceName, ANALYSIS_UNITS+".0", metric.AnalysisUnits[0]),
+					resource.TestCheckResourceAttr(resourceName, ANALYSIS_UNITS+".1", metric.AnalysisUnits[1]),
 					resource.TestCheckResourceAttr(resourceName, "urls.0.kind", metricUrlKind),
 					resource.TestCheckResourceAttr(resourceName, "urls.0.substring", metricUrlSubstring),
 				),

--- a/launchdarkly/data_source_metric_framework.go
+++ b/launchdarkly/data_source_metric_framework.go
@@ -31,7 +31,7 @@ type MetricDataSourceModel struct {
 	EventKey                  types.String `tfsdk:"event_key"`
 	SuccessCriteria           types.String `tfsdk:"success_criteria"`
 	URLs                      types.List   `tfsdk:"urls"`
-	RandomizationUnits        types.Set    `tfsdk:"randomization_units"`
+	AnalysisUnits             types.Set    `tfsdk:"analysis_units"`
 	IncludeUnitsWithoutEvents types.Bool   `tfsdk:"include_units_without_events"`
 	UnitAggregationType       types.String `tfsdk:"unit_aggregation_type"`
 	AnalysisType              types.String `tfsdk:"analysis_type"`
@@ -111,7 +111,7 @@ func (d *MetricDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 				Computed:    true,
 				Description: "The success criteria for your metric (if numeric metric).",
 			},
-			RANDOMIZATION_UNITS: schema.SetAttribute{
+			ANALYSIS_UNITS: schema.SetAttribute{
 				Computed:    true,
 				ElementType: types.StringType,
 				Description: "A set of one or more context kinds that this metric can measure events from.",
@@ -246,9 +246,17 @@ func (d *MetricDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	resp.Diagnostics.Append(diags...)
 	data.Tags = tagsSet
 
-	randomization, diags := setFromStringSlice(ctx, metric.RandomizationUnits)
+	// GET mirrors randomizationUnits and analysisUnits server-side at read
+	// time, regardless of metric age or which field was written (verified
+	// against the live API, incl. pre-rename metrics). The fallback is
+	// defense-in-depth only.
+	analysisUnitsRaw := metric.AnalysisUnits
+	if analysisUnitsRaw == nil {
+		analysisUnitsRaw = metric.RandomizationUnits
+	}
+	analysisUnits, diags := setFromStringSlice(ctx, analysisUnitsRaw)
 	resp.Diagnostics.Append(diags...)
-	data.RandomizationUnits = randomization
+	data.AnalysisUnits = analysisUnits
 
 	objectType := types.ObjectType{AttrTypes: metricURLAttrTypes}
 	elements := make([]attr.Value, 0, len(metric.Urls))

--- a/launchdarkly/ip_allowlist_helper.go
+++ b/launchdarkly/ip_allowlist_helper.go
@@ -1,13 +1,9 @@
 package launchdarkly
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-	"strings"
 	"sync"
+
+	ldapi "github.com/launchdarkly/api-client-go/v23"
 )
 
 // LD's IP allowlist API persists the whole allowlist as a single account
@@ -24,179 +20,140 @@ import (
 // handle the orphan scenario.
 var ipAllowlistWriteMu sync.Mutex
 
-func ipAllowlistMethodMutates(method string) bool {
-	switch method {
-	case http.MethodPost, http.MethodPatch, http.MethodPut, http.MethodDelete:
-		return true
-	}
-	return false
-}
-
-type ipAllowlistResponse struct {
-	SessionAllowlistEnabled  bool                       `json:"sessionAllowlistEnabled"`
-	ApiTokenAllowlistEnabled bool                       `json:"apiTokenAllowlistEnabled"`
-	Entries                  []ipAllowlistEntryResponse `json:"entries"`
-}
-
-type ipAllowlistEntryResponse struct {
-	ID          string  `json:"_id"`
-	IpAddress   string  `json:"ipAddress"`
-	Description *string `json:"description,omitempty"`
-}
-
-type createIpAllowlistEntryRequest struct {
-	IpAddress   string  `json:"ipAddress"`
-	Description *string `json:"description,omitempty"`
-}
-
-type patchIpAllowlistEntryRequest struct {
-	Description string `json:"description"`
-}
-
-type patchIpAllowlistConfigRequest struct {
-	SessionAllowlistEnabled  *bool `json:"sessionAllowlistEnabled,omitempty"`
-	ApiTokenAllowlistEnabled *bool `json:"apiTokenAllowlistEnabled,omitempty"`
-}
-
-type ipAllowlistErrorResponse struct {
-	Message string `json:"message"`
-	Code    string `json:"code"`
-}
-
-const ipAllowlistBasePath = "/api/v2/account/ip-allowlist"
-
-func ipAllowlistRequest(client *Client, method, path string, body interface{}) (*http.Response, []byte, error) {
-	endpoint := fmt.Sprintf("%s%s", client.apiHost, path)
-	if !strings.HasPrefix(endpoint, "http") {
-		endpoint = "https://" + endpoint
-	}
-
-	var bodyReader io.Reader
-	if body != nil {
-		rawBody, err := json.Marshal(body)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to marshal request body: %w", err)
-		}
-		bodyReader = bytes.NewBuffer(rawBody)
-	}
-
-	req, err := http.NewRequest(method, endpoint, bodyReader)
+// ipAllowlistBetaClient returns a beta-configured client for the IP
+// allowlist endpoints. The generated IPAllowlistBetaApi request builders
+// do not expose a per-request `.LDAPIVersion("beta")` setter, so we force
+// the `LD-API-Version: beta` header at the transport layer (see
+// betaVersionRoundTripper for why a default header is insufficient).
+func ipAllowlistBetaClient(c *Client) (*Client, error) {
+	beta, err := newBetaClient(c.apiKey, c.apiHost, false, DEFAULT_HTTP_TIMEOUT_S, DEFAULT_MAX_CONCURRENCY)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", client.apiKey)
-	req.Header.Set("LD-API-Version", "beta")
-
-	// Mutating calls serialise in-process so two test goroutines don't
-	// race the LD account allowlist version. GETs skip the mutex.
-	if ipAllowlistMethodMutates(method) {
-		ipAllowlistWriteMu.Lock()
-		defer ipAllowlistWriteMu.Unlock()
-	}
-
-	var resp *http.Response
-	err = client.withConcurrency(client.ctx, func() error {
-		resp, err = client.fallbackClient.Do(req)
-		return err
-	})
-	if err != nil {
-		return resp, nil, fmt.Errorf("request failed: %w", err)
-	}
-
-	respBody, err := io.ReadAll(resp.Body)
-	defer resp.Body.Close()
-	if err != nil {
-		return resp, nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	if resp.StatusCode >= 400 {
-		var apiErr ipAllowlistErrorResponse
-		if jsonErr := json.Unmarshal(respBody, &apiErr); jsonErr == nil && apiErr.Message != "" {
-			return resp, respBody, fmt.Errorf("API error (%d): %s", resp.StatusCode, apiErr.Message)
-		}
-		return resp, respBody, fmt.Errorf("API error (%d): %s", resp.StatusCode, string(respBody))
-	}
-
-	return resp, respBody, nil
+	forceBetaAPIVersion(beta.ld)
+	forceBetaAPIVersion(beta.ld404Retry)
+	return beta, nil
 }
 
-func getIpAllowlist(client *Client) (*ipAllowlistResponse, error) {
-	_, respBody, err := ipAllowlistRequest(client, http.MethodGet, ipAllowlistBasePath, nil)
+func getIpAllowlist(client *Client) (*ldapi.IpAllowlistResponse, error) {
+	beta, err := ipAllowlistBetaClient(client)
 	if err != nil {
 		return nil, err
 	}
 
-	var result ipAllowlistResponse
-	if err := json.Unmarshal(respBody, &result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal IP allowlist response: %w", err)
+	var result *ldapi.IpAllowlistResponse
+	err = beta.withConcurrency(beta.ctx, func() error {
+		result, _, err = beta.ld.IPAllowlistBetaApi.GetIpAllowlist(beta.ctx).Execute()
+		return err
+	})
+	if err != nil {
+		return nil, handleLdapiErr(err)
 	}
-	return &result, nil
+	return result, nil
 }
 
-func createIpAllowlistEntry(client *Client, ipAddress string, description *string) (*ipAllowlistEntryResponse, error) {
-	reqBody := createIpAllowlistEntryRequest{
+func createIpAllowlistEntry(client *Client, ipAddress string, description *string) (*ldapi.IpAllowlistEntryResponse, error) {
+	beta, err := ipAllowlistBetaClient(client)
+	if err != nil {
+		return nil, err
+	}
+
+	reqBody := ldapi.CreateIpAllowlistEntryRequest{
 		IpAddress:   ipAddress,
 		Description: description,
 	}
 
-	_, respBody, err := ipAllowlistRequest(client, http.MethodPost, ipAllowlistBasePath, reqBody)
+	ipAllowlistWriteMu.Lock()
+	defer ipAllowlistWriteMu.Unlock()
+
+	var result *ldapi.IpAllowlistEntryResponse
+	err = beta.withConcurrency(beta.ctx, func() error {
+		result, _, err = beta.ld.IPAllowlistBetaApi.CreateIpAllowlistEntry(beta.ctx).
+			CreateIpAllowlistEntryRequest(reqBody).
+			Execute()
+		return err
+	})
+	if err != nil {
+		return nil, handleLdapiErr(err)
+	}
+	return result, nil
+}
+
+func patchIpAllowlistEntry(client *Client, id string, description string) (*ldapi.IpAllowlistEntryResponse, error) {
+	beta, err := ipAllowlistBetaClient(client)
 	if err != nil {
 		return nil, err
 	}
 
-	var result ipAllowlistEntryResponse
-	if err := json.Unmarshal(respBody, &result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal IP allowlist entry response: %w", err)
-	}
-	return &result, nil
-}
-
-func patchIpAllowlistEntry(client *Client, id string, description string) (*ipAllowlistEntryResponse, error) {
-	path := fmt.Sprintf("%s/%s", ipAllowlistBasePath, id)
-	reqBody := patchIpAllowlistEntryRequest{
+	reqBody := ldapi.PatchIpAllowlistEntryRequest{
 		Description: description,
 	}
 
-	_, respBody, err := ipAllowlistRequest(client, http.MethodPatch, path, reqBody)
+	ipAllowlistWriteMu.Lock()
+	defer ipAllowlistWriteMu.Unlock()
+
+	var result *ldapi.IpAllowlistEntryResponse
+	err = beta.withConcurrency(beta.ctx, func() error {
+		result, _, err = beta.ld.IPAllowlistBetaApi.PatchIpAllowlistEntry(beta.ctx, id).
+			PatchIpAllowlistEntryRequest(reqBody).
+			Execute()
+		return err
+	})
+	if err != nil {
+		return nil, handleLdapiErr(err)
+	}
+	return result, nil
+}
+
+func deleteIpAllowlistEntry(client *Client, id string) error {
+	beta, err := ipAllowlistBetaClient(client)
+	if err != nil {
+		return err
+	}
+
+	ipAllowlistWriteMu.Lock()
+	defer ipAllowlistWriteMu.Unlock()
+
+	err = beta.withConcurrency(beta.ctx, func() error {
+		_, err = beta.ld.IPAllowlistBetaApi.DeleteIpAllowlistEntry(beta.ctx, id).Execute()
+		return err
+	})
+	if err != nil {
+		return handleLdapiErr(err)
+	}
+	return nil
+}
+
+func patchIpAllowlistConfig(client *Client, sessionEnabled, scopedEnabled *bool) (*ldapi.IpAllowlistResponse, error) {
+	beta, err := ipAllowlistBetaClient(client)
 	if err != nil {
 		return nil, err
 	}
 
-	var result ipAllowlistEntryResponse
-	if err := json.Unmarshal(respBody, &result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal IP allowlist entry response: %w", err)
-	}
-	return &result, nil
-}
-
-func deleteIpAllowlistEntry(client *Client, id string) error {
-	path := fmt.Sprintf("%s/%s", ipAllowlistBasePath, id)
-	_, _, err := ipAllowlistRequest(client, http.MethodDelete, path, nil)
-	return err
-}
-
-func patchIpAllowlistConfig(client *Client, sessionEnabled, scopedEnabled *bool) (*ipAllowlistResponse, error) {
-	reqBody := patchIpAllowlistConfigRequest{
+	reqBody := ldapi.PatchIpAllowlistConfigRequest{
 		SessionAllowlistEnabled:  sessionEnabled,
 		ApiTokenAllowlistEnabled: scopedEnabled,
 	}
 
-	_, respBody, err := ipAllowlistRequest(client, http.MethodPatch, ipAllowlistBasePath, reqBody)
-	if err != nil {
-		return nil, err
-	}
+	ipAllowlistWriteMu.Lock()
+	defer ipAllowlistWriteMu.Unlock()
 
-	var result ipAllowlistResponse
-	if err := json.Unmarshal(respBody, &result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal IP allowlist response: %w", err)
+	var result *ldapi.IpAllowlistResponse
+	err = beta.withConcurrency(beta.ctx, func() error {
+		result, _, err = beta.ld.IPAllowlistBetaApi.PatchIpAllowlistConfig(beta.ctx).
+			PatchIpAllowlistConfigRequest(reqBody).
+			Execute()
+		return err
+	})
+	if err != nil {
+		return nil, handleLdapiErr(err)
 	}
-	return &result, nil
+	return result, nil
 }
 
-func findIpAllowlistEntryByID(entries []ipAllowlistEntryResponse, id string) *ipAllowlistEntryResponse {
+func findIpAllowlistEntryByID(entries []ldapi.IpAllowlistEntryResponse, id string) *ldapi.IpAllowlistEntryResponse {
 	for _, entry := range entries {
-		if entry.ID == id {
+		if entry.Id == id {
 			return &entry
 		}
 	}

--- a/launchdarkly/keys.go
+++ b/launchdarkly/keys.go
@@ -10,6 +10,7 @@ const (
 	AI_CONFIG_KEY                             = "config_key"
 	ALLOCATION                                = "allocation"
 	ANALYSIS_TYPE                             = "analysis_type"
+	ANALYSIS_UNITS                            = "analysis_units"
 	API_KEY                                   = "api_key"
 	APPROVAL_SETTINGS                         = "approval_settings"
 	ARCHIVED                                  = "archived"

--- a/launchdarkly/resource_ip_allowlist_framework.go
+++ b/launchdarkly/resource_ip_allowlist_framework.go
@@ -234,7 +234,7 @@ func (r *IPAllowlistEntryResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
-	plan.ID = types.StringValue(entry.ID)
+	plan.ID = types.StringValue(entry.Id)
 	r.readIntoModel(plan.ID.ValueString(), &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
@@ -309,7 +309,7 @@ func (r *IPAllowlistEntryResource) readIntoModel(id string, data *IPAllowlistEnt
 		data.ID = types.StringNull()
 		return
 	}
-	data.ID = types.StringValue(entry.ID)
+	data.ID = types.StringValue(entry.Id)
 	data.IPAddress = types.StringValue(entry.IpAddress)
 	data.Description = stringValueFromPointer(entry.Description)
 }

--- a/launchdarkly/resource_launchdarkly_ip_allowlist_entry_test.go
+++ b/launchdarkly/resource_launchdarkly_ip_allowlist_entry_test.go
@@ -39,11 +39,11 @@ func cleanupOrphanIpAllowlistEntries(t *testing.T) {
 		if _, hit := targets[entry.IpAddress]; !hit {
 			continue
 		}
-		if delErr := deleteIpAllowlistEntry(client, entry.ID); delErr != nil {
-			t.Logf("ip-allowlist cleanup: failed to delete orphan %s (%s): %s", entry.ID, entry.IpAddress, delErr)
+		if delErr := deleteIpAllowlistEntry(client, entry.Id); delErr != nil {
+			t.Logf("ip-allowlist cleanup: failed to delete orphan %s (%s): %s", entry.Id, entry.IpAddress, delErr)
 			continue
 		}
-		t.Logf("ip-allowlist cleanup: deleted orphan entry %s for %s", entry.ID, entry.IpAddress)
+		t.Logf("ip-allowlist cleanup: deleted orphan entry %s for %s", entry.Id, entry.IpAddress)
 	}
 }
 

--- a/launchdarkly/resource_launchdarkly_metric_test.go
+++ b/launchdarkly/resource_launchdarkly_metric_test.go
@@ -53,7 +53,7 @@ resource "launchdarkly_metric" "basic" {
 }
 `
 
-	testAccMetricCustomWithRandomizationUnitsFmt = `
+	testAccMetricCustomWithAnalysisUnitsFmt = `
 resource "launchdarkly_metric" "custom" {
 	project_key = "%s"
 	key         = "custom-metric"
@@ -62,14 +62,14 @@ resource "launchdarkly_metric" "custom" {
 	kind        = "custom"
 	is_numeric  = false
 
-	randomization_units = [
+	analysis_units = [
 		"request",
 		"user"
 	]
 }
 `
 
-	testAccMetricCustomWithRandomizationUnitsUpdateFmt = `
+	testAccMetricCustomWithAnalysisUnitsUpdateFmt = `
 resource "launchdarkly_metric" "custom" {
 	project_key = "%s"
 	key         = "custom-metric"
@@ -78,7 +78,7 @@ resource "launchdarkly_metric" "custom" {
 	kind        = "custom"
 	is_numeric  = false
 
-	randomization_units = [
+	analysis_units = [
 		"organization",
 	  "request",
 		"user"
@@ -175,7 +175,7 @@ func TestAccMetric_BasicCreateAndUpdate(t *testing.T) {
 	})
 }
 
-func TestAccMetric_WithRandomizationUnits(t *testing.T) {
+func TestAccMetric_WithAnalysisUnits(t *testing.T) {
 	accTest := os.Getenv("TF_ACC")
 	if accTest == "" {
 		t.SkipNow()
@@ -203,7 +203,7 @@ func TestAccMetric_WithRandomizationUnits(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccMetricCustomWithRandomizationUnitsFmt, projectKey),
+				Config: fmt.Sprintf(testAccMetricCustomWithAnalysisUnitsFmt, projectKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMetricExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, NAME, "Custom Metric"),
@@ -212,8 +212,8 @@ func TestAccMetric_WithRandomizationUnits(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, KIND, "custom"),
 					resource.TestCheckResourceAttr(resourceName, EVENT_KEY, "Custom event"),
 					resource.TestCheckResourceAttr(resourceName, IS_NUMERIC, "false"),
-					resource.TestCheckResourceAttr(resourceName, RANDOMIZATION_UNITS+".0", "request"),
-					resource.TestCheckResourceAttr(resourceName, RANDOMIZATION_UNITS+".1", "user"),
+					resource.TestCheckResourceAttr(resourceName, ANALYSIS_UNITS+".0", "request"),
+					resource.TestCheckResourceAttr(resourceName, ANALYSIS_UNITS+".1", "user"),
 				),
 			},
 			{
@@ -222,7 +222,7 @@ func TestAccMetric_WithRandomizationUnits(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: fmt.Sprintf(testAccMetricCustomWithRandomizationUnitsUpdateFmt, projectKey),
+				Config: fmt.Sprintf(testAccMetricCustomWithAnalysisUnitsUpdateFmt, projectKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMetricExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, NAME, "Custom Metric"),
@@ -231,9 +231,9 @@ func TestAccMetric_WithRandomizationUnits(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, KIND, "custom"),
 					resource.TestCheckResourceAttr(resourceName, EVENT_KEY, "Custom event"),
 					resource.TestCheckResourceAttr(resourceName, IS_NUMERIC, "false"),
-					resource.TestCheckResourceAttr(resourceName, RANDOMIZATION_UNITS+".0", "organization"),
-					resource.TestCheckResourceAttr(resourceName, RANDOMIZATION_UNITS+".1", "request"),
-					resource.TestCheckResourceAttr(resourceName, RANDOMIZATION_UNITS+".2", "user"),
+					resource.TestCheckResourceAttr(resourceName, ANALYSIS_UNITS+".0", "organization"),
+					resource.TestCheckResourceAttr(resourceName, ANALYSIS_UNITS+".1", "request"),
+					resource.TestCheckResourceAttr(resourceName, ANALYSIS_UNITS+".2", "user"),
 				),
 			},
 			{

--- a/launchdarkly/resource_metric_framework.go
+++ b/launchdarkly/resource_metric_framework.go
@@ -49,7 +49,7 @@ type MetricResourceModel struct {
 	EventKey                  types.String `tfsdk:"event_key"`
 	SuccessCriteria           types.String `tfsdk:"success_criteria"`
 	URLs                      types.List   `tfsdk:"urls"`
-	RandomizationUnits        types.Set    `tfsdk:"randomization_units"`
+	AnalysisUnits             types.Set    `tfsdk:"analysis_units"`
 	IncludeUnitsWithoutEvents types.Bool   `tfsdk:"include_units_without_events"`
 	UnitAggregationType       types.String `tfsdk:"unit_aggregation_type"`
 	AnalysisType              types.String `tfsdk:"analysis_type"`
@@ -72,7 +72,7 @@ var metricUrlAttrTypes = map[string]attr.Type{
 
 func (r *MetricResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Version:     1,
+		Version:     2,
 		Description: "Provides a LaunchDarkly metric resource.\n\nThis resource allows you to create and manage metrics within your LaunchDarkly organization.\n\nTo learn more about metrics and experimentation, read [Experimentation Documentation](https://docs.launchdarkly.com/home/experimentation).",
 		Attributes:  metricSchemaAttributes(),
 	}
@@ -150,7 +150,7 @@ func metricSchemaAttributes() map[string]schema.Attribute {
 			Description: "The success criteria for your metric (if numeric metric). Available choices are `HigherThanBaseline` and `LowerThanBaseline`.",
 			Validators:  []validator.String{oneOfValidator{allowed: []string{"HigherThanBaseline", "LowerThanBaseline"}}},
 		},
-		RANDOMIZATION_UNITS: schema.SetAttribute{
+		ANALYSIS_UNITS: schema.SetAttribute{
 			Optional:    true,
 			Computed:    true,
 			ElementType: types.StringType,
@@ -217,10 +217,11 @@ func metricSchemaAttributes() map[string]schema.Attribute {
 }
 
 func (r *MetricResource) UpgradeState(_ context.Context) map[int64]resource.StateUpgrader {
-	priorSchema := schema.Schema{Attributes: metricSchemaAttributesV0()}
+	priorSchemaV0 := schema.Schema{Attributes: metricSchemaAttributesV0()}
+	priorSchemaV1 := schema.Schema{Attributes: metricSchemaAttributesV1()}
 	return map[int64]resource.StateUpgrader{
 		0: {
-			PriorSchema: &priorSchema,
+			PriorSchema: &priorSchemaV0,
 			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
 				var prior MetricResourceModelV0
 				resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
@@ -242,7 +243,40 @@ func (r *MetricResource) UpgradeState(_ context.Context) map[int64]resource.Stat
 					EventKey:                  nullIfEmptyString(prior.EventKey),
 					SuccessCriteria:           nullIfEmptyString(prior.SuccessCriteria),
 					URLs:                      nullIfEmptyList(ctx, prior.URLs),
-					RandomizationUnits:        prior.RandomizationUnits,
+					AnalysisUnits:             prior.RandomizationUnits,
+					IncludeUnitsWithoutEvents: prior.IncludeUnitsWithoutEvents,
+					UnitAggregationType:       prior.UnitAggregationType,
+					AnalysisType:              prior.AnalysisType,
+					PercentileValue:           prior.PercentileValue,
+					Version:                   prior.Version,
+				}
+				resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+			},
+		},
+		1: {
+			PriorSchema: &priorSchemaV1,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var prior MetricResourceModelV1
+				resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+				data := MetricResourceModel{
+					ID:                        prior.ID,
+					ProjectKey:                prior.ProjectKey,
+					Key:                       prior.Key,
+					Name:                      prior.Name,
+					Kind:                      prior.Kind,
+					MaintainerID:              prior.MaintainerID,
+					Description:               prior.Description,
+					Tags:                      prior.Tags,
+					IsNumeric:                 prior.IsNumeric,
+					Unit:                      prior.Unit,
+					Selector:                  prior.Selector,
+					EventKey:                  prior.EventKey,
+					SuccessCriteria:           prior.SuccessCriteria,
+					URLs:                      prior.URLs,
+					AnalysisUnits:             prior.RandomizationUnits,
 					IncludeUnitsWithoutEvents: prior.IncludeUnitsWithoutEvents,
 					UnitAggregationType:       prior.UnitAggregationType,
 					AnalysisType:              prior.AnalysisType,
@@ -455,7 +489,7 @@ func (r *MetricResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	tags, d := stringSliceFromSet(ctx, plan.Tags)
 	resp.Diagnostics.Append(d...)
-	randomization, d := stringSliceFromSet(ctx, plan.RandomizationUnits)
+	analysisUnits, d := stringSliceFromSet(ctx, plan.AnalysisUnits)
 	resp.Diagnostics.Append(d...)
 
 	var urls []metricURLModel
@@ -488,7 +522,7 @@ func (r *MetricResource) Create(ctx context.Context, req resource.CreateRequest,
 		IsNumeric:           &isNumeric,
 		Selector:            &selector,
 		Urls:                metricURLPostsFromModels(urls),
-		RandomizationUnits:  randomization,
+		AnalysisUnits:       analysisUnits,
 		Unit:                &unit,
 		EventKey:            &eventKey,
 		UnitAggregationType: &unitAggType,
@@ -601,7 +635,7 @@ func (r *MetricResource) ImportState(ctx context.Context, req resource.ImportSta
 
 // applyMetricUpdate issues a PATCH against an existing metric. Shared
 // between Update and the post-create maintainer set.
-func (r *MetricResource) applyMetricUpdate(ctx context.Context, plan *MetricResourceModel, includeRandomizationUnits bool) error {
+func (r *MetricResource) applyMetricUpdate(ctx context.Context, plan *MetricResourceModel, includeAnalysisUnits bool) error {
 	projectKey := plan.ProjectKey.ValueString()
 	key := plan.Key.ValueString()
 
@@ -654,10 +688,10 @@ func (r *MetricResource) applyMetricUpdate(ctx context.Context, plan *MetricReso
 		patch = append(patch, patchReplace("/maintainerId", mid))
 	}
 
-	if includeRandomizationUnits {
-		ru, _ := stringSliceFromSet(ctx, plan.RandomizationUnits)
-		if len(ru) > 0 {
-			patch = append(patch, patchReplace("/randomizationUnits", ru))
+	if includeAnalysisUnits {
+		au, _ := stringSliceFromSet(ctx, plan.AnalysisUnits)
+		if len(au) > 0 {
+			patch = append(patch, patchReplace("/analysisUnits", au))
 		}
 	}
 
@@ -737,9 +771,17 @@ func (r *MetricResource) readIntoModel(
 	diags.Append(d...)
 	data.Tags = tagsSet
 
-	ruSet, d := setFromStringSlice(ctx, metric.RandomizationUnits)
+	// GET mirrors randomizationUnits and analysisUnits server-side at read
+	// time, regardless of metric age or which field was written (verified
+	// against the live API, incl. pre-rename metrics). The fallback is
+	// defense-in-depth only.
+	analysisUnits := metric.AnalysisUnits
+	if analysisUnits == nil {
+		analysisUnits = metric.RandomizationUnits
+	}
+	auSet, d := setFromStringSlice(ctx, analysisUnits)
 	diags.Append(d...)
-	data.RandomizationUnits = ruSet
+	data.AnalysisUnits = auSet
 
 	urlObjType := types.ObjectType{AttrTypes: metricUrlAttrTypes}
 	if len(metric.Urls) == 0 {

--- a/launchdarkly/resource_metric_upgrade.go
+++ b/launchdarkly/resource_metric_upgrade.go
@@ -1,10 +1,18 @@
 package launchdarkly
 
-// Frozen pre-v3 metric schema + model used as PriorSchema for the
-// v0->v1 state upgrader. The v0 shape (v2.x SDKv2 provider) carried
-// the deprecated `is_active` attribute; v3 drops it. The upgrader
-// decodes prior state into MetricResourceModelV0 and projects to the
-// current MetricResourceModel, discarding IsActive.
+// Frozen prior metric schemas + models used as PriorSchema for state
+// upgraders.
+//
+// v0 (v2.x SDKv2 provider): carried the deprecated `is_active`
+// attribute and `randomization_units`.
+// v1 (v3 previews up to beta.6): dropped `is_active`, still had
+// `randomization_units`.
+// v2 (current): renames `randomization_units` to `analysis_units`,
+// following the API's randomizationUnits -> analysisUnits rename.
+//
+// Both upgraders decode prior state into the matching frozen model and
+// project to the current MetricResourceModel, discarding IsActive and
+// carrying randomization_units over to analysis_units.
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -35,11 +43,49 @@ type MetricResourceModelV0 struct {
 	Version                   types.Int64  `tfsdk:"version"`
 }
 
-// metricSchemaAttributesV0 returns the current attribute map plus the
-// removed is_active attribute, so the v0->v1 upgrader can decode prior
+type MetricResourceModelV1 struct {
+	ID                        types.String `tfsdk:"id"`
+	ProjectKey                types.String `tfsdk:"project_key"`
+	Key                       types.String `tfsdk:"key"`
+	Name                      types.String `tfsdk:"name"`
+	Kind                      types.String `tfsdk:"kind"`
+	MaintainerID              types.String `tfsdk:"maintainer_id"`
+	Description               types.String `tfsdk:"description"`
+	Tags                      types.Set    `tfsdk:"tags"`
+	IsNumeric                 types.Bool   `tfsdk:"is_numeric"`
+	Unit                      types.String `tfsdk:"unit"`
+	Selector                  types.String `tfsdk:"selector"`
+	EventKey                  types.String `tfsdk:"event_key"`
+	SuccessCriteria           types.String `tfsdk:"success_criteria"`
+	URLs                      types.List   `tfsdk:"urls"`
+	RandomizationUnits        types.Set    `tfsdk:"randomization_units"`
+	IncludeUnitsWithoutEvents types.Bool   `tfsdk:"include_units_without_events"`
+	UnitAggregationType       types.String `tfsdk:"unit_aggregation_type"`
+	AnalysisType              types.String `tfsdk:"analysis_type"`
+	PercentileValue           types.Int64  `tfsdk:"percentile_value"`
+	Version                   types.Int64  `tfsdk:"version"`
+}
+
+// metricSchemaAttributesV1 returns the current attribute map with
+// `analysis_units` swapped back to the pre-v2 `randomization_units`
+// attribute, so the v1->v2 upgrader can decode prior state shapes.
+func metricSchemaAttributesV1() map[string]schema.Attribute {
+	attrs := metricSchemaAttributes()
+	delete(attrs, ANALYSIS_UNITS)
+	attrs[RANDOMIZATION_UNITS] = schema.SetAttribute{
+		Optional:    true,
+		Computed:    true,
+		ElementType: types.StringType,
+		Description: "A set of one or more context kinds that this metric can measure events from.",
+	}
+	return attrs
+}
+
+// metricSchemaAttributesV0 returns the v1 attribute map plus the
+// removed is_active attribute, so the v0->v2 upgrader can decode prior
 // state shapes captured under the v2.x SDKv2 provider.
 func metricSchemaAttributesV0() map[string]schema.Attribute {
-	attrs := metricSchemaAttributes()
+	attrs := metricSchemaAttributesV1()
 	attrs[IS_ACTIVE] = schema.BoolAttribute{
 		Optional:           true,
 		Computed:           true,

--- a/launchdarkly/view_helper.go
+++ b/launchdarkly/view_helper.go
@@ -10,14 +10,6 @@ import (
 
 const viewAssociationsPageLimit = int32(100)
 
-// setViewRequestHeaders sets the common headers for View API requests
-func setViewRequestHeaders(req *http.Request, apiKey string) {
-	req.Header.Set("Authorization", apiKey)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("LD-API-Version", "beta")
-	req.Header.Set("User-Agent", fmt.Sprintf("launchdarkly-terraform-provider/%s", version))
-}
-
 type View struct {
 	Id          string          `json:"id"`
 	Key         string          `json:"key"`

--- a/launchdarkly/view_helper_test.go
+++ b/launchdarkly/view_helper_test.go
@@ -15,18 +15,6 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
-func TestSetViewRequestHeaders(t *testing.T) {
-	req, err := http.NewRequest("GET", "http://example.com", nil)
-	require.NoError(t, err)
-
-	setViewRequestHeaders(req, "test-api-key")
-
-	require.Equal(t, "test-api-key", req.Header.Get("Authorization"))
-	require.Equal(t, "application/json", req.Header.Get("Content-Type"))
-	require.Equal(t, "beta", req.Header.Get("LD-API-Version"))
-	require.Equal(t, fmt.Sprintf("launchdarkly-terraform-provider/%s", version), req.Header.Get("User-Agent"))
-}
-
 func TestViewRequestsIncludeUserAgentHeader(t *testing.T) {
 	projectKey := "test-project"
 	viewKey := "test-view"

--- a/scripts/migrate-tf-syntax/main_test.go
+++ b/scripts/migrate-tf-syntax/main_test.go
@@ -563,6 +563,39 @@ func TestApplyDSAttrRewrites(t *testing.T) {
 	}
 }
 
+// TestEmbeddedMappingsMetricAnalysisUnits guards the shipped mappings.json:
+// the metric resource's randomization_units attribute was renamed to
+// analysis_units in v3 (following the API's randomizationUnits ->
+// analysisUnits rename), both on the resource block and in data-source
+// references.
+func TestEmbeddedMappingsMetricAnalysisUnits(t *testing.T) {
+	var spec Spec
+	if err := json.Unmarshal(defaultMappings, &spec); err != nil {
+		t.Fatalf("parse embedded mappings: %v", err)
+	}
+	src := `resource "launchdarkly_metric" "m" {
+  randomization_units = ["user", "request"]
+}
+`
+	f, body := parseBody(t, src)
+	if !applyDeprecations(body, spec["launchdarkly_metric"].Deprecations, "test.tf") {
+		t.Fatal("expected rename")
+	}
+	out := string(hclwrite.Format(f.Bytes()))
+	if !strings.Contains(out, "analysis_units") || strings.Contains(out, "randomization_units") {
+		t.Errorf("randomization_units not renamed to analysis_units:\n%s", out)
+	}
+
+	dsSrc := []byte(`output "au" { value = data.launchdarkly_metric.m.randomization_units }`)
+	dsOut, changed := applyDSAttrRewrites(dsSrc, spec)
+	if !changed {
+		t.Fatal("expected data-source rewrite")
+	}
+	if !strings.Contains(string(dsOut), "data.launchdarkly_metric.m.analysis_units") {
+		t.Errorf("data-source reference not renamed:\n%s", dsOut)
+	}
+}
+
 // TestEmbeddedMappingsStripDataSourceIndices guards the shipped mappings.json:
 // every v3 single-object data-source attribute must have a ds_attr_rewrite that
 // drops a v2 list index, so v2 readers like `data.X.Y.attr[0].field` migrate to

--- a/scripts/migrate-tf-syntax/mappings.json
+++ b/scripts/migrate-tf-syntax/mappings.json
@@ -1,109 +1,284 @@
 {
   "launchdarkly_access_token": {
     "blocks": [
-      {"name": "inline_roles"},
-      {"name": "policy_statements"}
+      {
+        "name": "inline_roles"
+      },
+      {
+        "name": "policy_statements"
+      }
     ],
     "deprecations": [
-      {"name": "expire", "action": "drop"},
-      {"name": "policy_statements", "action": "rename", "to": "inline_roles"}
+      {
+        "name": "expire",
+        "action": "drop"
+      },
+      {
+        "name": "policy_statements",
+        "action": "rename",
+        "to": "inline_roles"
+      }
     ]
   },
   "launchdarkly_audit_log_subscription": {
-    "blocks": [{"name": "statements"}]
+    "blocks": [
+      {
+        "name": "statements"
+      }
+    ]
   },
   "launchdarkly_webhook": {
-    "blocks": [{"name": "statements"}]
+    "blocks": [
+      {
+        "name": "statements"
+      }
+    ]
   },
   "launchdarkly_custom_role": {
     "blocks": [
-      {"name": "policy"},
-      {"name": "policy_statements"}
+      {
+        "name": "policy"
+      },
+      {
+        "name": "policy_statements"
+      }
     ],
     "deprecations": [
-      {"name": "policy", "action": "policy_to_policy_statements", "to": "policy_statements"}
+      {
+        "name": "policy",
+        "action": "policy_to_policy_statements",
+        "to": "policy_statements"
+      }
     ]
   },
   "launchdarkly_relay_proxy_configuration": {
-    "blocks": [{"name": "policy"}]
+    "blocks": [
+      {
+        "name": "policy"
+      }
+    ]
   },
   "launchdarkly_project": {
     "blocks": [
-      {"name": "default_client_side_availability", "object": true},
-      {"name": "environments", "map_key": "key", "nested": [{"name": "approval_settings", "object": true}]}
+      {
+        "name": "default_client_side_availability",
+        "object": true
+      },
+      {
+        "name": "environments",
+        "map_key": "key",
+        "nested": [
+          {
+            "name": "approval_settings",
+            "object": true
+          }
+        ]
+      }
     ],
     "deprecations": [
-      {"name": "include_in_snippet", "action": "iis_to_csa", "to": "default_client_side_availability", "using_mobile_key": "true"}
+      {
+        "name": "include_in_snippet",
+        "action": "iis_to_csa",
+        "to": "default_client_side_availability",
+        "using_mobile_key": "true"
+      }
     ],
     "ds_attr_rewrites": [
-      {"from": "client_side_availability", "to": "default_client_side_availability", "strip_index": true}
+      {
+        "from": "client_side_availability",
+        "to": "default_client_side_availability",
+        "strip_index": true
+      }
     ]
   },
   "launchdarkly_environment": {
-    "blocks": [{"name": "approval_settings", "object": true}],
+    "blocks": [
+      {
+        "name": "approval_settings",
+        "object": true
+      }
+    ],
     "ds_attr_rewrites": [
-      {"from": "approval_settings", "to": "approval_settings", "strip_index": true}
+      {
+        "from": "approval_settings",
+        "to": "approval_settings",
+        "strip_index": true
+      }
     ]
   },
   "launchdarkly_segment": {
     "blocks": [
-      {"name": "included_contexts"},
-      {"name": "excluded_contexts"},
-      {"name": "rules", "nested": [{"name": "clauses"}]}
+      {
+        "name": "included_contexts"
+      },
+      {
+        "name": "excluded_contexts"
+      },
+      {
+        "name": "rules",
+        "nested": [
+          {
+            "name": "clauses"
+          }
+        ]
+      }
     ]
   },
   "launchdarkly_flag_trigger": {
-    "blocks": [{"name": "instructions", "object": true}],
+    "blocks": [
+      {
+        "name": "instructions",
+        "object": true
+      }
+    ],
     "ds_attr_rewrites": [
-      {"from": "instructions", "to": "instructions", "strip_index": true}
+      {
+        "from": "instructions",
+        "to": "instructions",
+        "strip_index": true
+      }
     ]
   },
   "launchdarkly_view_links": {
-    "blocks": [{"name": "segments"}]
+    "blocks": [
+      {
+        "name": "segments"
+      }
+    ]
   },
   "launchdarkly_metric": {
-    "blocks": [{"name": "urls"}],
-    "deprecations": [{"name": "is_active", "action": "drop"}]
+    "blocks": [
+      {
+        "name": "urls"
+      }
+    ],
+    "deprecations": [
+      {
+        "name": "is_active",
+        "action": "drop"
+      },
+      {
+        "name": "randomization_units",
+        "action": "rename",
+        "to": "analysis_units"
+      }
+    ],
+    "ds_attr_rewrites": [
+      {
+        "from": "randomization_units",
+        "to": "analysis_units"
+      }
+    ]
   },
   "launchdarkly_team": {
-    "blocks": [{"name": "role_attributes", "map_key": "key", "map_value": "values"}]
+    "blocks": [
+      {
+        "name": "role_attributes",
+        "map_key": "key",
+        "map_value": "values"
+      }
+    ]
   },
   "launchdarkly_team_member": {
-    "blocks": [{"name": "role_attributes", "map_key": "key", "map_value": "values"}]
+    "blocks": [
+      {
+        "name": "role_attributes",
+        "map_key": "key",
+        "map_value": "values"
+      }
+    ]
   },
   "launchdarkly_ai_config_variation": {
-    "blocks": [{"name": "messages"}]
+    "blocks": [
+      {
+        "name": "messages"
+      }
+    ]
   },
   "launchdarkly_flag_templates": {
-    "blocks": [{"name": "boolean_defaults", "object": true}]
+    "blocks": [
+      {
+        "name": "boolean_defaults",
+        "object": true
+      }
+    ]
   },
   "launchdarkly_feature_flag_environment": {
     "blocks": [
-      {"name": "prerequisites"},
-      {"name": "targets"},
-      {"name": "context_targets"},
-      {"name": "rules", "nested": [{"name": "clauses"}]},
-      {"name": "fallthrough", "object": true}
+      {
+        "name": "prerequisites"
+      },
+      {
+        "name": "targets"
+      },
+      {
+        "name": "context_targets"
+      },
+      {
+        "name": "rules",
+        "nested": [
+          {
+            "name": "clauses"
+          }
+        ]
+      },
+      {
+        "name": "fallthrough",
+        "object": true
+      }
     ],
     "ds_attr_rewrites": [
-      {"from": "fallthrough", "to": "fallthrough", "strip_index": true}
+      {
+        "from": "fallthrough",
+        "to": "fallthrough",
+        "strip_index": true
+      }
     ]
   },
   "launchdarkly_feature_flag": {
     "blocks": [
-      {"name": "client_side_availability", "object": true},
-      {"name": "variations"},
-      {"name": "custom_properties", "map_key": "key"},
-      {"name": "defaults", "object": true}
+      {
+        "name": "client_side_availability",
+        "object": true
+      },
+      {
+        "name": "variations"
+      },
+      {
+        "name": "custom_properties",
+        "map_key": "key"
+      },
+      {
+        "name": "defaults",
+        "object": true
+      }
     ],
     "deprecations": [
-      {"name": "include_in_snippet", "action": "iis_to_csa", "to": "client_side_availability"},
-      {"name": "variations", "action": "ensure_boolean_variations"}
+      {
+        "name": "include_in_snippet",
+        "action": "iis_to_csa",
+        "to": "client_side_availability"
+      },
+      {
+        "name": "variations",
+        "action": "ensure_boolean_variations"
+      }
     ],
     "ds_attr_rewrites": [
-      {"from": "include_in_snippet", "to_expr": "client_side_availability.using_environment_id"},
-      {"from": "client_side_availability", "to": "client_side_availability", "strip_index": true},
-      {"from": "defaults", "to": "defaults", "strip_index": true}
+      {
+        "from": "include_in_snippet",
+        "to_expr": "client_side_availability.using_environment_id"
+      },
+      {
+        "from": "client_side_availability",
+        "to": "client_side_availability",
+        "strip_index": true
+      },
+      {
+        "from": "defaults",
+        "to": "defaults",
+        "strip_index": true
+      }
     ]
   }
 }

--- a/templates/guides/migrating-to-v3.md.tmpl
+++ b/templates/guides/migrating-to-v3.md.tmpl
@@ -116,7 +116,7 @@ The provider includes a state upgrader for every resource whose state shape chan
 - `launchdarkly_flag_trigger`: converts `instructions` to an object.
 - `launchdarkly_flag_templates`: converts `boolean_defaults` to an object.
 - `launchdarkly_team` and `launchdarkly_team_member`: re-key `role_attributes` into a map of string lists.
-- `launchdarkly_metric`: discards `is_active`.
+- `launchdarkly_metric`: discards `is_active`, and renames `randomization_units` to `analysis_units` (following the LaunchDarkly API's rename).
 
 ## Your first plan after upgrading
 

--- a/templates/guides/v3-release-notes.md.tmpl
+++ b/templates/guides/v3-release-notes.md.tmpl
@@ -141,6 +141,7 @@ v3 removes the attributes that v2 marked deprecated. The state upgrade migrates 
 | `launchdarkly_project` resource | `include_in_snippet` | `default_client_side_availability` |
 | `launchdarkly_project` data source | `client_side_availability` | `default_client_side_availability` |
 | `launchdarkly_metric` | `is_active` | None. Remove it from your configuration. |
+| `launchdarkly_metric` resource and data source | `randomization_units` | `analysis_units` |
 
 ### Minimum versions
 


### PR DESCRIPTION
## Summary

Follow-up to #493. Adopts what the v23 client enables: typed-client migration for the IP allowlist, and the one API field rename that touches the provider surface. Breaking change is preview→preview only (no compat obligation before v3.0.0 GA).

### Typed-client migration (`refactor:`)

- `ip_allowlist_helper.go` rewritten on the typed `IPAllowlistBetaApi` + generated models; hand-rolled HTTP layer, local structs, and error parsing deleted (−63 lines). The generated builders lack a per-request `LDAPIVersion` setter, so the beta header is forced via the shared `forceBetaAPIVersion` round-tripper (same pattern as flag-import / metric-group). The account-singleton write mutex and no-retry-on-409 rationale are preserved.
- Removed dead `setViewRequestHeaders` left over from the view resource's raw-HTTP era.
- Audited the remaining raw-HTTP helpers; none can migrate yet: flag/segment creation needs `viewKeys` (absent from v23 `FeatureFlagBody`/`SegmentBody`), project view-association settings are not in the v23 `Project` model, and the dependent-flags builder still lacks an `LDAPIVersion` setter.

### `randomization_units` → `analysis_units` (`feat!:`)

The v23 API deprecates `randomizationUnits` in favor of `analysisUnits` on metrics. Attribute replaced outright on `launchdarkly_metric` (resource + data source):

- Create/patch/read wired to `analysisUnits`. GET mirrors both fields server-side regardless of metric age (verified against the live API, including a pre-rename metric); the legacy-field fallback in the read path is defense-in-depth only.
- Metric schema bumped to version 2 with state upgraders from v0 (v2.x SDKv2 shape) and v1 (v3 previews ≤ beta.6). Prior schemas are now frozen in `resource_metric_upgrade.go` instead of being derived from the live schema.
- `migrate-tf-syntax` renames the resource attribute and rewrites `data.launchdarkly_metric.*.randomization_units` references, with a mappings regression test.
- v3 migration guide + release notes updated.

This is the only v23 rename on the provider surface: all 157 provider-used models were swept for newly deprecated fields; the others have no corresponding resource, were deprecated before v23, or were never exposed.

## Test plan

- [x] `go build`, `go vet`, `make fmtcheck` clean; migrate-tf-syntax suite 28/28
- [x] `TestAccIpAllowlist*` (3/3) against a real LaunchDarkly account
- [x] `TestAccMetric_*` + `TestAccDataSourceMetric*` against a real account
- [x] End-to-end state upgrade: applied with the pre-rename schema-v1 build, planned with this build → `No changes.`, no replacement
- [ ] CI acceptance matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking Terraform attribute rename on metrics requires config/state migration; IP allowlist refactor touches account security settings but preserves concurrency behavior.
> 
> **Overview**
> Adopts **api-client-go v23** in two areas: IP allowlist calls move off hand-rolled HTTP onto typed **`IPAllowlistBetaApi`**, with beta versioning via the shared transport helper and the existing write mutex kept for account-level optimistic locking. **`launchdarkly_metric`** (resource and data source) replaces **`randomization_units`** with **`analysis_units`**, matching the API rename; create, patch, and read use `analysisUnits`, with a read-time fallback to the legacy field.
> 
> The metric resource schema is **version 2** with frozen prior schemas and **v0→v1→v2** state upgraders that map stored `randomization_units` into `analysis_units`. **`migrate-tf-syntax`** renames the attribute and data-source references; v3 migration and release notes document the change. Dead **`setViewRequestHeaders`** (views) is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85984739652b37856dcb9e08578e1b85e935119f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->