### PR TITLE
fix: attach AI config variation tools via the tools field (v2 backport of #518)

### DIFF
--- a/launchdarkly/resource_launchdarkly_ai_config_variation.go
+++ b/launchdarkly/resource_launchdarkly_ai_config_variation.go
@@ -84,7 +84,11 @@ func resourceAIConfigVariationCreate(ctx context.Context, d *schema.ResourceData
 
 	if v, ok := d.GetOk(TOOL_KEYS); ok {
 		toolKeys := stringsFromSchemaSet(optionalSchemaSetFromInterface(v))
-		post.ToolKeys = toolKeys
+		tools, err := resolveVariationTools(client, projectKey, toolKeys)
+		if err != nil {
+			return diag.Errorf("failed to resolve tool versions for AI config variation %q in config %q project %q: %s", variationKey, configKey, projectKey, err)
+		}
+		post.Tools = tools
 	}
 
 	var err error
@@ -157,7 +161,16 @@ func resourceAIConfigVariationUpdate(ctx context.Context, d *schema.ResourceData
 
 	if d.HasChange(TOOL_KEYS) {
 		toolKeys := stringsFromSchemaSet(getOptionalSet(d, TOOL_KEYS))
-		patch.ToolKeys = toolKeys
+		tools, err := resolveVariationTools(client, projectKey, toolKeys)
+		if err != nil {
+			return diag.Errorf("failed to resolve tool versions for AI config variation %q in config %q project %q: %s", variationKey, configKey, projectKey, err)
+		}
+		if tools == nil {
+			// A non-nil empty slice serializes as `"tools": []` to remove all
+			// tool associations; a nil slice would be omitted from the request.
+			tools = []ldapi.VariationToolPost{}
+		}
+		patch.Tools = tools
 	}
 
 	var err error
@@ -244,4 +257,29 @@ func resourceAIConfigVariationImport(ctx context.Context, d *schema.ResourceData
 	_ = d.Set(KEY, variationKey)
 
 	return []*schema.ResourceData{d}, nil
+}
+
+// resolveVariationTools resolves each tool key to its current version and
+// returns VariationToolPost entries for the request's `tools` field. The spec
+// documents a bare `toolKeys` field ("latest version of the tool will be
+// used"), but the API accepts it without attaching anything (see PR #518);
+// `tools`, which carries an explicit version, is the field that attaches.
+func resolveVariationTools(client *Client, projectKey string, toolKeys []string) ([]ldapi.VariationToolPost, error) {
+	if len(toolKeys) == 0 {
+		return nil, nil
+	}
+	tools := make([]ldapi.VariationToolPost, 0, len(toolKeys))
+	for _, key := range toolKeys {
+		var tool *ldapi.AITool
+		err := client.withConcurrency(client.ctx, func() error {
+			var e error
+			tool, _, e = client.ld.AIConfigsApi.GetAITool(client.ctx, projectKey, key).Execute()
+			return e
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to look up AI tool %q in project %q: %s", key, projectKey, handleLdapiErr(err))
+		}
+		tools = append(tools, *ldapi.NewVariationToolPost(key, tool.Version))
+	}
+	return tools, nil
 }

--- a/launchdarkly/resource_launchdarkly_ai_config_variation_test.go
+++ b/launchdarkly/resource_launchdarkly_ai_config_variation_test.go
@@ -2,6 +2,8 @@ package launchdarkly
 
 import (
 	"fmt"
+	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -161,6 +163,100 @@ resource "launchdarkly_ai_config_variation" "test" {
 	}
 }
 `
+
+	testAccAIConfigVariationWithToolKeysUpdate = `
+resource "launchdarkly_ai_tool" "test" {
+	project_key = launchdarkly_project.test.key
+	key         = "%[1]s"
+	description = "Test tool"
+	schema_json = jsonencode({
+		type = "object"
+		properties = {
+			query = { type = "string" }
+		}
+	})
+}
+
+resource "launchdarkly_ai_tool" "second" {
+	project_key = launchdarkly_project.test.key
+	key         = "%[2]s"
+	description = "Second test tool"
+	schema_json = jsonencode({
+		type = "object"
+		properties = {
+			id = { type = "string" }
+		}
+	})
+	depends_on = [launchdarkly_ai_tool.test]
+}
+
+resource "launchdarkly_ai_config" "test" {
+	project_key = launchdarkly_project.test.key
+	key         = "%[3]s"
+	name        = "Parent AI Config"
+	description = "Parent for tool keys test"
+	depends_on  = [launchdarkly_ai_tool.second]
+}
+
+resource "launchdarkly_ai_config_variation" "test" {
+	project_key = launchdarkly_project.test.key
+	config_key  = launchdarkly_ai_config.test.key
+	key         = "%[4]s"
+	name        = "Variation with tools"
+	tool_keys   = [launchdarkly_ai_tool.test.key, launchdarkly_ai_tool.second.key]
+	messages {
+		role    = "system"
+		content = "You are a helpful assistant."
+	}
+}
+`
+
+	testAccAIConfigVariationWithToolKeysRemoved = `
+resource "launchdarkly_ai_tool" "test" {
+	project_key = launchdarkly_project.test.key
+	key         = "%[1]s"
+	description = "Test tool"
+	schema_json = jsonencode({
+		type = "object"
+		properties = {
+			query = { type = "string" }
+		}
+	})
+}
+
+resource "launchdarkly_ai_tool" "second" {
+	project_key = launchdarkly_project.test.key
+	key         = "%[2]s"
+	description = "Second test tool"
+	schema_json = jsonencode({
+		type = "object"
+		properties = {
+			id = { type = "string" }
+		}
+	})
+	depends_on = [launchdarkly_ai_tool.test]
+}
+
+resource "launchdarkly_ai_config" "test" {
+	project_key = launchdarkly_project.test.key
+	key         = "%[3]s"
+	name        = "Parent AI Config"
+	description = "Parent for tool keys test"
+	depends_on  = [launchdarkly_ai_tool.second]
+}
+
+resource "launchdarkly_ai_config_variation" "test" {
+	project_key = launchdarkly_project.test.key
+	config_key  = launchdarkly_ai_config.test.key
+	key         = "%[4]s"
+	name        = "Variation with tools"
+	tool_keys   = []
+	messages {
+		role    = "system"
+		content = "You are a helpful assistant."
+	}
+}
+`
 )
 
 func TestAccAIConfigVariation_CreateAndUpdate(t *testing.T) {
@@ -296,12 +392,16 @@ func TestAccAIConfigVariation_AgentMode(t *testing.T) {
 	})
 }
 
-// TestAccAIConfigVariation_WithToolKeys tests creating a variation with tool_keys.
+// TestAccAIConfigVariation_WithToolKeys tests tool attachment end to end:
+// create with one tool, update to two, then remove all with an explicit
+// empty set. Every step asserts attachment through the API — state-only
+// checks are masked by the read's preserve-prior fallback.
 func TestAccAIConfigVariation_WithToolKeys(t *testing.T) {
 	aiTestCooldown()
 	projectKey := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	configKey := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	toolKey := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	secondToolKey := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	variationKey := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	resourceName := "launchdarkly_ai_config_variation.test"
 
@@ -316,6 +416,28 @@ func TestAccAIConfigVariation_WithToolKeys(t *testing.T) {
 					testAccCheckAIConfigVariationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, NAME, "Variation with tools"),
 					resource.TestCheckResourceAttr(resourceName, "tool_keys.#", "1"),
+					testAccCheckAIConfigVariationToolsAttached(resourceName, toolKey),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: withAITestProject(projectKey, fmt.Sprintf(testAccAIConfigVariationWithToolKeysUpdate, toolKey, secondToolKey, configKey, variationKey)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAIConfigVariationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tool_keys.#", "2"),
+					testAccCheckAIConfigVariationToolsAttached(resourceName, toolKey, secondToolKey),
+				),
+			},
+			{
+				Config: withAITestProject(projectKey, fmt.Sprintf(testAccAIConfigVariationWithToolKeysRemoved, toolKey, secondToolKey, configKey, variationKey)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAIConfigVariationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tool_keys.#", "0"),
+					testAccCheckAIConfigVariationToolsAttached(resourceName),
 				),
 			},
 		},
@@ -349,6 +471,50 @@ func TestAccAIConfigVariation_WithInlineModel(t *testing.T) {
 			},
 		},
 	})
+}
+
+// testAccCheckAIConfigVariationToolsAttached asserts against the API — not
+// Terraform state — that the variation has exactly the expected tools
+// attached. State-only checks (tool_keys.#) are masked by the read's
+// preserve-prior fallback, which echoes the planned tool_keys back into
+// state when the API returns no tools; this check cannot be masked.
+func testAccCheckAIConfigVariationToolsAttached(resourceName string, expected ...string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+		projectKey := rs.Primary.Attributes[PROJECT_KEY]
+		configKey := rs.Primary.Attributes[AI_CONFIG_KEY]
+		variationKey := rs.Primary.Attributes[KEY]
+
+		client := testAccProvider.Meta().(*Client)
+		variationsResp, _, err := client.ld.AIConfigsApi.GetAIConfigVariation(client.ctx, projectKey, configKey, variationKey).Execute()
+		if err != nil {
+			return fmt.Errorf("received an error getting AI config variation: %s", err)
+		}
+		if variationsResp == nil || len(variationsResp.Items) == 0 {
+			return fmt.Errorf("no variation versions returned for %s/%s/%s", projectKey, configKey, variationKey)
+		}
+		// Items contains all versions; assert against the highest.
+		variation := variationsResp.Items[0]
+		for _, v := range variationsResp.Items[1:] {
+			if v.Version > variation.Version {
+				variation = v
+			}
+		}
+		got := make([]string, 0, len(variation.Tools))
+		for _, t := range variation.Tools {
+			got = append(got, t.Key)
+		}
+		sort.Strings(got)
+		want := append([]string{}, expected...)
+		sort.Strings(want)
+		if !reflect.DeepEqual(got, want) {
+			return fmt.Errorf("API reports attached tools %v, want %v — tool_keys accepted on write but not attached or not returned on read", got, want)
+		}
+		return nil
+	}
 }
 
 func testAccCheckAIConfigVariationExists(resourceName string) resource.TestCheckFunc {


### PR DESCRIPTION
## What

Backport of #518 to the **v2** maintenance line.

A user reported `tool_keys` on `launchdarkly_ai_config_variation` applies cleanly but tools never actually attach. **Confirmed and fixed.**

**Root cause:** the API documents two write fields — `toolKeys` (`[string]`, "latest version of the tool will be used") and `tools` (`[{key, version}]`). The server **ignores `toolKeys` entirely** but honors `tools`. The provider was sending `toolKeys`.

**Fix:** resolve each `tool_keys` entry to its current version via `GetAITool` and send `tools`. No HCL change for users — `tool_keys = [...]` now actually attaches. Clearing `tool_keys` sends an empty `tools` array to remove all associations (a non-nil empty slice serializes as `"tools": []` via the generated `ToMap`, rather than being omitted).

**Why our tests never caught it:** `TestAccAIConfigVariation_WithToolKeys` asserted Terraform state only, which the read's preserve-prior fallback masks — it echoes the planned `tool_keys` into state when the API returns no tools, so the test was green whether or not attachment happened. This PR replaces that with `testAccCheckAIConfigVariationToolsAttached`, which asserts through the API and cannot be masked, now covering create, import, update-to-two-tools, and remove-all.

## v2-specific adaptation vs #518 (framework/v3)

- SDKv2 resource (`resource_launchdarkly_ai_config_variation.go`), not the framework file.
- api-client-go **v22** → uses `client.ld.AIConfigsApi` (v23's `AgentControlApi`). `VariationToolPost`, `NewVariationToolPost`, `AITool.Version`, and `Post/Patch.Tools` all exist in v22; the empty-slice removal semantics are identical (`ToMap` uses `!IsNil`, not the `omitempty` tag).
- `resolveVariationTools` is a package-level func taking `*Client` (main's is a resource method).
- Test HCL uses SDKv2 block syntax (`messages { ... }`); check helper obtains the client via `testAccProvider.Meta().(*Client)`.

## Divergence audit (the "any other fixes?" ask)

Compared `main` vs `v2` since their merge-base (2.30.1). The only other `fix:` commits on main:

- `#513` remove `archived` field from `launchdarkly_view` — **already on v2** as #514.
- `#509` v3 migration gotchas (empty tags, FFE import ID order, metric rename docs) — **v3-only**: touches only `*_framework.go` files and the v3 migration guide, and fixes regressions introduced by the framework migration; N/A to v2's SDKv2 code.

`#512` (judge attachments) is a `feat`, excluded per the fixes-only policy for v2.

## Validation

`go build`, `go vet`, `gofmt`, `make fmtcheck`, and package unit tests all pass locally. Acceptance tests (`TestAccAIConfigVariation_WithToolKeys`) require a real LaunchDarkly account and run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes write behavior for a resource field users rely on (extra API calls per tool on apply) but fixes incorrect silent no-ops; clearing tools depends on empty-array PATCH semantics.
> 
> **Overview**
> **Fixes `tool_keys` on `launchdarkly_ai_config_variation` not actually attaching tools.** Create and update no longer send `toolKeys`; they resolve each configured key with `GetAITool` and populate the API’s `tools` field (`key` + version). User HCL stays `tool_keys = [...]`.
> 
> On update, clearing `tool_keys` sends an explicit empty `tools` array so associations are removed (non-nil empty slice vs omitted field).
> 
> Acceptance coverage for tools is expanded: create → import → add second tool → clear all, with **`testAccCheckAIConfigVariationToolsAttached`** asserting against the LaunchDarkly API so state-only checks can’t hide the old bug (read path preserves prior `tool_keys` when GET returns no tools).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3d5602e208da2ecd76faea1fe291d7cd9f229d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->