### PR TITLE
chore: add make update-api-client-go for LD API client bumps

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -52,6 +52,15 @@ generate: install-codegen
 	go generate ./launchdarkly/...
 	go generate .
 
+# Bump the LaunchDarkly API client to a published release. A major bump moves the
+# module path (api-client-go/vN), so the script rewrites the import path in every
+# file that references it, not just go.mod.
+#  make update-api-client-go API_CLIENT_GO_VERSION=24.0.0
+# Normally run for you by the release automation in ld-openapi-private, which
+# opens the bump PR here after publishing a new client version.
+update-api-client-go:
+	./scripts/update_api_client_go.sh $(API_CLIENT_GO_VERSION)
+
 test-compile:
 	@if [ "$(TEST)" = "./..." ]; then \
 		echo "ERROR: Set TEST to a specific package. For example,"; \

--- a/scripts/update_api_client_go.sh
+++ b/scripts/update_api_client_go.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# Updates the api-client-go dependency, including a major version bump.
+#
+# Usage: scripts/update_api_client_go.sh VERSION      # e.g. 24.0.0
+#
+# A major release of the LaunchDarkly API client moves the Go module path
+# (api-client-go/vN), so this is not a one-line go.mod edit — the import path
+# appears in ~220 files here and all of them have to move together.
+#
+# Called by the release automation in launchdarkly/ld-openapi-private, which opens
+# the bump PR here after publishing a new client version. Safe to run by hand.
+
+set -e
+
+version=$1
+
+if [ -z "$version" ]; then
+  echo "usage: scripts/update_api_client_go.sh VERSION (e.g. 24.0.0)" >&2
+  exit 1
+fi
+
+if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "VERSION must be bare semver MAJOR.MINOR.PATCH with no leading 'v' (got '$version')" >&2
+  exit 1
+fi
+
+root="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null 2>&1 && pwd )"
+cd "$root"
+
+module_base=github.com/launchdarkly/api-client-go
+new_major=${version%%.*}
+
+current_path=$(grep -oE "${module_base}/v[0-9]+" go.mod | head -1 || true)
+if [ -z "$current_path" ]; then
+  echo "could not find ${module_base}/vN in go.mod" >&2
+  exit 1
+fi
+old_major=${current_path##*/v}
+
+echo "Updating api-client-go: v${old_major} -> v${new_major} (pinning ${version})"
+
+if [ "$old_major" != "$new_major" ]; then
+  old_module="${module_base}/v${old_major}"
+  new_module="${module_base}/v${new_major}"
+
+  # Read loop rather than `mapfile`, and `perl -pi` rather than `sed -i`: both
+  # mapfile and bare sed -i are GNU/bash-4-only, and macOS ships bash 3.2 with a
+  # BSD sed that consumes the next argument as a backup suffix.
+  echo "Rewriting import paths in Go sources"
+  go_files=()
+  while IFS= read -r file; do
+    go_files+=("$file")
+  done < <(git grep -l --fixed-strings "$old_module" -- '*.go' || true)
+  if [ ${#go_files[@]} -eq 0 ]; then
+    echo "expected Go files importing ${old_module}, found none - has the dependency moved?" >&2
+    exit 1
+  fi
+  echo "  ${#go_files[@]} files"
+  perl -pi -e "s|\Q${old_module}\E|${new_module}|g" "${go_files[@]}"
+
+  # Drop the stale requirement first, so go.mod never holds a vN module path
+  # pinned to a v(N-1) version.
+  go mod edit -droprequire "$old_module"
+fi
+
+go get "${module_base}/v${new_major}@v${version}"
+go mod tidy


### PR DESCRIPTION
## Summary

Adds `make update-api-client-go`, so bumping the `api-client-go` dependency is one command.

Bumping it is not a one-line `go.mod` edit when the release is a major one: the module path carries the major version (`api-client-go/vN`), so the import path has to move everywhere it appears — currently around **220 files** here. Most LaunchDarkly API releases are major, so this is the common path rather than an edge case.

```bash
make update-api-client-go API_CLIENT_GO_VERSION=24.0.0
```

## Why here rather than in the release workflow

The API client release process in [ld-openapi-private#300](https://github.com/launchdarkly/ld-openapi-private/pull/300) is being automated end to end. Part of that opens a PR here whenever a new client version is published, so this provider tracks the latest client instead of drifting behind.

That automation calls this make target. Keeping the codemod in this repo means the logic lives beside the imports it rewrites — if the layout here changes, the fix is local — rather than as a shell snippet embedded in a workflow in another repo. Same approach was taken in gonfalon, and it mirrors the existing `update-foundation` / `update-goaltender` convention there.

The bump PRs will be labelled `chore(deps):`, which release-please will not turn into a provider release on its own. Say the word if a client bump should ship one and I'll switch the prefix to `feat:`.

## Testing

Exercised on a fixture with `go` stubbed: rewrites import paths across all matching files, drops the stale requirement before adding the new module path so `go.mod` never holds a `vN` path pinned to a `v(N-1)` version, then runs `go get` and `go mod tidy`. Rejects a non-semver argument, and fails loudly rather than silently no-opping if no files reference the current major.

Not yet run against a real bump — the next API client release will be the first live exercise, and its PR will not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/tooling only—no provider logic, auth, or runtime paths change until someone runs the bump.
> 
> **Overview**
> Adds **`make update-api-client-go`** (with `API_CLIENT_GO_VERSION`) and **`scripts/update_api_client_go.sh`** so bumping `github.com/launchdarkly/api-client-go` is a single step instead of hand-editing `go.mod`.
> 
> On a **major** bump, the script rewrites `api-client-go/vN` imports across all matching `*.go` files, drops the old `go mod` requirement before pinning the new module path, then runs **`go get`** and **`go mod tidy`**. It validates bare semver input and fails if no Go files reference the current major. Import rewrites use **`perl -pi`** and a read loop instead of GNU-only **`mapfile`** / **`sed -i`** for macOS compatibility.
> 
> Intended for release automation in **ld-openapi-private** and manual use; it does not change provider runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f234a15dfef8567c8007cc7c002562d09daa79a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->