### PR TITLE
chore: consolidate FM Govern ownership into FM Enterprise in CODEOWNERS [Cursor]

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-* @launchdarkly/team-fm-govern
+* @launchdarkly/team-enterprise
 
 /docs/ @launchdarkly/team-docs


### PR DESCRIPTION
## Summary
Part of the FM Govern + FM Scale → FM Enterprise team consolidation. This repoints the CODEOWNERS team reference(s) in this repo away from the deprecated FM Govern / FM Scale GitHub teams.

- `@launchdarkly/team-fm-govern` / `@launchdarkly/team-fm-scale` → `@launchdarkly/team-enterprise` (or `@launchdarkly/team-foundation` for the Jira Connect app), matching the team ownership consolidation being applied in `launchdarkly/terraform`.
- Only team *references* are changed here; team *definitions* are handled separately in the org reorg (CHANGE-1296).

## Test plan
- [x] Confirm the new team handle(s) resolve and have write access to this repo.
- [x] Verify CODEOWNERS review routing points to the intended team on the next PR.

Made with [Cursor](https://cursor.com)