### PR TITLE
ci: repair acceptance-test matrix drift and guard against recurrence (REL-15194)

### DIFF
--- a/.github/workflows/test-fork-pr.yml
+++ b/.github/workflows/test-fork-pr.yml
@@ -72,31 +72,47 @@ jobs:
       TF_ACC: "1"
     strategy:
       matrix:
+        # Keep this list identical to the test_case list in test.yml (that file's
+        # build job runs the check; this workflow has no build job of its own).
+        # TestCIMatrixCoversAcceptanceTests (launchdarkly/ci_matrix_test.go) fails
+        # the build job if the two drift apart, or if either list gains an entry
+        # that matches no test / loses coverage of a TestAcc* function.
         test_case:
+          - TestAccAIAgentGraph_
           - TestAccAIConfig_
           - TestAccAIConfigVariation
           - TestAccAITool
           - TestAccDataSource
           - TestAccAccessToken
+          - TestAccAnnouncement_
           - TestAccAuditLogSubscription
+          - TestAccBigSegmentStoreIntegration_
+          - TestAccContextKind
           - TestAccCustomRole
           - TestAccDestination
           - TestAccEnvironment
           - TestAccFeatureFlag_
           - TestAccFeatureFlagEnvironment
+          # Not covered by TestAccFeatureFlag_ — the trailing underscore in that
+          # prefix does not match TestAccFeatureFlagViewKeys_*.
+          - TestAccFeatureFlagViewKeys
+          - TestAccFlagImportConfiguration_
           - TestAccFlagTemplates
           - TestAccFlagTrigger
           - TestAccIpAllowlistConfig
           - TestAccIpAllowlistEntry
-          - TestAccMetric
+          - TestAccIntegrationDeliveryConfiguration_
+          - TestAccMetricGroup_
+          - TestAccMetric_
           - TestAccModelConfig
+          - TestAccOAuthClient_
           - TestAccProject
           - TestAccRelayProxy
+          - TestAccReleasePolicy_
+          - TestAccSdkKey_
           - TestAccSegment
-          - TestAccTeamMember_CreateGeneric
-          - TestAccTeamMember_UpdateGeneric
-          - TestAccTeamMember_CreateWithCustomRole
-          - TestAccTeamMember_UpdateWithCustomRole
+          - TestAccTeamMember_CreateAndUpdateGeneric
+          - TestAccTeamMember_WithCustomRole
           - TestAccTeam_
           - TestAccTeamRoleMapping_
           - TestAccView

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,12 @@ jobs:
           cache: true
       - run: go mod download
       - run: go build -v .
+      # Cross-checks every TestAcc* function against the acceptance matrices in
+      # this file and test-fork-pr.yml. Needs no LaunchDarkly credentials, so it
+      # runs here rather than in the token-gated test job (and therefore also on
+      # fork PRs). See launchdarkly/ci_matrix_test.go for why this is needed.
+      - name: Check acceptance-test matrix coverage
+        run: make matrixcheck
       - name: Run linters
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
@@ -85,6 +91,10 @@ jobs:
       TF_ACC: "1"
     strategy:
       matrix:
+        # Keep this list identical to the test_case list in test-fork-pr.yml.
+        # TestCIMatrixCoversAcceptanceTests (launchdarkly/ci_matrix_test.go) fails
+        # the build job if the two drift apart, or if either list gains an entry
+        # that matches no test / loses coverage of a TestAcc* function.
         test_case:
           - TestAccAIAgentGraph_
           - TestAccAIConfig_
@@ -94,6 +104,7 @@ jobs:
           - TestAccAccessToken
           - TestAccAnnouncement_
           - TestAccAuditLogSubscription
+          - TestAccBigSegmentStoreIntegration_
           - TestAccContextKind
           - TestAccCustomRole
           - TestAccDestination
@@ -103,6 +114,7 @@ jobs:
           # Not covered by TestAccFeatureFlag_ — the trailing underscore in that
           # prefix does not match TestAccFeatureFlagViewKeys_*.
           - TestAccFeatureFlagViewKeys
+          - TestAccFlagImportConfiguration_
           - TestAccFlagTemplates
           - TestAccFlagTrigger
           - TestAccIpAllowlistConfig
@@ -117,10 +129,8 @@ jobs:
           - TestAccReleasePolicy_
           - TestAccSdkKey_
           - TestAccSegment
-          - TestAccTeamMember_CreateGeneric
-          - TestAccTeamMember_UpdateGeneric
-          - TestAccTeamMember_CreateWithCustomRole
-          - TestAccTeamMember_UpdateWithCustomRole
+          - TestAccTeamMember_CreateAndUpdateGeneric
+          - TestAccTeamMember_WithCustomRole
           - TestAccTeam_
           - TestAccTeamRoleMapping_
           - TestAccView

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,11 @@ Go version pinned in `.go-version`: **1.25.8** (`scripts/codegen/go.mod` and par
 - `make testacc` — full acceptance suite. Sets `TF_ACC=1`. Hits **real** LaunchDarkly via `LAUNCHDARKLY_ACCESS_TOKEN`; requires enterprise account. 120m timeout.
 - `make testacc-with-retry` — runs `testacc` once, retries once on failure. CI uses this.
 - `TESTARGS="-run TestAccProject_Create" make testacc` — single acceptance test. CI matrix entries (e.g. `TestAccFeatureFlag_`) are `go test -run` prefixes, not suite names.
+- `make matrixcheck` — needs no token. Cross-checks every `TestAcc*` function against the `test_case` matrices in `test.yml` **and** `test-fork-pr.yml`, and asserts the two lists are identical. Run it after adding an acceptance test or a matrix row. Because each entry is an *unanchored* regex, both drift directions used to fail silently: an entry matching nothing ran zero tests and went green, and a test matched by nothing never ran at all. See `launchdarkly/ci_matrix_test.go`.
 - `make generate` — installs the `codegen` tool, then runs `go generate ./launchdarkly/... .`. Regenerates `launchdarkly/integration_configs_generated.go` from `https://app.launchdarkly.com/api/v2/integration-manifests` **and** rebuilds `docs/` via `tfplugindocs`. Requires `LAUNCHDARKLY_ACCESS_TOKEN` and a real `terraform` binary on PATH (no wrapper).
 - `make vet` / `make errcheck` — also wired into CI.
 
-CI gate at `.github/workflows/test.yml`: build + lint (`golangci-lint v1.64.8`) + `make generate` diff check + matrix of `TestAcc*` prefixes. The `generate` and `test` jobs are **skipped on fork PRs** — a maintainer must add the `safe-to-test` label to trigger `test-fork-pr.yml`. New pushes strip the label (see `remove-safe-to-test-label.yml`), forcing re-review.
+CI gate at `.github/workflows/test.yml`: build + lint (`golangci-lint v1.64.8`) + `make matrixcheck` + `make generate` diff check + matrix of `TestAcc*` prefixes. `matrixcheck` runs in the `build` job (no credentials), so it gates fork PRs too — and it fails if `test.yml`'s matrix diverges from `test-fork-pr.yml`'s, which is the failure mode that let 27 tests go unrun on the fork path. The `generate` and `test` jobs are **skipped on fork PRs** — a maintainer must add the `safe-to-test` label to trigger `test-fork-pr.yml`. New pushes strip the label (see `remove-safe-to-test-label.yml`), forcing re-review.
 
 ## Local dev override
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -21,6 +21,11 @@ testacc: fmtcheck
 testacc-with-retry:
 	make testacc || make testacc
 
+# Cross-checks every TestAcc* function name against the test_case matrices in
+# .github/workflows/test.yml and test-fork-pr.yml. Requires no credentials.
+matrixcheck:
+	go test ./$(PKG_NAME)/ -run TestCIMatrixCoversAcceptanceTests -count=1
+
 vet:
 	@echo "go vet ."
 	@go vet $$(go list ./...) ; if [ $$? -eq 1 ]; then \
@@ -55,4 +60,4 @@ test-compile:
 	fi
 	go test -c $(TEST) $(TESTARGS)
 
-.PHONY: build install apply test testacc testacc-with-retry vet fmt fmtcheck errcheck lint test-compile
+.PHONY: build install apply test testacc testacc-with-retry matrixcheck vet fmt fmtcheck errcheck lint test-compile

--- a/launchdarkly/ci_matrix_test.go
+++ b/launchdarkly/ci_matrix_test.go
@@ -1,0 +1,193 @@
+package launchdarkly
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ciWorkflowFiles are the workflows that shard the acceptance suite across a
+// test_case matrix. Paths are relative to this package directory.
+var ciWorkflowFiles = []string{
+	filepath.Join("..", ".github", "workflows", "test.yml"),
+	filepath.Join("..", ".github", "workflows", "test-fork-pr.yml"),
+}
+
+var acceptanceTestFuncRe = regexp.MustCompile(`(?m)^func (TestAcc\w+)\(`)
+
+// ciWorkflow is the minimal shape needed to reach the acceptance matrix.
+type ciWorkflow struct {
+	Jobs map[string]struct {
+		Strategy struct {
+			Matrix struct {
+				TestCase []string `yaml:"test_case"`
+			} `yaml:"matrix"`
+		} `yaml:"strategy"`
+	} `yaml:"jobs"`
+}
+
+// TestCIMatrixCoversAcceptanceTests guards the CI acceptance matrices against
+// drift from the real TestAcc* function names.
+//
+// Each matrix entry is handed to `go test -run` as an *unanchored* regex, so
+// both drift directions fail silently:
+//
+//   - an entry that matches no test function runs zero tests and reports a
+//     green job (four TestAccTeamMember_* entries did exactly this until
+//     REL-15194);
+//   - a test function matched by no entry never executes in CI at all, so its
+//     config rots unnoticed until someone turns it on.
+//
+// Neither is visible from a passing workflow run, hence this check. It runs in
+// the build job, needs no LaunchDarkly credentials, and is skipped by nothing.
+func TestCIMatrixCoversAcceptanceTests(t *testing.T) {
+	names := acceptanceTestNames(t)
+	if len(names) == 0 {
+		t.Fatal("found no TestAcc* functions in this package; the discovery regex is broken")
+	}
+
+	matrices := make(map[string][]string, len(ciWorkflowFiles))
+	for _, path := range ciWorkflowFiles {
+		matrices[path] = acceptanceMatrix(t, path)
+	}
+
+	for path, entries := range matrices {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			checkMatrix(t, path, entries, names)
+		})
+	}
+
+	// The fork-PR workflow duplicates the matrix because pull_request_target
+	// needs its own job. Nothing in GitHub Actions keeps the two lists in
+	// sync, and in practice only test.yml got updated as resources were added.
+	t.Run("workflows agree", func(t *testing.T) {
+		base := ciWorkflowFiles[0]
+		for _, other := range ciWorkflowFiles[1:] {
+			for _, entry := range missing(matrices[base], matrices[other]) {
+				t.Errorf("%q is in %s but not %s; keep the two test_case lists identical", entry, base, other)
+			}
+			for _, entry := range missing(matrices[other], matrices[base]) {
+				t.Errorf("%q is in %s but not %s; keep the two test_case lists identical", entry, other, base)
+			}
+		}
+	})
+}
+
+// checkMatrix asserts a single test_case list covers every acceptance test,
+// contains no entry that matches nothing, and has no duplicates.
+func checkMatrix(t *testing.T, path string, entries, names []string) {
+	t.Helper()
+
+	patterns := make([]*regexp.Regexp, 0, len(entries))
+	seen := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		if seen[entry] {
+			t.Errorf("%s: duplicate test_case entry %q; GitHub Actions would run the same shard twice", path, entry)
+			continue
+		}
+		seen[entry] = true
+
+		re, err := regexp.Compile(entry)
+		if err != nil {
+			t.Errorf("%s: test_case entry %q is not a valid regex, so `go test -run` will reject it: %s", path, entry, err)
+			continue
+		}
+		patterns = append(patterns, re)
+
+		if !matchesAny(re, names) {
+			t.Errorf("%s: test_case entry %q matches no TestAcc* function; that shard silently runs zero tests and reports success. Fix the entry or delete it.", path, entry)
+		}
+	}
+
+	for _, name := range names {
+		matched := false
+		for _, re := range patterns {
+			if re.MatchString(name) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			t.Errorf("%s: %s is matched by no test_case entry, so it never runs in CI. Add an entry that matches it.", path, name)
+		}
+	}
+}
+
+// acceptanceTestNames scans the package's own _test.go files for acceptance
+// test declarations. This deliberately reads source rather than using
+// reflection: test functions are not addressable by name at runtime, and the
+// matrix entries are matched against source-level names anyway.
+func acceptanceTestNames(t *testing.T) []string {
+	t.Helper()
+
+	testFiles, err := filepath.Glob("*_test.go")
+	if err != nil {
+		t.Fatalf("globbing test files: %s", err)
+	}
+
+	var names []string
+	for _, file := range testFiles {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("reading %s: %s", file, err)
+		}
+		for _, match := range acceptanceTestFuncRe.FindAllStringSubmatch(string(src), -1) {
+			names = append(names, match[1])
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// acceptanceMatrix returns the test_case list from the workflow's matrix job.
+func acceptanceMatrix(t *testing.T, path string) []string {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %s", path, err)
+	}
+	var wf ciWorkflow
+	if err := yaml.Unmarshal(raw, &wf); err != nil {
+		t.Fatalf("parsing %s: %s", path, err)
+	}
+
+	var entries []string
+	for _, job := range wf.Jobs {
+		entries = append(entries, job.Strategy.Matrix.TestCase...)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("%s declares no test_case matrix; if the acceptance sharding moved, update ciWorkflowFiles", path)
+	}
+	return entries
+}
+
+func matchesAny(re *regexp.Regexp, names []string) bool {
+	for _, name := range names {
+		if re.MatchString(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// missing returns the entries of a that are absent from b.
+func missing(a, b []string) []string {
+	inB := make(map[string]bool, len(b))
+	for _, entry := range b {
+		inB[strings.TrimSpace(entry)] = true
+	}
+	var out []string
+	for _, entry := range a {
+		if !inB[strings.TrimSpace(entry)] {
+			out = append(out, entry)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/launchdarkly/ci_matrix_test.go
+++ b/launchdarkly/ci_matrix_test.go
@@ -122,6 +122,12 @@ func checkMatrix(t *testing.T, path string, entries, names []string) {
 // test declarations. This deliberately reads source rather than using
 // reflection: test functions are not addressable by name at runtime, and the
 // matrix entries are matched against source-level names anyway.
+//
+// Scanning only this package is deliberate too. Every TestAcc* function in the
+// repo lives here, and a repo-wide walk would also descend into .claude/
+// worktrees and pick up copies of these same files. If acceptance tests ever
+// move into another package, extend this to walk those directories explicitly
+// rather than globbing from the repo root.
 func acceptanceTestNames(t *testing.T) []string {
 	t.Helper()
 


### PR DESCRIPTION
Stacked on #522 — review/merge that first. This PR's diff against #522 is the 5 files listed below.

## Problem

Each `test_case` matrix entry is handed to `go test -run` as an **unanchored regex**, so drift fails silently in both directions:

- an entry matching no test function runs **zero tests and reports a green job**;
- a test function matched by no entry **never runs in CI at all**, so its config rots unnoticed.

Neither is visible from a passing workflow run.

## Audit

Both acceptance workflows had drifted, and `test-fork-pr.yml` far worse than `test.yml`:

| matrix | entries | dead entries | tests never run |
|---|---|---|---|
| `test.yml` :: test | 36 | 4 | 4 |
| `test-fork-pr.yml` :: test | 28 | 4 | **27** |

**`test.yml`** — `TestAccTeamMember_{Create,Update}Generic` and `TestAccTeamMember_{Create,Update}WithCustomRole` match nothing; the real functions are `TestAccTeamMember_CreateAndUpdateGeneric` and `TestAccTeamMember_WithCustomRole`. Four jobs were passing vacuously while both real tests never ran. Collapsed to the two real names, which preserves the generic/custom-role split the four rows were reaching for. Added `TestAccBigSegmentStoreIntegration_` and `TestAccFlagImportConfiguration_`, which had no entry at all.

**`test-fork-pr.yml`** — a second matrix nothing keeps in sync, missing the AIAgentGraph, Announcement, BigSegmentStore, ContextKind, FlagImport, IntegrationDelivery, OAuthClient, ReleasePolicy and SdkKey families entirely: new resources only ever updated `test.yml`. Synced to `test.yml`'s list.

Also checked and clean: no duplicate entries, no test matched by two entries, and every `t.SkipNow()` is a `TF_ACC == ""` guard, so nothing skips vacuously under CI's `TF_ACC: "1"`.

## Guard

`TestCIMatrixCoversAcceptanceTests` (`launchdarkly/ci_matrix_test.go`) cross-checks every `^func TestAcc*` name against both matrices and fails on:

- a test matched by no entry,
- an entry that matches no test,
- a duplicate entry,
- an entry that isn't a valid regex,
- divergence between the two workflows' lists.

Exposed as `make matrixcheck` and wired into the **build** job — it needs no LaunchDarkly credentials, so it gates fork PRs too. Verified by injecting drift in both directions and confirming it fails with actionable messages.

## Bit-rot status of the newly-enabled tests

`go vet ./launchdarkly/` is clean and all four configs already match current schemas — `withRandomProject` uses the `environments = { "test" = {...} }` map form (REL-14236), `policy_statements` is a nested attribute list, and `role_attributes` is a map. No config changes were needed. The `TestAccFeatureFlagViewKeys` entry and its `environments` fix come from #522.

Per @monsagri's ask, acceptance verification for the four newly-enabled tests runs on this PR's real CI matrix rather than locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/terraform-provider-launchdarkly/pull/523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflows, Makefile/docs, and a new test that reads workflow YAML—no provider runtime or auth logic.
> 
> **Overview**
> Fixes **silent CI gaps** where `go test -run` matrix prefixes could match no tests (green vacuous jobs) or leave `TestAcc*` functions uncovered, and adds a guard so that cannot happen again.
> 
> **Matrix repairs** in `test.yml` and `test-fork-pr.yml`: aligns the fork workflow with the main list (many missing shards), replaces four dead `TestAccTeamMember_*` rows with `TestAccTeamMember_CreateAndUpdateGeneric` and `TestAccTeamMember_WithCustomRole`, and adds or splits prefixes for newly uncovered suites (e.g. `TestAccBigSegmentStoreIntegration_`, `TestAccFlagImportConfiguration_`, `TestAccMetricGroup_` / `TestAccMetric_`, plus several resource families only present on one workflow before).
> 
> **New `TestCIMatrixCoversAcceptanceTests`** (`launchdarkly/ci_matrix_test.go`) discovers every `TestAcc*` in the package, validates each workflow matrix (coverage, dead entries, duplicates, valid regex), and asserts **`test.yml` and `test-fork-pr.yml` stay identical**. Exposed as **`make matrixcheck`** and run in the **build** job (no LaunchDarkly token), so fork PRs are gated too. **`CLAUDE.md`** documents the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fed05cca95599f073af092bedfad0f99fe77ec4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->