### PR TITLE
chore: skip ServiceNow approvals acceptance test by default (v2)

### DIFF
--- a/launchdarkly/resource_launchdarkly_environment_test.go
+++ b/launchdarkly/resource_launchdarkly_environment_test.go
@@ -2,6 +2,7 @@ package launchdarkly
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
@@ -422,7 +423,29 @@ func TestAccEnvironment_WithApprovals(t *testing.T) {
 	})
 }
 
+// TestAccEnvironment_WithApprovalIntegrations exercises approval_settings with
+// service_kind = "servicenow". Unlike every other acceptance test, it depends on
+// state we do not control from this repo: the test account must have the
+// ServiceNow approval integration enabled AND a live OAuth connection to a
+// reachable ServiceNow instance. The manifest's `template` form variable is a
+// dynamicEnum whose allowed values LaunchDarkly resolves at write time by
+// calling {{oauth.baseURI}}/api/sn_chg_rest/change/standard/template with the
+// account's OAuth token, so if that connection lapses the PATCH is rejected and
+// this test fails with no provider-side cause.
+//
+// That is exactly what happened: the nightly run on the default branch has
+// failed here since 2026-08-14 (last green 2026-08-13) on an unchanged commit,
+// and the same failure blocks v2 PRs, which run this matrix entry on push.
+// Skipped by default so a broken external dependency cannot gate merges; set
+// LD_TEST_SERVICENOW_APPROVALS=1 to run it once the account's ServiceNow
+// connection is restored.
+//
+// Kept as a named TestAcc* function (rather than deleted) so `make matrixcheck`
+// coverage of the TestAccEnvironment matrix entry stays honest.
 func TestAccEnvironment_WithApprovalIntegrations(t *testing.T) {
+	if os.Getenv("LD_TEST_SERVICENOW_APPROVALS") == "" {
+		t.Skip("skipping: requires a live ServiceNow OAuth connection on the test account; set LD_TEST_SERVICENOW_APPROVALS=1 to run")
+	}
 	projectKey := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	resourceName := "launchdarkly_environment.auto_apply_test"
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
v2 backport of #538.

## Why

`TestAccEnvironment_WithApprovalIntegrations` depends on state this repo does not control: the test account must have the ServiceNow approval integration enabled **and** a live OAuth connection to a reachable ServiceNow instance. The ServiceNow approval manifest declares `template` as a **`dynamicEnum`**, so LaunchDarkly resolves its allowed values at write time by calling `{{oauth.baseURI}}/api/sn_chg_rest/change/standard/template` with the account's stored OAuth token. When that connection lapses, the `approval_settings` PATCH is rejected with a 400 and the test fails with no provider-side cause.

That is the current state. The nightly run on the default branch has failed on this test since **2026-08-14** (last green 2026-08-13) on an unchanged commit. The cron fires only on the default branch, but v2 runs the same `TestAccEnvironment` matrix entry on push and PR, so the same external breakage blocks v2 bugfixes.

Evidence it is not provider code: in each failing run only this test fails — `TestAccEnvironment_WithApprovals` (`launchdarkly` service kind) passes, so the approvals code paths themselves are fine; only the ServiceNow-specific validation fails.

## What this does

Skips the test unless `LD_TEST_SERVICENOW_APPROVALS=1` is set, with a comment recording the dependency and the incident dates. Identical gate and env var to #538 so both lines behave the same.

The function is kept rather than deleted so `make matrixcheck` coverage of the `TestAccEnvironment` matrix entry stays honest; the other `TestAccEnvironment_*` tests still run.

## Follow-up

Restore the test account's ServiceNow OAuth connection, then run with `LD_TEST_SERVICENOW_APPROVALS=1` on both lines to re-verify.

## Test plan

- `TF_ACC=1 go test ./launchdarkly/ -run TestAccEnvironment_WithApprovalIntegrations` → `--- SKIP`
- `make matrixcheck` → ok
- `gofmt -l` / `go vet` clean
- Equivalent change on main is green in CI (#538, run 32354258626): `WithApprovalIntegrations` skipped, other seven `TestAccEnvironment_*` passed against real LaunchDarkly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1bfc570a4a0f6474d89c728a9959e016cb291066. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->