### PR TITLE
chore: drop View archived-field shim now that api-client-go v24 removes it

### DIFF
--- a/launchdarkly/config.go
+++ b/launchdarkly/config.go
@@ -1,12 +1,9 @@
 package launchdarkly
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"math"
 	"net/http"
@@ -175,92 +172,7 @@ func newRetryableClient(retryPolicy retryablehttp.CheckRetry) *http.Client {
 	retryClient.RetryMax = MAX_RETRIES
 	retryClient.ErrorHandler = retryablehttp.PassthroughErrorHandler
 
-	client := retryClient.StandardClient()
-	client.Transport = &viewArchivedShimTransport{base: client.Transport}
-	return client
-}
-
-// viewArchivedShimTransport works around a mismatch between the LaunchDarkly
-// API and the pinned api-client-go generated models. LaunchDarkly removed view
-// archival (REL-14370), so the API no longer returns the `archived` field on
-// views. The generated ldapi.View model still lists `archived` as a required
-// property, so responses without it fail to deserialize with
-// "no value given for required property archived". Until api-client-go is
-// regenerated from the updated spec, we re-insert a default `archived: false`
-// into `/views` responses so decoding succeeds. The provider itself no longer
-// exposes the field.
-//
-// TODO(REL-14370): remove once api-client-go drops the `archived` requirement.
-type viewArchivedShimTransport struct {
-	base http.RoundTripper
-}
-
-func (t *viewArchivedShimTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	base := t.base
-	if base == nil {
-		base = http.DefaultTransport
-	}
-	resp, err := base.RoundTrip(req)
-	if err != nil || resp == nil {
-		return resp, err
-	}
-	// Only touch successful JSON responses from endpoints that return View
-	// objects: `/views...` (get/create/update, linked resources) and
-	// `/view-associations/...` (views linked to a flag or segment).
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 || !isViewAPIResponsePath(req.URL.Path) {
-		return resp, nil
-	}
-
-	body, readErr := io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
-	if readErr != nil {
-		// Best effort: hand back whatever we managed to read.
-		resp.Body = io.NopCloser(bytes.NewReader(body))
-		return resp, nil
-	}
-
-	var parsed interface{}
-	if json.Unmarshal(body, &parsed) != nil {
-		resp.Body = io.NopCloser(bytes.NewReader(body))
-		return resp, nil
-	}
-	injectArchivedDefault(parsed)
-	rewritten, marshalErr := json.Marshal(parsed)
-	if marshalErr != nil {
-		rewritten = body
-	}
-	resp.Body = io.NopCloser(bytes.NewReader(rewritten))
-	resp.ContentLength = int64(len(rewritten))
-	resp.Header.Set("Content-Length", strconv.Itoa(len(rewritten)))
-	return resp, nil
-}
-
-// isViewAPIResponsePath reports whether a request path targets an endpoint that
-// returns View objects, whose strict generated model requires `archived`.
-func isViewAPIResponsePath(path string) bool {
-	return strings.Contains(path, "/views") || strings.Contains(path, "/view-associations")
-}
-
-// injectArchivedDefault walks a decoded JSON value and sets `archived` to false
-// on any object that looks like a view (identified by a `projectKey` field) and
-// does not already carry one. It recurses so that list responses (e.g.
-// `{"items": [ ... ]}`) are handled as well as single-view responses.
-func injectArchivedDefault(v interface{}) {
-	switch val := v.(type) {
-	case map[string]interface{}:
-		if _, isView := val["projectKey"]; isView {
-			if _, hasArchived := val["archived"]; !hasArchived {
-				val["archived"] = false
-			}
-		}
-		for _, child := range val {
-			injectArchivedDefault(child)
-		}
-	case []interface{}:
-		for _, item := range val {
-			injectArchivedDefault(item)
-		}
-	}
+	return retryClient.StandardClient()
 }
 
 func backOff(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {

--- a/launchdarkly/config_test.go
+++ b/launchdarkly/config_test.go
@@ -1,12 +1,9 @@
 package launchdarkly
 
 import (
-	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -309,104 +306,4 @@ func TestSemaphoreConcurrencyLimits(t *testing.T) {
 	maxConcurrent := atomic.LoadInt32(&maxConcurrentRequests)
 	assert.LessOrEqual(t, maxConcurrent, int32(maxConcurrency),
 		"Max concurrent requests (%d) exceeded semaphore limit (%d)", maxConcurrent, maxConcurrency)
-}
-
-func TestInjectArchivedDefault(t *testing.T) {
-	t.Run("single view without archived gets default", func(t *testing.T) {
-		view := map[string]interface{}{"key": "v1", "projectKey": "proj", "name": "View 1"}
-		injectArchivedDefault(view)
-		assert.Equal(t, false, view["archived"])
-	})
-
-	t.Run("existing archived is preserved", func(t *testing.T) {
-		view := map[string]interface{}{"key": "v1", "projectKey": "proj", "archived": true}
-		injectArchivedDefault(view)
-		assert.Equal(t, true, view["archived"])
-	})
-
-	t.Run("list response injects into each view item", func(t *testing.T) {
-		resp := map[string]interface{}{
-			"totalCount": 2,
-			"items": []interface{}{
-				map[string]interface{}{"key": "v1", "projectKey": "proj"},
-				map[string]interface{}{"key": "v2", "projectKey": "proj"},
-			},
-		}
-		injectArchivedDefault(resp)
-		items := resp["items"].([]interface{})
-		for _, item := range items {
-			assert.Equal(t, false, item.(map[string]interface{})["archived"])
-		}
-	})
-
-	t.Run("non-view objects are left untouched", func(t *testing.T) {
-		linked := map[string]interface{}{"resourceKey": "flag-1", "resourceType": "flags"}
-		injectArchivedDefault(linked)
-		_, hasArchived := linked["archived"]
-		assert.False(t, hasArchived, "objects without projectKey must not gain an archived field")
-	})
-}
-
-// TestViewArchivedShimTransport verifies that a view API response missing the
-// `archived` field (as returned by LaunchDarkly after REL-14370) is rewritten
-// to include `archived: false` so the strict generated model can deserialize
-// it, while non-view responses are passed through untouched.
-func TestViewArchivedShimTransport(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		switch {
-		case strings.Contains(r.URL.Path, "/view-associations"):
-			// GetLinkedViews returns a list of views; mimic the post-REL-14370
-			// API with no `archived` field on the items.
-			_, _ = w.Write([]byte(`{"totalCount":1,"items":[{"key":"v1","projectKey":"proj"}]}`))
-		case strings.Contains(r.URL.Path, "/views"):
-			// Mimic the post-REL-14370 API: no `archived` field.
-			_, _ = w.Write([]byte(`{"key":"v1","projectKey":"proj","name":"View 1"}`))
-		default:
-			_, _ = w.Write([]byte(`{"key":"other"}`))
-		}
-	}))
-	t.Cleanup(ts.Close)
-
-	client := &http.Client{Transport: &viewArchivedShimTransport{base: http.DefaultTransport}}
-
-	t.Run("view response gains archived", func(t *testing.T) {
-		resp, err := client.Get(ts.URL + "/api/v2/projects/proj/views/v1")
-		require.NoError(t, err)
-		body, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-		_ = resp.Body.Close()
-
-		var decoded map[string]interface{}
-		require.NoError(t, json.Unmarshal(body, &decoded))
-		assert.Equal(t, false, decoded["archived"])
-	})
-
-	t.Run("view-associations list items gain archived", func(t *testing.T) {
-		resp, err := client.Get(ts.URL + "/api/v2/projects/proj/view-associations/segments/seg-1")
-		require.NoError(t, err)
-		body, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-		_ = resp.Body.Close()
-
-		var decoded map[string]interface{}
-		require.NoError(t, json.Unmarshal(body, &decoded))
-		items := decoded["items"].([]interface{})
-		require.Len(t, items, 1)
-		assert.Equal(t, false, items[0].(map[string]interface{})["archived"])
-	})
-
-	t.Run("non-view response is untouched", func(t *testing.T) {
-		resp, err := client.Get(ts.URL + "/api/v2/flags/proj/flag-1")
-		require.NoError(t, err)
-		body, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-		_ = resp.Body.Close()
-
-		var decoded map[string]interface{}
-		require.NoError(t, json.Unmarshal(body, &decoded))
-		_, hasArchived := decoded["archived"]
-		assert.False(t, hasArchived)
-	})
 }

--- a/launchdarkly/view_helper_test.go
+++ b/launchdarkly/view_helper_test.go
@@ -15,8 +15,7 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
-// newViewTestClient returns a Client pointed at ts that decodes views through
-// the same archived-field shim production uses.
+// newViewTestClient returns a Client pointed at ts.
 func newViewTestClient(t *testing.T, ts *httptest.Server) *Client {
 	t.Helper()
 
@@ -24,7 +23,6 @@ func newViewTestClient(t *testing.T, ts *httptest.Server) *Client {
 	cfg.Scheme = "https"
 	cfg.Host = strings.TrimPrefix(ts.URL, "https://")
 	cfg.HTTPClient = ts.Client()
-	cfg.HTTPClient.Transport = &viewArchivedShimTransport{base: cfg.HTTPClient.Transport}
 
 	return &Client{
 		apiKey:    "test-token",
@@ -160,10 +158,6 @@ func TestViewRequestsIncludeUserAgentHeader(t *testing.T) {
 	cfg.Host = strings.TrimPrefix(ts.URL, "https://")
 	cfg.UserAgent = expectedUA
 	cfg.HTTPClient = ts.Client()
-	// Route through the archived-field shim so the test exercises the same
-	// decode path as production, where the views API no longer returns the
-	// `archived` field required by the generated ldapi.View model.
-	cfg.HTTPClient.Transport = &viewArchivedShimTransport{base: cfg.HTTPClient.Transport}
 
 	client := &Client{
 		apiKey:    "test-token",


### PR DESCRIPTION
Closes [REL-15206](https://launchdarkly.atlassian.net/browse/REL-15206).

Follow-up to #528 (api-client-go v22 -> v24 bump): remove the provider-side workarounds that only existed because the pinned client still required a field the API had stopped returning.

## The change

v24 regenerated `View` and `ViewPatch` from the current spec, which no longer carries `archived` / `archivedAt` (removed in REL-14370). `archived` is also gone from `View`'s `requiredProperties` list, so view responses now decode natively.

That makes the stopgap added in #513 dead code. Removed from `launchdarkly/config.go`:

- `viewArchivedShimTransport` — a `http.RoundTripper` that read, JSON-parsed, mutated, and re-serialized **every** `/views` and `/view-associations` response body to re-insert `archived: false`
- `isViewAPIResponsePath`
- `injectArchivedDefault`
- its wiring in `newRetryableClient`

Plus the tests that covered the shim (`TestInjectArchivedDefault`, `TestViewArchivedShimTransport`) and the two test clients in `view_helper_test.go` that routed through it.

Net 199 lines removed, 2 added. Every HTTP response the provider receives is now handed to the generated decoder unmodified — no body rewriting in the request path.

## Rest of the v23 -> v24 delta: no provider code needed

I diffed the two generated clients in full rather than assuming the compile passing meant we were done.

| Category | Finding |
| --- | --- |
| Removed, unreferenced here | `SdkKey.ViewSummaries` (moved to the new `SdkKeyForPutSdkKeyViews` + new `GetSdkKeys` endpoint), `Metric*`/`Denominator*.WinsorExcludeImputed`, `UsersApi.DeleteUser` |
| Additive, not exposed | `ContextKindRep.EnvironmentObservations`, `FeatureFlag.Stale`, `AIConfigVariation{,Post,Patch}.Skills`, `ModelConfig._maintainer` / `ModelConfigPost.maintainerId`+`maintainerTeamKey`, metric `analysisUnit`/`analysisType`/`valueColumn`, `IPAllowlistResponse._links`+`totalCount`, `ReleaseProgression.activePhaseStatus` |
| Net-new endpoints | AgentSkills CRUD (7 ops), `patchModelConfig`, `listModelConfigVersions`, `GetSdkKeys` |

The drift report agrees independently: `stale_families: 0`, `stale_operations: 0`, `unmapped_resources: 0`. The net-new surface lands as the 9 `unclaimed_operations` the autogen pipeline already tracks — separate scaffolding work, deliberately out of scope here.

Two other things checked and intentionally left alone:

- `APIVersion = "20240415"` is unchanged; the only other client-wide delta is the generator's `UserAgent` string moving `23` -> `24`, which the provider overrides anyway.
- `AgentGraphPatch` is byte-identical in v24, so the `requiresReplaceOnClear*` both-or-neither workaround in `resource_ai_agent_graph_framework.go` stays. That one is an API constraint, not a client gap.

## Validation

- `go build ./...`, `go vet ./...`, `make fmtcheck`, `make matrixcheck` — clean
- `go generate .` produces no docs diff (no schema or template changes)
- golangci-lint v2.12.2 (the CI-pinned version) — 0 issues
- Real account, locally built provider, read-only: `data.launchdarkly_view`, `data.launchdarkly_feature_flag`, and `data.launchdarkly_segment` all resolve against pre-existing views, exercising the three paths the shim covered — `GET /views/{key}`, `GET /views/{key}/linked` (`linked_flags` / `linked_segments`), and `/view-associations` (flag and segment `view_keys`). The live API confirms no `archived` or `archivedAt` on view payloads.

Create/update paths were not exercised locally — the acceptance matrix (`TestAccView_*`) covers those, and they decode the same `View` model.

Unit-test note: `Test404RetryClient/max_retries_exceeded` (a 20s timeout flake) and the five `TestAcc*` cases that need `LAUNCHDARKLY_ACCESS_TOKEN` fail locally. I confirmed an identical failure set on `main` in a throwaway worktree, so they are pre-existing and unrelated. Separately, `make errcheck` panics on Go 1.25 due to a 2020-era `x/tools` — not a CI gate, and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[REL-15206]: https://launchdarkly.atlassian.net/browse/REL-15206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cleanup of obsolete client workaround with no change to provider-exposed behavior; view read paths were validated against the live API without `archived`.
> 
> **Overview**
> Removes the **View `archived` HTTP shim** that was only needed while the pinned `api-client-go` still treated `archived` as required on view payloads after LaunchDarkly dropped it (REL-14370). With v24, view responses decode without provider-side mutation.
> 
> `newRetryableClient` no longer wraps the transport in `viewArchivedShimTransport` (no read/parse/rewrite of `/views` and `/view-associations` JSON). Related helpers (`isViewAPIResponsePath`, `injectArchivedDefault`) and their tests are deleted; view helper tests no longer route through the shim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df45ba8294c78fa20d6afff29c182bb6b29c2847. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->