### PR TITLE
fix: attach AgentControl variation tools via the tools field

### DIFF
--- a/launchdarkly/resource_ai_config_variation_framework.go
+++ b/launchdarkly/resource_ai_config_variation_framework.go
@@ -312,9 +312,6 @@ func (r *AIConfigVariationResource) Create(ctx context.Context, req resource.Cre
 
 	toolKeys, d := stringSliceFromSet(ctx, plan.ToolKeys)
 	resp.Diagnostics.Append(d...)
-	if len(toolKeys) > 0 {
-		post.ToolKeys = toolKeys
-	}
 
 	judges, d := variationJudgesFromMap(ctx, plan.Judges)
 	resp.Diagnostics.Append(d...)
@@ -326,6 +323,15 @@ func (r *AIConfigVariationResource) Create(ctx context.Context, req resource.Cre
 
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if len(toolKeys) > 0 {
+		tools, terr := r.resolveVariationTools(projectKey, toolKeys)
+		if terr != nil {
+			addLdapiError(&resp.Diagnostics, fmt.Sprintf("failed to resolve tool versions for AgentControl config variation %q in project %q", variationKey, projectKey), terr)
+			return
+		}
+		post.Tools = tools
 	}
 
 	err := r.client.withConcurrency(r.client.ctx, func() error {
@@ -411,7 +417,19 @@ func (r *AIConfigVariationResource) Update(ctx context.Context, req resource.Upd
 	if !plan.ToolKeys.Equal(state.ToolKeys) {
 		tks, d := stringSliceFromSet(ctx, plan.ToolKeys)
 		resp.Diagnostics.Append(d...)
-		patch.ToolKeys = tks
+		if !d.HasError() {
+			tools, terr := r.resolveVariationTools(projectKey, tks)
+			if terr != nil {
+				addLdapiError(&resp.Diagnostics, fmt.Sprintf("failed to resolve tool versions for AgentControl config variation %q in project %q", variationKey, projectKey), terr)
+				return
+			}
+			if tools == nil {
+				// A non-nil empty slice serializes as `"tools": []` to
+				// remove all tool associations.
+				tools = []ldapi.VariationToolPost{}
+			}
+			patch.Tools = tools
+		}
 	}
 	if !plan.Judges.Equal(state.Judges) {
 		judges, d := variationJudgesFromMap(ctx, plan.Judges)
@@ -673,6 +691,32 @@ func variationMessagesFromList(ctx context.Context, list types.List) ([]ldapi.Me
 		out[i] = *ldapi.NewMessage(m.Content, m.Role)
 	}
 	return out, diags
+}
+
+// resolveVariationTools resolves each tool key to its current version and
+// returns VariationToolPost entries for the request's `tools` field. The
+// spec documents a bare `toolKeys` field ("latest version of the tool will
+// be used"), but the API accepts it without attaching anything (see PR
+// #518); `tools`, which carries an explicit version, is the field that
+// attaches.
+func (r *AIConfigVariationResource) resolveVariationTools(projectKey string, toolKeys []string) ([]ldapi.VariationToolPost, error) {
+	if len(toolKeys) == 0 {
+		return nil, nil
+	}
+	tools := make([]ldapi.VariationToolPost, 0, len(toolKeys))
+	for _, key := range toolKeys {
+		var tool *ldapi.AITool
+		err := r.client.withConcurrency(r.client.ctx, func() error {
+			var e error
+			tool, _, e = r.client.ld.AgentControlApi.GetAITool(r.client.ctx, projectKey, key).Execute()
+			return e
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to look up AI tool %q in project %q: %w", key, projectKey, err)
+		}
+		tools = append(tools, *ldapi.NewVariationToolPost(key, tool.Version))
+	}
+	return tools, nil
 }
 
 // variationJudgesFromMap converts the framework judges map (keyed by judge

--- a/launchdarkly/resource_launchdarkly_ai_config_variation_test.go
+++ b/launchdarkly/resource_launchdarkly_ai_config_variation_test.go
@@ -280,6 +280,100 @@ resource "launchdarkly_ai_config_variation" "test" {
 	}]
 }
 `
+
+	testAccAIConfigVariationWithToolKeysUpdate = `
+resource "launchdarkly_ai_tool" "test" {
+	project_key = launchdarkly_project.test.key
+	key         = "%[1]s"
+	description = "Test tool"
+	schema_json = jsonencode({
+		type = "object"
+		properties = {
+			query = { type = "string" }
+		}
+	})
+}
+
+resource "launchdarkly_ai_tool" "second" {
+	project_key = launchdarkly_project.test.key
+	key         = "%[2]s"
+	description = "Second test tool"
+	schema_json = jsonencode({
+		type = "object"
+		properties = {
+			id = { type = "string" }
+		}
+	})
+	depends_on = [launchdarkly_ai_tool.test]
+}
+
+resource "launchdarkly_ai_config" "test" {
+	project_key = launchdarkly_project.test.key
+	key         = "%[3]s"
+	name        = "Parent AI Config"
+	description = "Parent for tool keys test"
+	depends_on  = [launchdarkly_ai_tool.second]
+}
+
+resource "launchdarkly_ai_config_variation" "test" {
+	project_key = launchdarkly_project.test.key
+	config_key  = launchdarkly_ai_config.test.key
+	key         = "%[4]s"
+	name        = "Variation with tools"
+	tool_keys   = [launchdarkly_ai_tool.test.key, launchdarkly_ai_tool.second.key]
+	messages = [{
+		role    = "system"
+		content = "You are a helpful assistant."
+	}]
+}
+`
+
+	testAccAIConfigVariationWithToolKeysRemoved = `
+resource "launchdarkly_ai_tool" "test" {
+	project_key = launchdarkly_project.test.key
+	key         = "%[1]s"
+	description = "Test tool"
+	schema_json = jsonencode({
+		type = "object"
+		properties = {
+			query = { type = "string" }
+		}
+	})
+}
+
+resource "launchdarkly_ai_tool" "second" {
+	project_key = launchdarkly_project.test.key
+	key         = "%[2]s"
+	description = "Second test tool"
+	schema_json = jsonencode({
+		type = "object"
+		properties = {
+			id = { type = "string" }
+		}
+	})
+	depends_on = [launchdarkly_ai_tool.test]
+}
+
+resource "launchdarkly_ai_config" "test" {
+	project_key = launchdarkly_project.test.key
+	key         = "%[3]s"
+	name        = "Parent AI Config"
+	description = "Parent for tool keys test"
+	depends_on  = [launchdarkly_ai_tool.second]
+}
+
+resource "launchdarkly_ai_config_variation" "test" {
+	project_key = launchdarkly_project.test.key
+	config_key  = launchdarkly_ai_config.test.key
+	key         = "%[4]s"
+	name        = "Variation with tools"
+	tool_keys   = []
+	messages = [{
+		role    = "system"
+		content = "You are a helpful assistant."
+	}]
+}
+`
 )
 
 func TestAccAIConfigVariation_CreateAndUpdate(t *testing.T) {
@@ -465,12 +559,16 @@ func TestAccAIConfigVariation_WithJudges(t *testing.T) {
 	})
 }
 
-// TestAccAIConfigVariation_WithToolKeys tests creating a variation with tool_keys.
+// TestAccAIConfigVariation_WithToolKeys tests tool attachment end to end:
+// create with one tool, update to two, then remove all with an explicit
+// empty set. Every step asserts attachment through the API — state-only
+// checks are masked by the read's preserve-prior fallback.
 func TestAccAIConfigVariation_WithToolKeys(t *testing.T) {
 	aiTestCooldown()
 	projectKey := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	configKey := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	toolKey := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	secondToolKey := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	variationKey := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	resourceName := "launchdarkly_ai_config_variation.test"
 
@@ -486,6 +584,27 @@ func TestAccAIConfigVariation_WithToolKeys(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, NAME, "Variation with tools"),
 					resource.TestCheckResourceAttr(resourceName, "tool_keys.#", "1"),
 					testAccCheckAIConfigVariationToolsAttached(resourceName, toolKey),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: withAITestProject(projectKey, fmt.Sprintf(testAccAIConfigVariationWithToolKeysUpdate, toolKey, secondToolKey, configKey, variationKey)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAIConfigVariationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tool_keys.#", "2"),
+					testAccCheckAIConfigVariationToolsAttached(resourceName, toolKey, secondToolKey),
+				),
+			},
+			{
+				Config: withAITestProject(projectKey, fmt.Sprintf(testAccAIConfigVariationWithToolKeysRemoved, toolKey, secondToolKey, configKey, variationKey)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAIConfigVariationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tool_keys.#", "0"),
+					testAccCheckAIConfigVariationToolsAttached(resourceName),
 				),
 			},
 		},

--- a/launchdarkly/resource_launchdarkly_ai_config_variation_test.go
+++ b/launchdarkly/resource_launchdarkly_ai_config_variation_test.go
@@ -2,6 +2,8 @@ package launchdarkly
 
 import (
 	"fmt"
+	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -483,6 +485,7 @@ func TestAccAIConfigVariation_WithToolKeys(t *testing.T) {
 					testAccCheckAIConfigVariationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, NAME, "Variation with tools"),
 					resource.TestCheckResourceAttr(resourceName, "tool_keys.#", "1"),
+					testAccCheckAIConfigVariationToolsAttached(resourceName, toolKey),
 				),
 			},
 		},
@@ -516,6 +519,49 @@ func TestAccAIConfigVariation_WithInlineModel(t *testing.T) {
 			},
 		},
 	})
+}
+
+// testAccCheckAIConfigVariationToolsAttached asserts against the API — not
+// Terraform state — that the variation has exactly the expected tools
+// attached. State-only checks (tool_keys.#) are masked by the read's
+// preserve-prior fallback, which echoes the planned tool_keys back into
+// state when the API returns no tools; this check cannot be masked.
+func testAccCheckAIConfigVariationToolsAttached(resourceName string, expected ...string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+		projectKey := rs.Primary.Attributes[PROJECT_KEY]
+		configKey := rs.Primary.Attributes[AI_CONFIG_KEY]
+		variationKey := rs.Primary.Attributes[KEY]
+
+		client := mustTestAccClient()
+		variationsResp, _, err := client.ld.AgentControlApi.GetAIConfigVariation(client.ctx, projectKey, configKey, variationKey).Execute()
+		if err != nil {
+			return fmt.Errorf("received an error getting AI config variation: %s", err)
+		}
+		if variationsResp == nil || len(variationsResp.Items) == 0 {
+			return fmt.Errorf("no variation versions returned for %s/%s/%s", projectKey, configKey, variationKey)
+		}
+		variation := variationsResp.Items[0]
+		for _, v := range variationsResp.Items[1:] {
+			if v.Version > variation.Version {
+				variation = v
+			}
+		}
+		got := make([]string, 0, len(variation.Tools))
+		for _, t := range variation.Tools {
+			got = append(got, t.Key)
+		}
+		sort.Strings(got)
+		want := append([]string{}, expected...)
+		sort.Strings(want)
+		if !reflect.DeepEqual(got, want) {
+			return fmt.Errorf("API reports attached tools %v, want %v — tool_keys accepted on write but not attached or not returned on read", got, want)
+		}
+		return nil
+	}
 }
 
 func testAccCheckAIConfigVariationExists(resourceName string) resource.TestCheckFunc {


### PR DESCRIPTION
## What

A user reported `tool_keys` on `launchdarkly_ai_config_variation` applies cleanly but tools never actually attach. **Confirmed and fixed.**

**Root cause:** the API documents two write fields — `toolKeys` ([string], "latest version of the tool will be used") and `tools` ([{key, version}]). The server **ignores `toolKeys` entirely** (proven by the API-side assertion in this PR: `API reports attached tools [], want [key]`) but honors `tools`. The provider was sending `toolKeys`.

**Fix:** resolve each `tool_keys` entry to its current version via `GetAITool` and send `tools`. No HCL changes for users — `tool_keys = [...]` now actually attaches. Removal is an explicit `tool_keys = []` (the attribute is Optional+Computed, so omitting it preserves prior state).

**Why our tests never caught it:** `TestAccAIConfigVariation_WithToolKeys` asserted Terraform state, and the read's preserve-prior fallback echoes the planned value into state when the API returns no tools — green whether or not attachment happened. This PR replaces that with `testAccCheckAIConfigVariationToolsAttached`, which asserts through the API and cannot be masked, now covering create, import, update-to-two-tools, and remove-all.

**Verified live:** the create-path fix went green on the API-side assertion (run on e019ae1); the update/removal coverage lands in this PR's latest run.

## For the API team

`toolKeys` is documented in the public OpenAPI spec on both `postAIConfigVariation` and `patchAIConfigVariation` but is a no-op server-side. Either wire it up or remove it from the spec — as-is it's a silent-failure trap for every API consumer (this provider shipped v3.0.0–v3.1.x with it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Create/update now perform extra AgentControl API calls per tool key and fail if a referenced tool is missing; behavior change fixes real mis-attachment but adds dependency on tool lookup at apply time.
> 
> **Overview**
> Fixes **`tool_keys`** on **`launchdarkly_ai_config_variation`** applying in Terraform without tools actually attaching in AgentControl.
> 
> **Create/update** no longer send the API’s **`toolKeys`** field (accepted but ineffective). The provider now resolves each key with **`GetAITool`**, builds **`tools`** entries with explicit versions, and sends those on POST/PATCH. Clearing **`tool_keys`** sends an empty **`tools`** array so associations are removed.
> 
> Acceptance tests for **`tool_keys`** now cover add, expand, and remove, and assert attached tools via the API (not only state), avoiding false greens from the read path that preserves prior **`tool_keys`** when the API returns no tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0beab71e36dabd3a298c2bbe028e5801bf200af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->